### PR TITLE
Sprint 1 UI Component Dataset

### DIFF
--- a/design/components/card-stats.md
+++ b/design/components/card-stats.md
@@ -1,0 +1,126 @@
+# CardStats
+
+## 用途
+
+Dashboard 頁面的統計摘要卡片。顯示一個指標數字 + 標題 + 可選的趨勢/描述。基於 shadcn/ui 的 `Card` 元件。
+
+## Props
+
+| Prop | Type | Default | 說明 |
+|------|------|---------|------|
+| title | `string` | - | 卡片標題 |
+| value | `string \| number` | - | 主要數值 |
+| description | `string` | - | 描述文字 |
+| icon | `LucideIcon` | - | 左側圖示 |
+| trend | `{ value: number; label: string }` | - | 趨勢指標（選填） |
+
+## 外觀規格
+
+```
+┌─────────────────────────────────┐
+│  [Icon]   今日出勤人數           │
+│           42                    │
+│           較昨日 +3             │
+└─────────────────────────────────┘
+```
+
+| 部位 | 樣式 |
+|------|------|
+| 容器 | `rounded-lg border bg-card p-6 shadow-sm` |
+| Icon | `h-5 w-5 text-muted-foreground`，右上角 |
+| Title | `text-sm font-medium text-muted-foreground` |
+| Value | `text-3xl font-bold tracking-tight` |
+| Description | `text-xs text-muted-foreground` |
+| 趨勢正值 | `text-green-600` |
+| 趨勢負值 | `text-red-600` |
+
+## 範例程式碼
+
+```tsx
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { LucideIcon, TrendingUp, TrendingDown } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface CardStatsProps {
+  title: string;
+  value: string | number;
+  description?: string;
+  icon: LucideIcon;
+  trend?: { value: number; label: string };
+}
+
+export function CardStats({ title, value, description, icon: Icon, trend }: CardStatsProps) {
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between pb-2">
+        <CardTitle className="text-sm font-medium text-muted-foreground">
+          {title}
+        </CardTitle>
+        <Icon className="h-5 w-5 text-muted-foreground" />
+      </CardHeader>
+      <CardContent>
+        <div className="text-3xl font-bold tracking-tight">{value}</div>
+        {(description || trend) && (
+          <p className="mt-1 text-xs text-muted-foreground">
+            {trend && (
+              <span
+                className={cn(
+                  "inline-flex items-center gap-0.5 font-medium",
+                  trend.value >= 0 ? "text-green-600" : "text-red-600"
+                )}
+              >
+                {trend.value >= 0 ? (
+                  <TrendingUp className="h-3 w-3" />
+                ) : (
+                  <TrendingDown className="h-3 w-3" />
+                )}
+                {trend.value >= 0 ? "+" : ""}
+                {trend.value}
+              </span>
+            )}{" "}
+            {trend?.label || description}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+```
+
+## 使用範例
+
+```tsx
+import { Users, Clock, AlertTriangle, CheckCircle2 } from "lucide-react";
+
+// Dashboard 摘要卡片
+<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+  <CardStats
+    title="今日出勤"
+    value={42}
+    icon={Users}
+    trend={{ value: 3, label: "較昨日" }}
+  />
+  <CardStats
+    title="準時率"
+    value="95%"
+    icon={CheckCircle2}
+    trend={{ value: 2, label: "較上週" }}
+  />
+  <CardStats
+    title="遲到人數"
+    value={2}
+    icon={AlertTriangle}
+    description="今日"
+  />
+  <CardStats
+    title="平均工時"
+    value="8.2h"
+    icon={Clock}
+    description="本月平均"
+  />
+</div>
+```
+
+## 使用的 shadcn/ui 元件
+
+- `Card`（CardHeader, CardTitle, CardContent）

--- a/design/components/clock-button.md
+++ b/design/components/clock-button.md
@@ -1,0 +1,254 @@
+# ClockButton
+
+## 用途
+
+打卡頁面的核心元件 — 一個大型的打卡按鈕，搭配即時時鐘顯示和今日打卡狀態。設計重點為手機 PWA 操作友善、視覺明確。
+
+## Props
+
+| Prop | Type | Default | 說明 |
+|------|------|---------|------|
+| status | `'idle' \| 'clocked_in' \| 'clocked_out'` | `'idle'` | 今日打卡狀態 |
+| clockInTime | `string \| null` | `null` | 上班打卡時間（ISO string） |
+| clockOutTime | `string \| null` | `null` | 下班打卡時間（ISO string） |
+| onClockIn | `() => void` | - | 上班打卡回呼 |
+| onClockOut | `() => void` | - | 下班打卡回呼 |
+| isLoading | `boolean` | `false` | 打卡請求中 |
+
+## 狀態與外觀
+
+| Status | 按鈕文字 | 按鈕顏色 | 按鈕動作 | 狀態文字 |
+|--------|---------|----------|---------|---------|
+| `idle` | 上班打卡 | Primary (Blue) | `onClockIn` | 尚未打卡 |
+| `clocked_in` | 下班打卡 | Success (Green) | `onClockOut` | 已打上班卡 HH:mm |
+| `clocked_out` | 今日已完成 | Muted (Gray) | disabled | 上班 HH:mm / 下班 HH:mm |
+
+## 外觀規格
+
+| 部位 | 樣式 |
+|------|------|
+| 容器 | `flex flex-col items-center gap-6`，置中 |
+| 即時時鐘 | `text-5xl font-bold tabular-nums tracking-tight`，每秒更新 |
+| 日期 | `text-lg text-muted-foreground`，格式：2026年4月7日 星期二 |
+| 打卡按鈕 | 圓形，`w-48 h-48 rounded-full`，shadow-lg |
+| 按鈕文字 | `text-2xl font-bold text-white` |
+| 按鈕 Icon | `h-10 w-10`，在文字上方 |
+| 狀態卡片 | `rounded-xl border bg-card p-4`，寬度與按鈕同 |
+| Loading | 按鈕內顯示 Spinner，文字變 "處理中..." |
+
+## 範例程式碼
+
+```tsx
+"use client";
+
+import { useState, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  LogIn,
+  LogOut,
+  CheckCircle2,
+  Loader2,
+  Clock,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { format } from "date-fns";
+import { zhTW } from "date-fns/locale";
+
+interface ClockButtonProps {
+  status: "idle" | "clocked_in" | "clocked_out";
+  clockInTime: string | null;
+  clockOutTime: string | null;
+  onClockIn: () => void;
+  onClockOut: () => void;
+  isLoading?: boolean;
+}
+
+export function ClockButton({
+  status,
+  clockInTime,
+  clockOutTime,
+  onClockIn,
+  onClockOut,
+  isLoading = false,
+}: ClockButtonProps) {
+  const [now, setNow] = useState(new Date());
+
+  // 即時時鐘（每秒更新）
+  useEffect(() => {
+    const timer = setInterval(() => setNow(new Date()), 1000);
+    return () => clearInterval(timer);
+  }, []);
+
+  const buttonConfig = {
+    idle: {
+      label: "上班打卡",
+      icon: LogIn,
+      onClick: onClockIn,
+      disabled: false,
+      className: "bg-primary hover:bg-primary/90 shadow-primary/25",
+    },
+    clocked_in: {
+      label: "下班打卡",
+      icon: LogOut,
+      onClick: onClockOut,
+      disabled: false,
+      className: "bg-green-600 hover:bg-green-700 shadow-green-600/25",
+    },
+    clocked_out: {
+      label: "今日已完成",
+      icon: CheckCircle2,
+      onClick: () => {},
+      disabled: true,
+      className: "bg-muted text-muted-foreground shadow-none",
+    },
+  };
+
+  const config = buttonConfig[status];
+  const Icon = config.icon;
+
+  return (
+    <div className="flex flex-col items-center gap-8">
+      {/* 即時時鐘 */}
+      <div className="text-center">
+        <p className="text-5xl font-bold tabular-nums tracking-tight">
+          {format(now, "HH:mm:ss")}
+        </p>
+        <p className="mt-2 text-lg text-muted-foreground">
+          {format(now, "yyyy年M月d日 EEEE", { locale: zhTW })}
+        </p>
+      </div>
+
+      {/* 打卡按鈕 */}
+      <button
+        onClick={config.onClick}
+        disabled={config.disabled || isLoading}
+        className={cn(
+          "flex h-48 w-48 flex-col items-center justify-center rounded-full",
+          "text-white shadow-lg transition-all duration-200",
+          "active:scale-95 disabled:opacity-60 disabled:active:scale-100",
+          "focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-ring",
+          config.className
+        )}
+        aria-label={config.label}
+      >
+        {isLoading ? (
+          <>
+            <Loader2 className="h-10 w-10 animate-spin" />
+            <span className="mt-2 text-lg font-semibold">處理中...</span>
+          </>
+        ) : (
+          <>
+            <Icon className="h-10 w-10" />
+            <span className="mt-2 text-2xl font-bold">{config.label}</span>
+          </>
+        )}
+      </button>
+
+      {/* 今日狀態 */}
+      <Card className="w-full max-w-xs">
+        <CardContent className="p-4">
+          <h3 className="mb-3 text-center text-sm font-medium text-muted-foreground">
+            今日打卡狀態
+          </h3>
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2 text-sm">
+                <LogIn className="h-4 w-4 text-muted-foreground" />
+                <span>上班</span>
+              </div>
+              <span className={cn("text-sm font-medium", clockInTime ? "" : "text-muted-foreground")}>
+                {clockInTime
+                  ? format(new Date(clockInTime), "HH:mm:ss")
+                  : "--:--:--"}
+              </span>
+            </div>
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2 text-sm">
+                <LogOut className="h-4 w-4 text-muted-foreground" />
+                <span>下班</span>
+              </div>
+              <span className={cn("text-sm font-medium", clockOutTime ? "" : "text-muted-foreground")}>
+                {clockOutTime
+                  ? format(new Date(clockOutTime), "HH:mm:ss")
+                  : "--:--:--"}
+              </span>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+```
+
+## 使用範例
+
+```tsx
+// 尚未打卡
+<ClockButton
+  status="idle"
+  clockInTime={null}
+  clockOutTime={null}
+  onClockIn={handleClockIn}
+  onClockOut={handleClockOut}
+/>
+
+// 已打上班卡
+<ClockButton
+  status="clocked_in"
+  clockInTime="2026-04-07T01:00:00Z"
+  clockOutTime={null}
+  onClockIn={handleClockIn}
+  onClockOut={handleClockOut}
+/>
+
+// 今日已完成
+<ClockButton
+  status="clocked_out"
+  clockInTime="2026-04-07T01:00:00Z"
+  clockOutTime="2026-04-07T10:00:00Z"
+  onClockIn={handleClockIn}
+  onClockOut={handleClockOut}
+/>
+
+// 載入中
+<ClockButton
+  status="idle"
+  clockInTime={null}
+  clockOutTime={null}
+  onClockIn={handleClockIn}
+  onClockOut={handleClockOut}
+  isLoading
+/>
+```
+
+## 響應式行為
+
+| 斷點 | 按鈕大小 | 時鐘字體 |
+|------|---------|---------|
+| >= 768px (md) | 192x192px (w-48) | text-5xl |
+| < 768px (sm) | 160x160px (w-40) | text-4xl |
+
+手機版按鈕仍需保持足夠大的觸控區域（最小 48x48px，實際遠超此標準）。
+
+## PWA 特殊考量
+
+- 即時時鐘每秒更新一次（`setInterval 1000ms`），在 visibilitychange 時暫停/恢復以節省電量
+- 按鈕按下時有 `active:scale-95` 回饋，提供觸覺感
+- Loading 狀態防止重複點擊（雙重保護：UI disable + API debounce）
+- 離線時顯示離線提示（由上層頁面處理）
+
+## Accessibility
+
+- 按鈕有明確的 `aria-label`
+- Loading 時 `aria-busy="true"`
+- Disabled 時 `aria-disabled="true"`
+- 時鐘使用 `tabular-nums` 確保數字等寬，避免跳動
+- Focus ring 明顯（`ring-4`）
+- 色彩不作為唯一的狀態辨識（搭配 icon + 文字）
+
+## 使用的 shadcn/ui 元件
+
+- `Button`（樣式參考）
+- `Card`

--- a/design/components/confirm-dialog.md
+++ b/design/components/confirm-dialog.md
@@ -1,0 +1,157 @@
+# ConfirmDialog
+
+## 用途
+
+確認對話框，用於需要使用者確認的操作（刪除部門、停用帳號、重設密碼等）。基於 shadcn/ui 的 `AlertDialog` 元件。
+
+## Props
+
+| Prop | Type | Default | 說明 |
+|------|------|---------|------|
+| open | `boolean` | - | 是否開啟 |
+| onOpenChange | `(open: boolean) => void` | - | 開關狀態變更 |
+| title | `string` | - | 對話框標題 |
+| description | `string` | - | 描述文字 |
+| confirmLabel | `string` | `"確認"` | 確認按鈕文字 |
+| cancelLabel | `string` | `"取消"` | 取消按鈕文字 |
+| variant | `'default' \| 'destructive'` | `'default'` | 按鈕樣式 |
+| onConfirm | `() => void` | - | 確認回呼 |
+| isLoading | `boolean` | `false` | 確認按鈕載入狀態 |
+
+## Variants
+
+| Variant | 確認按鈕 | 用途 |
+|---------|---------|------|
+| `default` | `bg-primary` | 一般確認操作 |
+| `destructive` | `bg-destructive` | 刪除、停用等破壞性操作 |
+
+## 外觀規格
+
+| 部位 | 樣式 |
+|------|------|
+| Overlay | `bg-black/80`，點擊不關閉（需明確操作） |
+| Dialog | `max-w-md`，`rounded-lg`，`p-6` |
+| Title | `text-lg font-semibold` |
+| Description | `text-sm text-muted-foreground`，`mt-2` |
+| Actions | `flex justify-end gap-2`，`mt-6` |
+
+## 範例程式碼
+
+```tsx
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { buttonVariants } from "@/components/ui/button";
+import { Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface ConfirmDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  variant?: "default" | "destructive";
+  onConfirm: () => void;
+  isLoading?: boolean;
+}
+
+export function ConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel = "確認",
+  cancelLabel = "取消",
+  variant = "default",
+  onConfirm,
+  isLoading = false,
+}: ConfirmDialogProps) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isLoading}>
+            {cancelLabel}
+          </AlertDialogCancel>
+          <AlertDialogAction
+            onClick={onConfirm}
+            disabled={isLoading}
+            className={cn(
+              variant === "destructive" &&
+                buttonVariants({ variant: "destructive" })
+            )}
+          >
+            {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            {confirmLabel}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+```
+
+## 使用範例
+
+```tsx
+// 刪除部門
+<ConfirmDialog
+  open={showDeleteDialog}
+  onOpenChange={setShowDeleteDialog}
+  title="刪除部門"
+  description="確定要刪除「工程部」嗎？此操作無法復原。部門內不可有員工。"
+  confirmLabel="刪除"
+  variant="destructive"
+  onConfirm={handleDelete}
+  isLoading={isDeleting}
+/>
+
+// 停用帳號
+<ConfirmDialog
+  open={showDeactivateDialog}
+  onOpenChange={setShowDeactivateDialog}
+  title="停用帳號"
+  description="確定要停用王小明的帳號嗎？停用後該員工將無法登入系統。"
+  confirmLabel="停用"
+  variant="destructive"
+  onConfirm={handleDeactivate}
+/>
+
+// 重設密碼
+<ConfirmDialog
+  open={showResetDialog}
+  onOpenChange={setShowResetDialog}
+  title="重設密碼"
+  description="確定要重設王小明的密碼嗎？系統將產生新的臨時密碼。"
+  confirmLabel="重設"
+  variant="default"
+  onConfirm={handleResetPassword}
+/>
+```
+
+## Accessibility
+
+- AlertDialog 會自動 trap focus
+- 按 Escape 關閉（取消操作）
+- 開啟時 focus 移到取消按鈕（安全預設）
+- 使用 `AlertDialogTitle` 和 `AlertDialogDescription` 提供語意
+- `role="alertdialog"` + `aria-modal="true"`
+- 確認按鈕在右側（破壞性操作使用紅色，視覺區分）
+
+## 使用的 shadcn/ui 元件
+
+- `AlertDialog`（含所有子元件）
+- `Button`（buttonVariants）

--- a/design/components/data-table.md
+++ b/design/components/data-table.md
@@ -1,0 +1,427 @@
+# DataTable
+
+## 用途
+
+可排序、可分頁、可搜尋的資料表格。搭配 `@tanstack/react-table` 實作 headless 邏輯，`shadcn/ui Table` 負責外觀。用於員工列表、打卡紀錄列表等頁面。
+
+## Props
+
+| Prop | Type | Default | 說明 |
+|------|------|---------|------|
+| columns | `ColumnDef<T>[]` | - | TanStack Table 欄位定義 |
+| data | `T[]` | - | 資料陣列 |
+| searchKey | `string` | - | 搜尋欄位的 key（如 `"name"`） |
+| searchPlaceholder | `string` | `"搜尋..."` | 搜尋框 placeholder |
+| filterableColumns | `FilterableColumn[]` | `[]` | 可篩選的欄位定義 |
+| pageSize | `number` | `20` | 每頁筆數 |
+| pageSizeOptions | `number[]` | `[10, 20, 50]` | 每頁筆數選項 |
+| isLoading | `boolean` | `false` | 載入中狀態 |
+| emptyMessage | `string` | `"沒有資料"` | 無資料時的提示 |
+| onRowClick | `(row: T) => void` | - | 行點擊事件 |
+| serverSide | `boolean` | `false` | 是否為 server-side 分頁 |
+| totalRows | `number` | - | server-side 時的總筆數 |
+| onPageChange | `(page: number) => void` | - | server-side 換頁 |
+| onSortChange | `(sort: SortingState) => void` | - | server-side 排序 |
+
+## 子型別
+
+```ts
+interface FilterableColumn {
+  id: string;
+  title: string;
+  options: { label: string; value: string; icon?: React.ComponentType }[];
+}
+```
+
+## 外觀規格
+
+| 部位 | 樣式 |
+|------|------|
+| 表頭 | `bg-muted/50`，`text-sm font-medium text-muted-foreground` |
+| 表格行 | `border-b`，hover 時 `bg-muted/50` |
+| 表格 cell | `p-3 text-sm`，垂直置中 |
+| 分頁列 | 底部，左側顯示筆數，右側分頁按鈕 |
+| 搜尋框 | 表格上方，`max-w-sm` |
+| 篩選器 | 搜尋框右側，使用 Popover + Command |
+
+## 範例程式碼
+
+### 基礎 DataTable 元件
+
+```tsx
+"use client";
+
+import {
+  ColumnDef,
+  ColumnFiltersState,
+  SortingState,
+  flexRender,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  ChevronLeft,
+  ChevronRight,
+  ChevronsLeft,
+  ChevronsRight,
+  Search,
+  Loader2,
+} from "lucide-react";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface DataTableProps<TData, TValue> {
+  columns: ColumnDef<TData, TValue>[];
+  data: TData[];
+  searchKey?: string;
+  searchPlaceholder?: string;
+  pageSize?: number;
+  isLoading?: boolean;
+  emptyMessage?: string;
+  onRowClick?: (row: TData) => void;
+}
+
+export function DataTable<TData, TValue>({
+  columns,
+  data,
+  searchKey,
+  searchPlaceholder = "搜尋...",
+  pageSize = 20,
+  isLoading = false,
+  emptyMessage = "沒有資料",
+  onRowClick,
+}: DataTableProps<TData, TValue>) {
+  const [sorting, setSorting] = useState<SortingState>([]);
+  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    onSortingChange: setSorting,
+    onColumnFiltersChange: setColumnFilters,
+    state: { sorting, columnFilters },
+    initialState: { pagination: { pageSize } },
+  });
+
+  return (
+    <div className="space-y-4">
+      {/* Toolbar */}
+      {searchKey && (
+        <div className="flex items-center gap-2">
+          <div className="relative max-w-sm">
+            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              placeholder={searchPlaceholder}
+              value={(table.getColumn(searchKey)?.getFilterValue() as string) ?? ""}
+              onChange={(e) => table.getColumn(searchKey)?.setFilterValue(e.target.value)}
+              className="pl-9"
+            />
+          </div>
+        </div>
+      )}
+
+      {/* Table */}
+      <div className="rounded-lg border">
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <TableHead key={header.id} className="bg-muted/50">
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(header.column.columnDef.header, header.getContext())}
+                  </TableHead>
+                ))}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {isLoading ? (
+              // Loading skeleton
+              Array.from({ length: 5 }).map((_, i) => (
+                <TableRow key={i}>
+                  {columns.map((_, j) => (
+                    <TableCell key={j}>
+                      <Skeleton className="h-5 w-full" />
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : table.getRowModel().rows?.length ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow
+                  key={row.id}
+                  onClick={() => onRowClick?.(row.original)}
+                  className={onRowClick ? "cursor-pointer" : ""}
+                >
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id}>
+                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell colSpan={columns.length} className="h-24 text-center text-muted-foreground">
+                  {emptyMessage}
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* Pagination */}
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">
+          共 {table.getFilteredRowModel().rows.length} 筆資料
+        </p>
+        <div className="flex items-center gap-2">
+          <Select
+            value={`${table.getState().pagination.pageSize}`}
+            onValueChange={(value) => table.setPageSize(Number(value))}
+          >
+            <SelectTrigger className="h-8 w-[100px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {[10, 20, 50].map((size) => (
+                <SelectItem key={size} value={`${size}`}>
+                  {size} 筆/頁
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          <div className="flex items-center gap-1">
+            <Button
+              variant="outline"
+              size="icon"
+              className="h-8 w-8"
+              onClick={() => table.setPageIndex(0)}
+              disabled={!table.getCanPreviousPage()}
+            >
+              <ChevronsLeft className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="outline"
+              size="icon"
+              className="h-8 w-8"
+              onClick={() => table.previousPage()}
+              disabled={!table.getCanPreviousPage()}
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </Button>
+            <span className="text-sm text-muted-foreground">
+              第 {table.getState().pagination.pageIndex + 1} / {table.getPageCount()} 頁
+            </span>
+            <Button
+              variant="outline"
+              size="icon"
+              className="h-8 w-8"
+              onClick={() => table.nextPage()}
+              disabled={!table.getCanNextPage()}
+            >
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="outline"
+              size="icon"
+              className="h-8 w-8"
+              onClick={() => table.setPageIndex(table.getPageCount() - 1)}
+              disabled={!table.getCanNextPage()}
+            >
+              <ChevronsRight className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+### 可排序欄位 Header
+
+```tsx
+import { Column } from "@tanstack/react-table";
+import { ArrowUpDown, ArrowUp, ArrowDown } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface SortableHeaderProps<TData, TValue> {
+  column: Column<TData, TValue>;
+  title: string;
+}
+
+export function SortableHeader<TData, TValue>({
+  column,
+  title,
+}: SortableHeaderProps<TData, TValue>) {
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      className="-ml-3 h-8"
+      onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+    >
+      {title}
+      {column.getIsSorted() === "asc" ? (
+        <ArrowUp className="ml-2 h-4 w-4" />
+      ) : column.getIsSorted() === "desc" ? (
+        <ArrowDown className="ml-2 h-4 w-4" />
+      ) : (
+        <ArrowUpDown className="ml-2 h-4 w-4" />
+      )}
+    </Button>
+  );
+}
+```
+
+### 員工列表欄位定義範例
+
+```tsx
+import { ColumnDef } from "@tanstack/react-table";
+import { StatusBadge } from "@/components/status-badge";
+import { SortableHeader } from "@/components/sortable-header";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { MoreHorizontal, Pencil, KeyRound, UserX } from "lucide-react";
+
+interface Employee {
+  id: string;
+  employee_id: string;
+  name: string;
+  email: string;
+  role: "employee" | "manager" | "admin";
+  department: { id: string; name: string };
+  status: "active" | "inactive" | "suspended";
+  hire_date: string;
+}
+
+export const employeeColumns: ColumnDef<Employee>[] = [
+  {
+    accessorKey: "employee_id",
+    header: "員工編號",
+    cell: ({ row }) => (
+      <span className="font-mono text-sm">{row.getValue("employee_id")}</span>
+    ),
+  },
+  {
+    accessorKey: "name",
+    header: ({ column }) => <SortableHeader column={column} title="姓名" />,
+  },
+  {
+    accessorKey: "email",
+    header: "Email",
+    cell: ({ row }) => (
+      <span className="text-muted-foreground">{row.getValue("email")}</span>
+    ),
+  },
+  {
+    accessorKey: "department.name",
+    header: "部門",
+    filterFn: (row, id, value) => value.includes(row.original.department.id),
+  },
+  {
+    accessorKey: "role",
+    header: "角色",
+    cell: ({ row }) => <StatusBadge type="role" value={row.getValue("role")} />,
+  },
+  {
+    accessorKey: "status",
+    header: "狀態",
+    cell: ({ row }) => <StatusBadge type="account" value={row.getValue("status")} />,
+  },
+  {
+    accessorKey: "hire_date",
+    header: ({ column }) => <SortableHeader column={column} title="到職日" />,
+    cell: ({ row }) => new Date(row.getValue("hire_date")).toLocaleDateString("zh-TW"),
+  },
+  {
+    id: "actions",
+    cell: ({ row }) => (
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="ghost" size="icon" className="h-8 w-8">
+            <MoreHorizontal className="h-4 w-4" />
+            <span className="sr-only">操作選單</span>
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onClick={() => onEdit(row.original)}>
+            <Pencil className="mr-2 h-4 w-4" />
+            編輯
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={() => onResetPassword(row.original)}>
+            <KeyRound className="mr-2 h-4 w-4" />
+            重設密碼
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onClick={() => onDeactivate(row.original)}
+            className="text-destructive"
+          >
+            <UserX className="mr-2 h-4 w-4" />
+            停用帳號
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    ),
+  },
+];
+```
+
+## States
+
+| State | 外觀 |
+|-------|------|
+| Loading | 5 列 Skeleton rows |
+| Empty | 中央顯示 emptyMessage，高度 96px |
+| Error | 中央顯示錯誤訊息 + 重試按鈕 |
+| Normal | 正常表格 |
+
+## Accessibility
+
+- Table 使用語意化 `<table>` 元素
+- 排序按鈕有 `aria-sort` 屬性
+- 分頁按鈕有 `aria-label`（如 "前一頁"、"下一頁"）
+- 行操作的 DropdownMenu trigger 有 `sr-only` 標籤
+- Loading 狀態使用 `aria-busy="true"`
+
+## 使用的 shadcn/ui 元件
+
+- `Table`（含 TableHeader, TableBody, TableRow, TableHead, TableCell）
+- `Button`
+- `Input`
+- `Select`
+- `DropdownMenu`
+- `Skeleton`

--- a/design/components/empty-state.md
+++ b/design/components/empty-state.md
@@ -1,0 +1,111 @@
+# EmptyState
+
+## 用途
+
+無資料時的提示畫面。當列表為空、搜尋無結果時顯示。提供 icon、標題、描述和可選的操作按鈕。
+
+## Props
+
+| Prop | Type | Default | 說明 |
+|------|------|---------|------|
+| icon | `LucideIcon` | `Inbox` | 圖示 |
+| title | `string` | `"沒有資料"` | 標題 |
+| description | `string` | - | 描述文字 |
+| action | `ReactNode` | - | 操作按鈕（選填） |
+
+## 外觀規格
+
+| 部位 | 樣式 |
+|------|------|
+| 容器 | `flex flex-col items-center justify-center py-12` |
+| Icon | `h-12 w-12 text-muted-foreground/50` |
+| Title | `mt-4 text-lg font-medium` |
+| Description | `mt-1 text-sm text-muted-foreground text-center max-w-sm` |
+| Action | `mt-4` |
+
+## 範例程式碼
+
+```tsx
+import { LucideIcon, Inbox } from "lucide-react";
+
+interface EmptyStateProps {
+  icon?: LucideIcon;
+  title?: string;
+  description?: string;
+  action?: React.ReactNode;
+}
+
+export function EmptyState({
+  icon: Icon = Inbox,
+  title = "沒有資料",
+  description,
+  action,
+}: EmptyStateProps) {
+  return (
+    <div className="flex flex-col items-center justify-center py-12">
+      <Icon className="h-12 w-12 text-muted-foreground/50" />
+      <h3 className="mt-4 text-lg font-medium">{title}</h3>
+      {description && (
+        <p className="mt-1 max-w-sm text-center text-sm text-muted-foreground">
+          {description}
+        </p>
+      )}
+      {action && <div className="mt-4">{action}</div>}
+    </div>
+  );
+}
+```
+
+## 使用範例
+
+```tsx
+import { Users, Search, Building2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Plus } from "lucide-react";
+
+// 員工列表為空
+<EmptyState
+  icon={Users}
+  title="尚無員工"
+  description="開始新增員工來管理您的團隊"
+  action={
+    <Button>
+      <Plus className="mr-2 h-4 w-4" />
+      新增員工
+    </Button>
+  }
+/>
+
+// 搜尋無結果
+<EmptyState
+  icon={Search}
+  title="找不到結果"
+  description="嘗試調整搜尋條件或篩選器"
+/>
+
+// 部門列表為空
+<EmptyState
+  icon={Building2}
+  title="尚無部門"
+  description="建立部門來組織您的團隊結構"
+  action={
+    <Button>
+      <Plus className="mr-2 h-4 w-4" />
+      新增部門
+    </Button>
+  }
+/>
+
+// 打卡紀錄為空
+<EmptyState
+  icon={CalendarDays}
+  title="這個月沒有打卡紀錄"
+  description="選擇其他月份查看"
+/>
+```
+
+## Accessibility
+
+- Icon 為裝飾性（`aria-hidden`）
+- 標題使用 `<h3>` 保持語意結構
+- Action 按鈕可 focus，提供明確的操作路徑

--- a/design/components/form-field.md
+++ b/design/components/form-field.md
@@ -1,0 +1,354 @@
+# FormField
+
+## 用途
+
+表單欄位元件，封裝 `react-hook-form` + `zod` 驗證 + shadcn/ui 表單元件。統一表單的錯誤提示、標籤、說明文字樣式。用於員工表單、部門表單、登入表單、密碼表單等。
+
+## 基礎架構
+
+shadcn/ui 提供 `Form` 系列元件（基於 react-hook-form），本文件定義各種欄位的使用規範。
+
+### Form 元件層級
+
+```
+<Form>                    ← react-hook-form 的 FormProvider
+  <FormField>             ← 綁定 control + name
+    <FormItem>            ← 外層容器（含 label, control, message）
+      <FormLabel>         ← 標籤
+      <FormControl>       ← 表單控制項
+        <Input />         ← 實際輸入元件
+      </FormControl>
+      <FormDescription>   ← 說明文字（選填）
+      <FormMessage>       ← 錯誤訊息
+    </FormItem>
+  </FormField>
+</Form>
+```
+
+## 欄位類型
+
+### 1. Text Input
+
+```tsx
+<FormField
+  control={form.control}
+  name="name"
+  render={({ field }) => (
+    <FormItem>
+      <FormLabel>姓名</FormLabel>
+      <FormControl>
+        <Input placeholder="請輸入姓名" {...field} />
+      </FormControl>
+      <FormMessage />
+    </FormItem>
+  )}
+/>
+```
+
+### 2. Email Input
+
+```tsx
+<FormField
+  control={form.control}
+  name="email"
+  render={({ field }) => (
+    <FormItem>
+      <FormLabel>Email</FormLabel>
+      <FormControl>
+        <Input type="email" placeholder="user@company.com" {...field} />
+      </FormControl>
+      <FormMessage />
+    </FormItem>
+  )}
+/>
+```
+
+### 3. Password Input（含顯示/隱藏切換）
+
+```tsx
+function PasswordInput({ field, placeholder = "請輸入密碼" }) {
+  const [showPassword, setShowPassword] = useState(false);
+
+  return (
+    <div className="relative">
+      <Input
+        type={showPassword ? "text" : "password"}
+        placeholder={placeholder}
+        {...field}
+      />
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="absolute right-0 top-0 h-full px-3 hover:bg-transparent"
+        onClick={() => setShowPassword(!showPassword)}
+        aria-label={showPassword ? "隱藏密碼" : "顯示密碼"}
+      >
+        {showPassword ? (
+          <EyeOff className="h-4 w-4 text-muted-foreground" />
+        ) : (
+          <Eye className="h-4 w-4 text-muted-foreground" />
+        )}
+      </Button>
+    </div>
+  );
+}
+
+// 使用方式
+<FormField
+  control={form.control}
+  name="password"
+  render={({ field }) => (
+    <FormItem>
+      <FormLabel>密碼</FormLabel>
+      <FormControl>
+        <PasswordInput field={field} />
+      </FormControl>
+      <FormMessage />
+    </FormItem>
+  )}
+/>
+```
+
+### 4. Select（下拉選單）
+
+```tsx
+<FormField
+  control={form.control}
+  name="department_id"
+  render={({ field }) => (
+    <FormItem>
+      <FormLabel>部門</FormLabel>
+      <Select onValueChange={field.onChange} defaultValue={field.value}>
+        <FormControl>
+          <SelectTrigger>
+            <SelectValue placeholder="請選擇部門" />
+          </SelectTrigger>
+        </FormControl>
+        <SelectContent>
+          {departments.map((dept) => (
+            <SelectItem key={dept.id} value={dept.id}>
+              {dept.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <FormMessage />
+    </FormItem>
+  )}
+/>
+```
+
+### 5. Combobox（可搜尋下拉 — 主管選擇）
+
+```tsx
+<FormField
+  control={form.control}
+  name="manager_id"
+  render={({ field }) => (
+    <FormItem className="flex flex-col">
+      <FormLabel>直屬主管</FormLabel>
+      <Popover>
+        <PopoverTrigger asChild>
+          <FormControl>
+            <Button
+              variant="outline"
+              role="combobox"
+              className={cn(
+                "w-full justify-between",
+                !field.value && "text-muted-foreground"
+              )}
+            >
+              {field.value
+                ? managers.find((m) => m.id === field.value)?.name
+                : "請選擇主管"}
+              <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+            </Button>
+          </FormControl>
+        </PopoverTrigger>
+        <PopoverContent className="w-full p-0">
+          <Command>
+            <CommandInput placeholder="搜尋主管..." />
+            <CommandEmpty>找不到主管</CommandEmpty>
+            <CommandGroup>
+              {managers.map((manager) => (
+                <CommandItem
+                  key={manager.id}
+                  value={manager.name}
+                  onSelect={() => field.onChange(manager.id)}
+                >
+                  <Check
+                    className={cn(
+                      "mr-2 h-4 w-4",
+                      manager.id === field.value ? "opacity-100" : "opacity-0"
+                    )}
+                  />
+                  {manager.name}
+                  <span className="ml-auto text-xs text-muted-foreground">
+                    {manager.department}
+                  </span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </Command>
+        </PopoverContent>
+      </Popover>
+      <FormDescription>選填，僅限 manager 角色的使用者</FormDescription>
+      <FormMessage />
+    </FormItem>
+  )}
+/>
+```
+
+### 6. Date Picker
+
+```tsx
+<FormField
+  control={form.control}
+  name="hire_date"
+  render={({ field }) => (
+    <FormItem className="flex flex-col">
+      <FormLabel>到職日</FormLabel>
+      <Popover>
+        <PopoverTrigger asChild>
+          <FormControl>
+            <Button
+              variant="outline"
+              className={cn(
+                "w-full pl-3 text-left font-normal",
+                !field.value && "text-muted-foreground"
+              )}
+            >
+              {field.value
+                ? format(field.value, "yyyy-MM-dd")
+                : "請選擇日期"}
+              <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
+            </Button>
+          </FormControl>
+        </PopoverTrigger>
+        <PopoverContent className="w-auto p-0" align="start">
+          <Calendar
+            mode="single"
+            selected={field.value}
+            onSelect={field.onChange}
+            initialFocus
+          />
+        </PopoverContent>
+      </Popover>
+      <FormMessage />
+    </FormItem>
+  )}
+/>
+```
+
+## Zod Schema 範例
+
+### 員工表單 Schema
+
+```tsx
+import { z } from "zod";
+
+export const employeeFormSchema = z.object({
+  employee_id: z
+    .string()
+    .min(1, "員工編號為必填")
+    .max(20, "員工編號最長 20 字元"),
+  email: z
+    .string()
+    .min(1, "Email 為必填")
+    .email("Email 格式不正確")
+    .max(255),
+  password: z
+    .string()
+    .min(8, "密碼至少 8 個字元")
+    .max(100, "密碼最長 100 個字元")
+    .optional(), // 編輯時不需要
+  name: z
+    .string()
+    .min(1, "姓名為必填")
+    .max(100, "姓名最長 100 字元"),
+  role: z.enum(["employee", "manager", "admin"], {
+    required_error: "請選擇角色",
+  }),
+  department_id: z.string().uuid("請選擇部門"),
+  manager_id: z.string().uuid().optional().or(z.literal("")),
+  hire_date: z.date({ required_error: "請選擇到職日" }),
+});
+
+export type EmployeeFormValues = z.infer<typeof employeeFormSchema>;
+```
+
+### 部門表單 Schema
+
+```tsx
+export const departmentFormSchema = z.object({
+  name: z
+    .string()
+    .min(1, "部門名稱為必填")
+    .max(100, "部門名稱最長 100 字元"),
+  code: z
+    .string()
+    .min(1, "部門代碼為必填")
+    .max(20, "部門代碼最長 20 字元")
+    .regex(/^[a-zA-Z0-9-]+$/, "僅允許英數字和連字號"),
+  manager_id: z.string().uuid().optional().or(z.literal("")),
+  parent_id: z.string().uuid().optional().or(z.literal("")),
+});
+
+export type DepartmentFormValues = z.infer<typeof departmentFormSchema>;
+```
+
+### 登入表單 Schema
+
+```tsx
+export const loginFormSchema = z.object({
+  email: z
+    .string()
+    .min(1, "請輸入 Email")
+    .email("Email 格式不正確"),
+  password: z
+    .string()
+    .min(1, "請輸入密碼"),
+});
+
+export type LoginFormValues = z.infer<typeof loginFormSchema>;
+```
+
+## 表單 Layout 規格
+
+| 場景 | Layout |
+|------|--------|
+| 登入表單 | 單欄，最大寬度 400px |
+| 員工表單（Dialog） | 兩欄 grid（`grid-cols-2`），手機變單欄 |
+| 部門表單（Dialog） | 單欄 |
+| 密碼表單（Dialog） | 單欄，最大寬度 400px |
+
+## 外觀規格
+
+| 部位 | 樣式 |
+|------|------|
+| Label | `text-sm font-medium`，必填欄位加紅色 `*` |
+| Input | 高度 40px（`h-10`），圓角 `rounded-md`，border `border-input` |
+| Error Message | `text-sm text-destructive`，出現時 input border 變 `border-destructive` |
+| Description | `text-xs text-muted-foreground` |
+| 欄位間距 | `gap-4`（16px） |
+| 表單底部 Actions | `flex justify-end gap-2`，包含取消 + 送出按鈕 |
+
+## Accessibility
+
+- 所有 `<input>` 透過 `FormControl` 自動綁定 `aria-describedby`（指向 FormMessage）
+- 錯誤狀態時 input 有 `aria-invalid="true"`
+- Label 透過 `htmlFor` 關聯 input
+- 必填欄位有 `aria-required="true"`
+- 密碼顯示/隱藏按鈕有 `aria-label`
+- 表單送出時 focus 第一個錯誤欄位
+
+## 使用的 shadcn/ui 元件
+
+- `Form`（FormField, FormItem, FormLabel, FormControl, FormDescription, FormMessage）
+- `Input`
+- `Select`
+- `Popover`
+- `Command`（Combobox）
+- `Calendar`
+- `Button`

--- a/design/components/layout.md
+++ b/design/components/layout.md
@@ -1,0 +1,351 @@
+# AppLayout
+
+## 用途
+
+應用程式的主要佈局框架，包含 Sidebar 導航、Header 頂部欄和主內容區。所有需要認證的頁面都使用此 Layout。
+
+## 結構
+
+```
+┌──────────────────────────────────────────────────┐
+│ Header (h: 64px, sticky top)                     │
+│ [Hamburger] [Breadcrumb]        [User] [Logout]  │
+├────────────┬─────────────────────────────────────┤
+│ Sidebar    │ Main Content                        │
+│ (w: 256px) │ (max-w: 1280px, mx-auto)           │
+│            │                                     │
+│ [Logo]     │ ┌───────────────────────────────┐   │
+│ [Nav 1]    │ │ Page Header                   │   │
+│ [Nav 2]    │ │ h1 + description + actions    │   │
+│ [Nav 3]    │ ├───────────────────────────────┤   │
+│ [Nav 4]    │ │ Page Content                  │   │
+│            │ │ (p: 24px)                     │   │
+│ ────────── │ │                               │   │
+│ [Settings] │ │                               │   │
+│ [User]     │ └───────────────────────────────┘   │
+└────────────┴─────────────────────────────────────┘
+```
+
+## 子元件
+
+### 1. Sidebar
+
+基於 shadcn/ui 的 `Sidebar` 元件。
+
+**Props:**
+
+| Prop | Type | Default | 說明 |
+|------|------|---------|------|
+| role | `'employee' \| 'manager' \| 'admin'` | - | 根據角色顯示不同選單 |
+
+**導航項目（依角色）:**
+
+| 選單項目 | Icon | 路由 | employee | manager | admin |
+|---------|------|------|----------|---------|-------|
+| Dashboard | `LayoutDashboard` | `/` | v | v | v |
+| 打卡 | `Clock` | `/clock` | v | v | v |
+| 打卡紀錄 | `CalendarDays` | `/clock/records` | v | v | v |
+| 員工管理 | `Users` | `/employees` | - | - | v |
+| 部門管理 | `Building2` | `/departments` | - | - | v |
+
+**底部項目（所有角色）:**
+
+| 選單項目 | Icon | 動作 |
+|---------|------|------|
+| 變更密碼 | `KeyRound` | 開啟 PasswordForm Modal |
+| 登出 | `LogOut` | 呼叫 logout API |
+
+**範例程式碼:**
+
+```tsx
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarProvider,
+  SidebarTrigger,
+} from "@/components/ui/sidebar";
+import {
+  LayoutDashboard,
+  Clock,
+  CalendarDays,
+  Users,
+  Building2,
+  KeyRound,
+  LogOut,
+} from "lucide-react";
+
+// 導航設定
+const navItems = {
+  main: [
+    { title: "Dashboard", icon: LayoutDashboard, href: "/", roles: ["employee", "manager", "admin"] },
+    { title: "打卡", icon: Clock, href: "/clock", roles: ["employee", "manager", "admin"] },
+    { title: "打卡紀錄", icon: CalendarDays, href: "/clock/records", roles: ["employee", "manager", "admin"] },
+  ],
+  admin: [
+    { title: "員工管理", icon: Users, href: "/employees", roles: ["admin"] },
+    { title: "部門管理", icon: Building2, href: "/departments", roles: ["admin"] },
+  ],
+};
+
+function AppSidebar({ role }: { role: string }) {
+  const filteredMain = navItems.main.filter((item) => item.roles.includes(role));
+  const filteredAdmin = navItems.admin.filter((item) => item.roles.includes(role));
+
+  return (
+    <Sidebar>
+      <SidebarHeader>
+        <div className="flex items-center gap-2 px-4 py-2">
+          <Clock className="h-6 w-6 text-primary" />
+          <span className="text-lg font-semibold">HR 工時系統</span>
+        </div>
+      </SidebarHeader>
+
+      <SidebarContent>
+        <SidebarGroup>
+          <SidebarGroupLabel>主選單</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {filteredMain.map((item) => (
+                <SidebarMenuItem key={item.href}>
+                  <SidebarMenuButton asChild>
+                    <a href={item.href}>
+                      <item.icon className="h-4 w-4" />
+                      <span>{item.title}</span>
+                    </a>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              ))}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+
+        {filteredAdmin.length > 0 && (
+          <SidebarGroup>
+            <SidebarGroupLabel>管理</SidebarGroupLabel>
+            <SidebarGroupContent>
+              <SidebarMenu>
+                {filteredAdmin.map((item) => (
+                  <SidebarMenuItem key={item.href}>
+                    <SidebarMenuButton asChild>
+                      <a href={item.href}>
+                        <item.icon className="h-4 w-4" />
+                        <span>{item.title}</span>
+                      </a>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                ))}
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        )}
+      </SidebarContent>
+
+      <SidebarFooter>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton onClick={onChangePassword}>
+              <KeyRound className="h-4 w-4" />
+              <span>變更密碼</span>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+          <SidebarMenuItem>
+            <SidebarMenuButton onClick={onLogout}>
+              <LogOut className="h-4 w-4" />
+              <span>登出</span>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarFooter>
+    </Sidebar>
+  );
+}
+```
+
+### 2. Header
+
+**Props:**
+
+| Prop | Type | Default | 說明 |
+|------|------|---------|------|
+| user | `{ name: string; role: string; department: string }` | - | 當前登入使用者 |
+| breadcrumbs | `{ label: string; href?: string }[]` | - | 麵包屑導航 |
+
+**範例程式碼:**
+
+```tsx
+import { SidebarTrigger } from "@/components/ui/sidebar";
+import { Separator } from "@/components/ui/separator";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { KeyRound, LogOut } from "lucide-react";
+
+function AppHeader({ user, breadcrumbs }) {
+  return (
+    <header className="sticky top-0 z-30 flex h-16 items-center gap-4 border-b bg-background px-4">
+      <SidebarTrigger className="-ml-1" />
+      <Separator orientation="vertical" className="h-4" />
+
+      {/* Breadcrumb */}
+      <Breadcrumb>
+        <BreadcrumbList>
+          {breadcrumbs.map((crumb, i) => (
+            <Fragment key={i}>
+              {i > 0 && <BreadcrumbSeparator />}
+              <BreadcrumbItem>
+                {i === breadcrumbs.length - 1 ? (
+                  <BreadcrumbPage>{crumb.label}</BreadcrumbPage>
+                ) : (
+                  <BreadcrumbLink href={crumb.href}>{crumb.label}</BreadcrumbLink>
+                )}
+              </BreadcrumbItem>
+            </Fragment>
+          ))}
+        </BreadcrumbList>
+      </Breadcrumb>
+
+      {/* User Menu */}
+      <div className="ml-auto flex items-center gap-2">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button className="flex items-center gap-2 rounded-lg px-2 py-1.5 hover:bg-accent">
+              <Avatar className="h-8 w-8">
+                <AvatarFallback className="bg-primary text-primary-foreground text-xs">
+                  {user.name.slice(0, 1)}
+                </AvatarFallback>
+              </Avatar>
+              <div className="hidden text-left text-sm md:block">
+                <p className="font-medium leading-none">{user.name}</p>
+                <p className="text-xs text-muted-foreground">{user.department}</p>
+              </div>
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-48">
+            <DropdownMenuLabel>
+              {user.name}
+              <span className="block text-xs font-normal text-muted-foreground">
+                {user.role === "admin" ? "管理員" : user.role === "manager" ? "主管" : "員工"}
+              </span>
+            </DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onClick={onChangePassword}>
+              <KeyRound className="mr-2 h-4 w-4" />
+              變更密碼
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={onLogout} className="text-destructive">
+              <LogOut className="mr-2 h-4 w-4" />
+              登出
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    </header>
+  );
+}
+```
+
+### 3. AppLayout（組合）
+
+```tsx
+import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar";
+
+function AppLayout({ children, user, breadcrumbs }) {
+  return (
+    <SidebarProvider>
+      <AppSidebar role={user.role} />
+      <SidebarInset>
+        <AppHeader user={user} breadcrumbs={breadcrumbs} />
+        <main className="flex-1 p-6 md:p-6 p-4">
+          <div className="mx-auto max-w-7xl">{children}</div>
+        </main>
+      </SidebarInset>
+    </SidebarProvider>
+  );
+}
+```
+
+### 4. PageHeader
+
+頁面標題區，統一風格。
+
+```tsx
+interface PageHeaderProps {
+  title: string;
+  description?: string;
+  actions?: React.ReactNode;
+}
+
+function PageHeader({ title, description, actions }: PageHeaderProps) {
+  return (
+    <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">{title}</h1>
+        {description && (
+          <p className="mt-1 text-sm text-muted-foreground">{description}</p>
+        )}
+      </div>
+      {actions && <div className="flex gap-2">{actions}</div>}
+    </div>
+  );
+}
+
+// 使用範例
+<PageHeader
+  title="員工管理"
+  description="管理公司員工帳號與資料"
+  actions={
+    <Button>
+      <Plus className="mr-2 h-4 w-4" />
+      新增員工
+    </Button>
+  }
+/>
+```
+
+## 響應式行為
+
+| 斷點 | Sidebar | Header | Content |
+|------|---------|--------|---------|
+| >= 1024px (lg) | 固定展開 256px | 顯示 breadcrumb + user | padding 24px |
+| 768-1023px (md) | 可收合，預設收合 | 顯示 hamburger + user | padding 24px |
+| < 768px (sm) | 隱藏，hamburger 開啟 overlay | 簡化（僅 avatar） | padding 16px |
+
+## Accessibility
+
+- Sidebar 使用 `nav` + `role="navigation"` + `aria-label="主選單"`
+- 當前頁面的 nav item 標記 `aria-current="page"`
+- SidebarTrigger 有 `aria-label="切換側邊欄"`
+- 手機版 sidebar 為 overlay modal，按 Escape 關閉
+- 所有互動元素支援 keyboard navigation（Tab / Enter / Escape）
+- Skip to content link 在 header 最前方
+
+## 使用的 shadcn/ui 元件
+
+- `Sidebar`（含所有子元件）
+- `Breadcrumb`
+- `Avatar`
+- `DropdownMenu`
+- `Separator`
+- `Button`

--- a/design/components/loading-state.md
+++ b/design/components/loading-state.md
@@ -1,0 +1,160 @@
+# LoadingState
+
+## 用途
+
+載入中的骨架屏和 Spinner 元件。提供頁面級、區塊級和元件級的三種載入狀態。
+
+## 元件
+
+### 1. PageLoader（頁面級）
+
+全頁面載入，用於路由切換或初始資料載入。
+
+```tsx
+import { Loader2 } from "lucide-react";
+
+export function PageLoader() {
+  return (
+    <div className="flex h-[50vh] items-center justify-center">
+      <Loader2 className="h-8 w-8 animate-spin text-primary" />
+    </div>
+  );
+}
+```
+
+### 2. Skeleton Patterns（骨架屏）
+
+基於 shadcn/ui 的 `Skeleton` 元件。
+
+#### 表格骨架屏
+
+```tsx
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function TableSkeleton({ rows = 5, columns = 5 }) {
+  return (
+    <div className="space-y-4">
+      {/* Toolbar skeleton */}
+      <div className="flex gap-2">
+        <Skeleton className="h-10 w-64" />
+        <Skeleton className="h-10 w-36" />
+        <Skeleton className="h-10 w-36" />
+      </div>
+
+      {/* Table skeleton */}
+      <div className="rounded-lg border">
+        {/* Header */}
+        <div className="flex border-b bg-muted/50 p-3">
+          {Array.from({ length: columns }).map((_, i) => (
+            <Skeleton key={i} className="mr-4 h-4 flex-1" />
+          ))}
+        </div>
+        {/* Rows */}
+        {Array.from({ length: rows }).map((_, i) => (
+          <div key={i} className="flex border-b p-3 last:border-0">
+            {Array.from({ length: columns }).map((_, j) => (
+              <Skeleton key={j} className="mr-4 h-4 flex-1" />
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+```
+
+#### 表單骨架屏
+
+```tsx
+export function FormSkeleton({ fields = 4 }) {
+  return (
+    <div className="space-y-6">
+      {Array.from({ length: fields }).map((_, i) => (
+        <div key={i} className="space-y-2">
+          <Skeleton className="h-4 w-20" />
+          <Skeleton className="h-10 w-full" />
+        </div>
+      ))}
+      <div className="flex justify-end gap-2">
+        <Skeleton className="h-10 w-20" />
+        <Skeleton className="h-10 w-20" />
+      </div>
+    </div>
+  );
+}
+```
+
+#### Dashboard 統計卡片骨架屏
+
+```tsx
+export function StatsCardsSkeleton({ count = 4 }) {
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      {Array.from({ length: count }).map((_, i) => (
+        <div key={i} className="rounded-lg border p-6">
+          <div className="flex items-center justify-between">
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-5 w-5 rounded" />
+          </div>
+          <Skeleton className="mt-3 h-8 w-16" />
+          <Skeleton className="mt-2 h-3 w-32" />
+        </div>
+      ))}
+    </div>
+  );
+}
+```
+
+#### 打卡頁骨架屏
+
+```tsx
+export function ClockSkeleton() {
+  return (
+    <div className="flex flex-col items-center gap-8">
+      <div className="text-center">
+        <Skeleton className="mx-auto h-12 w-48" />
+        <Skeleton className="mx-auto mt-2 h-6 w-36" />
+      </div>
+      <Skeleton className="h-48 w-48 rounded-full" />
+      <Skeleton className="h-24 w-72 rounded-xl" />
+    </div>
+  );
+}
+```
+
+### 3. Button Loading
+
+按鈕的載入狀態，使用 spinner 取代 icon。
+
+```tsx
+import { Button } from "@/components/ui/button";
+import { Loader2 } from "lucide-react";
+
+// 載入中的按鈕
+<Button disabled>
+  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+  處理中...
+</Button>
+```
+
+## 使用規範
+
+| 情境 | 使用的載入元件 | 說明 |
+|------|-------------|------|
+| 頁面初次載入 | `PageLoader` | 置中 spinner |
+| 表格載入 | `TableSkeleton` | 顯示列骨架 |
+| 表單載入 | `FormSkeleton` | 顯示欄位骨架 |
+| Dashboard 載入 | `StatsCardsSkeleton` | 卡片骨架 |
+| 按鈕提交中 | Button + Loader2 | 按鈕內 spinner |
+| 下拉選單載入 | Skeleton in Select | 選項內骨架 |
+
+## Accessibility
+
+- Skeleton 區域使用 `aria-busy="true"` + `aria-label="載入中"`
+- Spinner 使用 `role="status"` + 隱藏的 "載入中" 文字
+- 載入完成後 focus 移到內容區
+
+## 使用的 shadcn/ui 元件
+
+- `Skeleton`
+- `Button`（Loader2 icon）

--- a/design/components/password-form.md
+++ b/design/components/password-form.md
@@ -1,0 +1,282 @@
+# PasswordForm
+
+## 用途
+
+變更密碼的 Modal 表單。使用者從 Header 選單或 Sidebar 觸發開啟，輸入目前密碼 + 新密碼後送出。基於 shadcn/ui `Dialog` + `react-hook-form` + `zod`。
+
+## Props
+
+| Prop | Type | Default | 說明 |
+|------|------|---------|------|
+| open | `boolean` | - | 是否開啟 |
+| onOpenChange | `(open: boolean) => void` | - | 開關狀態變更 |
+| onSubmit | `(data: PasswordFormValues) => Promise<void>` | - | 送出回呼 |
+
+## 表單欄位
+
+| 欄位 | Label | Type | 驗證 |
+|------|-------|------|------|
+| current_password | 目前密碼 | password | 必填，min 8 |
+| new_password | 新密碼 | password | 必填，min 8，不可與目前密碼相同 |
+| confirm_password | 確認新密碼 | password | 必填，必須與新密碼一致 |
+
+## Zod Schema
+
+```tsx
+const passwordFormSchema = z
+  .object({
+    current_password: z.string().min(1, "請輸入目前密碼"),
+    new_password: z
+      .string()
+      .min(8, "密碼至少 8 個字元")
+      .max(100, "密碼最長 100 個字元"),
+    confirm_password: z.string().min(1, "請確認新密碼"),
+  })
+  .refine((data) => data.new_password === data.confirm_password, {
+    message: "新密碼與確認密碼不一致",
+    path: ["confirm_password"],
+  })
+  .refine((data) => data.current_password !== data.new_password, {
+    message: "新密碼不可與目前密碼相同",
+    path: ["new_password"],
+  });
+
+type PasswordFormValues = z.infer<typeof passwordFormSchema>;
+```
+
+## 外觀規格
+
+| 部位 | 樣式 |
+|------|------|
+| Dialog | `max-w-sm`（400px） |
+| Title | "變更密碼" |
+| Description | "請輸入目前密碼和新密碼" |
+| 欄位間距 | `space-y-4` |
+| Actions | `flex justify-end gap-2`，取消 + 送出 |
+
+## 範例程式碼
+
+```tsx
+"use client";
+
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Eye, EyeOff, Loader2 } from "lucide-react";
+
+const passwordFormSchema = z
+  .object({
+    current_password: z.string().min(1, "請輸入目前密碼"),
+    new_password: z
+      .string()
+      .min(8, "密碼至少 8 個字元")
+      .max(100, "密碼最長 100 個字元"),
+    confirm_password: z.string().min(1, "請確認新密碼"),
+  })
+  .refine((data) => data.new_password === data.confirm_password, {
+    message: "新密碼與確認密碼不一致",
+    path: ["confirm_password"],
+  })
+  .refine((data) => data.current_password !== data.new_password, {
+    message: "新密碼不可與目前密碼相同",
+    path: ["new_password"],
+  });
+
+type PasswordFormValues = z.infer<typeof passwordFormSchema>;
+
+interface PasswordFormProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (data: PasswordFormValues) => Promise<void>;
+}
+
+export function PasswordForm({ open, onOpenChange, onSubmit }: PasswordFormProps) {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const form = useForm<PasswordFormValues>({
+    resolver: zodResolver(passwordFormSchema),
+    defaultValues: {
+      current_password: "",
+      new_password: "",
+      confirm_password: "",
+    },
+  });
+
+  const handleSubmit = async (data: PasswordFormValues) => {
+    setIsSubmitting(true);
+    try {
+      await onSubmit(data);
+      form.reset();
+      onOpenChange(false);
+    } catch {
+      // API 錯誤由上層處理（toast）
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-sm">
+        <DialogHeader>
+          <DialogTitle>變更密碼</DialogTitle>
+          <DialogDescription>請輸入目前密碼和新密碼</DialogDescription>
+        </DialogHeader>
+
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-4">
+            <PasswordField
+              control={form.control}
+              name="current_password"
+              label="目前密碼"
+              placeholder="請輸入目前密碼"
+            />
+            <PasswordField
+              control={form.control}
+              name="new_password"
+              label="新密碼"
+              placeholder="至少 8 個字元"
+            />
+            <PasswordField
+              control={form.control}
+              name="confirm_password"
+              label="確認新密碼"
+              placeholder="再次輸入新密碼"
+            />
+
+            <DialogFooter className="pt-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+                disabled={isSubmitting}
+              >
+                取消
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                變更密碼
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// 密碼欄位子元件
+function PasswordField({
+  control,
+  name,
+  label,
+  placeholder,
+}: {
+  control: any;
+  name: string;
+  label: string;
+  placeholder: string;
+}) {
+  const [show, setShow] = useState(false);
+
+  return (
+    <FormField
+      control={control}
+      name={name}
+      render={({ field }) => (
+        <FormItem>
+          <FormLabel>{label}</FormLabel>
+          <FormControl>
+            <div className="relative">
+              <Input
+                type={show ? "text" : "password"}
+                placeholder={placeholder}
+                {...field}
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="absolute right-0 top-0 h-full px-3 hover:bg-transparent"
+                onClick={() => setShow(!show)}
+                tabIndex={-1}
+                aria-label={show ? "隱藏密碼" : "顯示密碼"}
+              >
+                {show ? (
+                  <EyeOff className="h-4 w-4 text-muted-foreground" />
+                ) : (
+                  <Eye className="h-4 w-4 text-muted-foreground" />
+                )}
+              </Button>
+            </div>
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+}
+```
+
+## 使用範例
+
+```tsx
+const [showPasswordForm, setShowPasswordForm] = useState(false);
+
+async function handleChangePassword(data: PasswordFormValues) {
+  await api.put("/auth/password", {
+    current_password: data.current_password,
+    new_password: data.new_password,
+  });
+  toast({ title: "密碼變更成功" });
+}
+
+<PasswordForm
+  open={showPasswordForm}
+  onOpenChange={setShowPasswordForm}
+  onSubmit={handleChangePassword}
+/>
+```
+
+## 錯誤處理
+
+| API 錯誤碼 | 前端行為 |
+|-----------|---------|
+| `INVALID_CREDENTIALS` | Toast 顯示 "目前密碼不正確" |
+| `SAME_PASSWORD` | Toast 顯示 "新密碼不可與目前密碼相同" |
+| 網路錯誤 | Toast 顯示 "網路錯誤，請稍後再試" |
+
+## Accessibility
+
+- Dialog 自動 trap focus
+- 按 Escape 關閉
+- 密碼顯示/隱藏按鈕有 `aria-label`
+- `tabIndex={-1}` 讓顯示/隱藏按鈕不在 Tab 序列中
+- 表單錯誤自動 focus 第一個錯誤欄位
+- 送出成功後自動關閉並 reset 表單
+
+## 使用的 shadcn/ui 元件
+
+- `Dialog`
+- `Form`（FormField, FormItem, FormLabel, FormControl, FormMessage）
+- `Input`
+- `Button`

--- a/design/components/search-filter.md
+++ b/design/components/search-filter.md
@@ -1,0 +1,230 @@
+# SearchFilter
+
+## 用途
+
+搜尋框 + 篩選器的組合元件，用於列表頁面的資料過濾。支援文字搜尋 + 多個下拉篩選條件。用於員工列表、打卡紀錄列表等。
+
+## Props
+
+| Prop | Type | Default | 說明 |
+|------|------|---------|------|
+| searchValue | `string` | `""` | 搜尋文字 |
+| onSearchChange | `(value: string) => void` | - | 搜尋變更回呼 |
+| searchPlaceholder | `string` | `"搜尋..."` | 搜尋框 placeholder |
+| filters | `FilterConfig[]` | `[]` | 篩選器設定 |
+| filterValues | `Record<string, string>` | `{}` | 當前篩選值 |
+| onFilterChange | `(key: string, value: string) => void` | - | 篩選變更回呼 |
+| onReset | `() => void` | - | 重置所有篩選 |
+
+## 子型別
+
+```ts
+interface FilterConfig {
+  key: string;                           // 篩選欄位 key
+  label: string;                         // 顯示標籤
+  placeholder: string;                   // 預設文字
+  options: { label: string; value: string }[];  // 選項
+}
+```
+
+## 外觀規格
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ [🔍 搜尋員工...]  [部門 ▼]  [角色 ▼]  [狀態 ▼]  [重置] │
+└─────────────────────────────────────────────────────────┘
+```
+
+| 部位 | 樣式 |
+|------|------|
+| 容器 | `flex flex-wrap items-center gap-2` |
+| 搜尋框 | `w-full sm:w-64`，左側 Search icon |
+| 篩選 Select | `w-full sm:w-36`，有 placeholder |
+| 重置按鈕 | `variant="ghost" size="sm"`，僅在有篩選條件時顯示 |
+| 活躍篩選指示 | Select trigger 內文字為非 placeholder 色 |
+
+## 範例程式碼
+
+```tsx
+"use client";
+
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Search, X } from "lucide-react";
+
+interface FilterConfig {
+  key: string;
+  label: string;
+  placeholder: string;
+  options: { label: string; value: string }[];
+}
+
+interface SearchFilterProps {
+  searchValue: string;
+  onSearchChange: (value: string) => void;
+  searchPlaceholder?: string;
+  filters?: FilterConfig[];
+  filterValues?: Record<string, string>;
+  onFilterChange?: (key: string, value: string) => void;
+  onReset?: () => void;
+}
+
+export function SearchFilter({
+  searchValue,
+  onSearchChange,
+  searchPlaceholder = "搜尋...",
+  filters = [],
+  filterValues = {},
+  onFilterChange,
+  onReset,
+}: SearchFilterProps) {
+  const hasActiveFilters =
+    searchValue || Object.values(filterValues).some((v) => v && v !== "all");
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {/* 搜尋框 */}
+      <div className="relative w-full sm:w-64">
+        <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          placeholder={searchPlaceholder}
+          value={searchValue}
+          onChange={(e) => onSearchChange(e.target.value)}
+          className="pl-9"
+        />
+      </div>
+
+      {/* 篩選器 */}
+      {filters.map((filter) => (
+        <Select
+          key={filter.key}
+          value={filterValues[filter.key] || "all"}
+          onValueChange={(value) => onFilterChange?.(filter.key, value)}
+        >
+          <SelectTrigger className="w-full sm:w-36">
+            <SelectValue placeholder={filter.placeholder} />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">{filter.placeholder}</SelectItem>
+            {filter.options.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      ))}
+
+      {/* 重置按鈕 */}
+      {hasActiveFilters && (
+        <Button variant="ghost" size="sm" onClick={onReset} className="h-10 px-2">
+          <X className="mr-1 h-4 w-4" />
+          重置
+        </Button>
+      )}
+    </div>
+  );
+}
+```
+
+## 使用範例
+
+### 員工列表篩選
+
+```tsx
+const employeeFilters: FilterConfig[] = [
+  {
+    key: "department_id",
+    label: "部門",
+    placeholder: "所有部門",
+    options: departments.map((d) => ({ label: d.name, value: d.id })),
+  },
+  {
+    key: "role",
+    label: "角色",
+    placeholder: "所有角色",
+    options: [
+      { label: "員工", value: "employee" },
+      { label: "主管", value: "manager" },
+      { label: "管理員", value: "admin" },
+    ],
+  },
+  {
+    key: "status",
+    label: "狀態",
+    placeholder: "所有狀態",
+    options: [
+      { label: "啟用", value: "active" },
+      { label: "停用", value: "inactive" },
+      { label: "凍結", value: "suspended" },
+    ],
+  },
+];
+
+<SearchFilter
+  searchValue={search}
+  onSearchChange={setSearch}
+  searchPlaceholder="搜尋員工姓名、編號、Email..."
+  filters={employeeFilters}
+  filterValues={filters}
+  onFilterChange={(key, value) => setFilters((prev) => ({ ...prev, [key]: value }))}
+  onReset={() => {
+    setSearch("");
+    setFilters({});
+  }}
+/>
+```
+
+### 打卡紀錄篩選（含月份選擇）
+
+```tsx
+const clockFilters: FilterConfig[] = [
+  {
+    key: "status",
+    label: "出勤狀態",
+    placeholder: "所有狀態",
+    options: [
+      { label: "正常", value: "normal" },
+      { label: "遲到", value: "late" },
+      { label: "早退", value: "early_leave" },
+      { label: "缺席", value: "absent" },
+    ],
+  },
+];
+
+<SearchFilter
+  searchValue=""
+  onSearchChange={() => {}}
+  filters={clockFilters}
+  filterValues={filters}
+  onFilterChange={handleFilterChange}
+  onReset={handleReset}
+/>
+```
+
+## 響應式行為
+
+| 斷點 | Layout |
+|------|--------|
+| >= 640px (sm) | 一行排列，搜尋框 256px，篩選各 144px |
+| < 640px | 堆疊排列，全部 full width |
+
+## Accessibility
+
+- 搜尋框有明確的 placeholder 文字
+- Select 使用 Radix UI，天然支援 keyboard navigation
+- 重置按鈕在無篩選時不顯示（減少干擾）
+- 搜尋框左側 icon 為裝飾性（`aria-hidden`）
+
+## 使用的 shadcn/ui 元件
+
+- `Input`
+- `Select`
+- `Button`

--- a/design/components/status-badge.md
+++ b/design/components/status-badge.md
@@ -1,0 +1,194 @@
+# StatusBadge
+
+## 用途
+
+顯示各種狀態標籤的 Badge 元件。支援出勤狀態、帳號狀態、角色標籤三種類型。基於 shadcn/ui 的 `Badge` 元件擴展。
+
+## Props
+
+| Prop | Type | Default | 說明 |
+|------|------|---------|------|
+| type | `'attendance' \| 'account' \| 'role'` | - | Badge 類型 |
+| value | `string` | - | 狀態值 |
+| showIcon | `boolean` | `true` | 是否顯示前置圖示 |
+
+## Variants
+
+### 出勤狀態（type="attendance"）
+
+| Value | 標籤文字 | 顏色 | Icon |
+|-------|---------|------|------|
+| `normal` | 正常 | Green bg + Green text | `CheckCircle2` |
+| `late` | 遲到 | Amber bg + Amber text | `Clock` |
+| `early_leave` | 早退 | Orange bg + Orange text | `LogOut` |
+| `absent` | 缺席 | Red bg + Red text | `XCircle` |
+| `amended` | 已補打卡 | Blue bg + Blue text | `FileEdit` |
+
+### 帳號狀態（type="account"）
+
+| Value | 標籤文字 | 顏色 | Icon |
+|-------|---------|------|------|
+| `active` | 啟用 | Green bg + Green text | `CheckCircle2` |
+| `inactive` | 停用 | Gray bg + Gray text | `MinusCircle` |
+| `suspended` | 凍結 | Red bg + Red text | `Ban` |
+
+### 角色標籤（type="role"）
+
+| Value | 標籤文字 | 顏色 | Icon |
+|-------|---------|------|------|
+| `admin` | 管理員 | Purple bg + Purple text | `Shield` |
+| `manager` | 主管 | Blue bg + Blue text | `UserCog` |
+| `employee` | 員工 | Gray bg + Gray text | `User` |
+
+## 外觀規格
+
+| 部位 | 樣式 |
+|------|------|
+| 容器 | `inline-flex items-center gap-1 rounded-full px-2.5 py-0.5` |
+| 文字 | `text-xs font-medium` |
+| Icon | `h-3 w-3` |
+| 背景 | 使用對應顏色的淡色版本（opacity 10-15%） |
+| 文字色 | 使用對應顏色的深色版本（700） |
+
+## 範例程式碼
+
+```tsx
+import { Badge } from "@/components/ui/badge";
+import {
+  CheckCircle2,
+  Clock,
+  LogOut,
+  XCircle,
+  FileEdit,
+  MinusCircle,
+  Ban,
+  Shield,
+  UserCog,
+  User,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+
+type StatusType = "attendance" | "account" | "role";
+
+interface StatusBadgeProps {
+  type: StatusType;
+  value: string;
+  showIcon?: boolean;
+}
+
+const statusConfig = {
+  attendance: {
+    normal: {
+      label: "正常",
+      icon: CheckCircle2,
+      className: "bg-green-100 text-green-700 dark:bg-green-950 dark:text-green-400",
+    },
+    late: {
+      label: "遲到",
+      icon: Clock,
+      className: "bg-amber-100 text-amber-700 dark:bg-amber-950 dark:text-amber-400",
+    },
+    early_leave: {
+      label: "早退",
+      icon: LogOut,
+      className: "bg-orange-100 text-orange-700 dark:bg-orange-950 dark:text-orange-400",
+    },
+    absent: {
+      label: "缺席",
+      icon: XCircle,
+      className: "bg-red-100 text-red-700 dark:bg-red-950 dark:text-red-400",
+    },
+    amended: {
+      label: "已補打卡",
+      icon: FileEdit,
+      className: "bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-400",
+    },
+  },
+  account: {
+    active: {
+      label: "啟用",
+      icon: CheckCircle2,
+      className: "bg-green-100 text-green-700 dark:bg-green-950 dark:text-green-400",
+    },
+    inactive: {
+      label: "停用",
+      icon: MinusCircle,
+      className: "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-400",
+    },
+    suspended: {
+      label: "凍結",
+      icon: Ban,
+      className: "bg-red-100 text-red-700 dark:bg-red-950 dark:text-red-400",
+    },
+  },
+  role: {
+    admin: {
+      label: "管理員",
+      icon: Shield,
+      className: "bg-purple-100 text-purple-700 dark:bg-purple-950 dark:text-purple-400",
+    },
+    manager: {
+      label: "主管",
+      icon: UserCog,
+      className: "bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-400",
+    },
+    employee: {
+      label: "員工",
+      icon: User,
+      className: "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-400",
+    },
+  },
+} as const;
+
+export function StatusBadge({ type, value, showIcon = true }: StatusBadgeProps) {
+  const config = statusConfig[type]?.[value as keyof (typeof statusConfig)[typeof type]];
+
+  if (!config) return null;
+
+  const Icon = config.icon;
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium",
+        config.className
+      )}
+    >
+      {showIcon && <Icon className="h-3 w-3" />}
+      {config.label}
+    </span>
+  );
+}
+```
+
+## 使用範例
+
+```tsx
+// 出勤狀態
+<StatusBadge type="attendance" value="normal" />    // [v] 正常
+<StatusBadge type="attendance" value="late" />       // [!] 遲到
+<StatusBadge type="attendance" value="absent" />     // [x] 缺席
+
+// 帳號狀態
+<StatusBadge type="account" value="active" />        // [v] 啟用
+<StatusBadge type="account" value="suspended" />     // [x] 凍結
+
+// 角色
+<StatusBadge type="role" value="admin" />            // [盾] 管理員
+<StatusBadge type="role" value="manager" />          // [齒] 主管
+
+// 不顯示 icon
+<StatusBadge type="attendance" value="late" showIcon={false} />
+```
+
+## Accessibility
+
+- 使用 `<span>` 而非 `<div>`，語意正確為 inline 元素
+- Icon 為裝飾性（`aria-hidden="true"`，lucide-react 預設）
+- 文字標籤提供足夠語意，不需額外 aria-label
+- 色彩對比度符合 WCAG 2.1 AA（文字色 vs 背景色對比 >= 4.5:1）
+- Dark mode 下使用更深背景 + 更亮文字確保對比度
+
+## 使用的 shadcn/ui 元件
+
+- `Badge`（作為樣式參考，實際使用自訂 `<span>`）

--- a/design/components/toast-notification.md
+++ b/design/components/toast-notification.md
@@ -1,0 +1,168 @@
+# Toast / Notification
+
+## 用途
+
+全域的通知提示元件，用於操作回饋（成功、失敗、警告、資訊）。基於 shadcn/ui 的 `Toast` 元件（使用 Radix UI Toast primitive）。
+
+## Variants
+
+| Variant | 外觀 | Icon | 用途範例 |
+|---------|------|------|---------|
+| `default` | 白色背景 + 深色文字 | `Info` | 一般資訊提示 |
+| `success` | 綠色左邊框 | `CheckCircle2` | 操作成功 |
+| `destructive` | 紅色背景 | `XCircle` | 操作失敗 |
+| `warning` | 橙色左邊框 | `AlertTriangle` | 警告提示 |
+
+## Toast 函式介面
+
+```ts
+// shadcn/ui 的 useToast hook
+const { toast } = useToast();
+
+// 基礎用法
+toast({
+  title: "操作成功",
+  description: "員工資料已更新",
+  variant: "default",
+});
+
+// 封裝後的便捷函式
+function showSuccess(title: string, description?: string);
+function showError(title: string, description?: string);
+function showWarning(title: string, description?: string);
+function showInfo(title: string, description?: string);
+```
+
+## 外觀規格
+
+| 部位 | 樣式 |
+|------|------|
+| 位置 | 右下角（`bottom-right`），距離邊框 16px |
+| 容器 | `rounded-lg border p-4 shadow-lg`，最大寬度 420px |
+| Title | `text-sm font-semibold` |
+| Description | `text-sm text-muted-foreground` |
+| 關閉按鈕 | 右上角 X icon |
+| 自動消失 | 5 秒後自動關閉 |
+| 動畫 | 從右側滑入，淡出消失 |
+
+## 範例程式碼
+
+### Toaster 元件（放在 layout 中）
+
+```tsx
+// app/layout.tsx 或 providers.tsx
+import { Toaster } from "@/components/ui/toaster";
+
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>
+        {children}
+        <Toaster />
+      </body>
+    </html>
+  );
+}
+```
+
+### Toast 便捷函式
+
+```tsx
+import { useToast } from "@/hooks/use-toast";
+import { CheckCircle2, XCircle, AlertTriangle, Info } from "lucide-react";
+
+export function useNotification() {
+  const { toast } = useToast();
+
+  return {
+    success: (title: string, description?: string) =>
+      toast({
+        title: (
+          <div className="flex items-center gap-2">
+            <CheckCircle2 className="h-4 w-4 text-green-600" />
+            {title}
+          </div>
+        ),
+        description,
+      }),
+
+    error: (title: string, description?: string) =>
+      toast({
+        title: (
+          <div className="flex items-center gap-2">
+            <XCircle className="h-4 w-4" />
+            {title}
+          </div>
+        ),
+        description,
+        variant: "destructive",
+      }),
+
+    warning: (title: string, description?: string) =>
+      toast({
+        title: (
+          <div className="flex items-center gap-2">
+            <AlertTriangle className="h-4 w-4 text-amber-600" />
+            {title}
+          </div>
+        ),
+        description,
+      }),
+
+    info: (title: string, description?: string) =>
+      toast({
+        title: (
+          <div className="flex items-center gap-2">
+            <Info className="h-4 w-4 text-blue-600" />
+            {title}
+          </div>
+        ),
+        description,
+      }),
+  };
+}
+```
+
+### 使用範例
+
+```tsx
+const { success, error } = useNotification();
+
+// 登入成功
+success("登入成功", "歡迎回來，王小明");
+
+// 登入失敗
+error("登入失敗", "Email 或密碼不正確");
+
+// 員工建立成功
+success("新增成功", "員工 EMP001 已建立");
+
+// 刪除部門失敗
+error("刪除失敗", "部門仍有員工，無法刪除");
+
+// 打卡成功
+success("上班打卡成功", "打卡時間 09:00:15");
+
+// 網路錯誤
+error("網路錯誤", "無法連線到伺服器，請稍後再試");
+
+// 離線警告
+warning("離線模式", "目前無網路連線，部分功能可能無法使用");
+
+// 密碼即將過期
+info("密碼提醒", "您的密碼將於 7 天後過期，請盡快變更");
+```
+
+## Accessibility
+
+- Toast 使用 `role="status"` + `aria-live="polite"`（非緊急通知）
+- Destructive toast 使用 `aria-live="assertive"`（錯誤需立即注意）
+- 關閉按鈕有 `aria-label="關閉通知"`
+- 自動消失前可被 hover 暫停
+- 支援 keyboard dismiss（Escape）
+- 通知堆疊時最多顯示 3 個，超過排隊等待
+
+## 使用的 shadcn/ui 元件
+
+- `Toast`（Toaster, ToastProvider, ToastViewport）
+- `useToast` hook

--- a/design/pages/clock-in.md
+++ b/design/pages/clock-in.md
@@ -1,0 +1,207 @@
+# 打卡頁
+
+## 對應 Feature
+
+#8 F-001: 打卡（上班/下班）
+
+## Layout
+
+```
+┌──────────────────────────────────────────────────┐
+│ Header: [≡] 打卡                  [Avatar ▼]     │
+├────────────┬─────────────────────────────────────┤
+│ Sidebar    │ Main Content (centered)             │
+│            │                                     │
+│   Dashboard│                                     │
+│ > 打卡     │         14:32:08                    │
+│   打卡紀錄 │    2026年4月7日 星期二               │
+│   ─────    │                                     │
+│   員工管理 │       ┌──────────┐                   │
+│   部門管理 │       │          │                   │
+│            │       │  下班    │                   │
+│            │       │  打卡    │                   │
+│            │       │          │                   │
+│            │       └──────────┘                   │
+│            │                                     │
+│            │       ┌──────────┐                   │
+│            │       │ 上班 09:00│                  │
+│            │       │ 下班 --:--│                  │
+│            │       └──────────┘                   │
+│            │                                     │
+│            │    ⚡ 可加入備註                      │
+│            │                                     │
+└────────────┴─────────────────────────────────────┘
+```
+
+## 頁面規格
+
+| 項目 | 說明 |
+|------|------|
+| 路由 | `/clock` |
+| 認證 | 需要（所有角色） |
+| Layout | `AppLayout` |
+| Breadcrumb | `[Dashboard, 打卡]` |
+| 內容對齊 | 水平垂直置中 |
+
+## 使用的元件
+
+| 元件 | 來源 | 用途 |
+|------|------|------|
+| AppLayout | `components/layout` | 頁面框架 |
+| ClockButton | `components/clock-button` | 打卡按鈕 + 時鐘 + 狀態 |
+| Toast | shadcn/ui | 打卡結果通知 |
+| Textarea | shadcn/ui | 備註輸入（選填） |
+
+## 互動行為
+
+### 頁面載入
+
+1. 呼叫 `GET /api/v1/clock/today` 取得今日狀態
+2. 根據回傳決定 ClockButton 的 status：
+   - `clock_in == null` => `idle`
+   - `clock_in != null && clock_out == null` => `clocked_in`
+   - `clock_in != null && clock_out != null` => `clocked_out`
+
+### 打卡流程
+
+1. 使用者按下打卡按鈕
+2. 按鈕進入 loading 狀態
+3. 呼叫 `POST /api/v1/clock/in` 或 `POST /api/v1/clock/out`
+4. 成功：
+   - Toast "上班打卡成功，打卡時間 09:00:15"
+   - 更新 ClockButton status
+5. 失敗：
+   - `ALREADY_CLOCKED_IN` => Toast "今日已打過上班卡"
+   - `NOT_CLOCKED_IN` => Toast "請先打上班卡"
+   - `ALREADY_CLOCKED_OUT` => Toast "今日已打過下班卡"
+
+### 備註（可選）
+
+- 打卡按鈕下方有一個可展開的「加入備註」連結
+- 點擊展開 Textarea
+- 備註會在打卡 API 中帶入 `note` 欄位
+
+## 範例程式碼
+
+```tsx
+"use client";
+
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { ClockButton } from "@/components/clock-button";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { useNotification } from "@/hooks/use-notification";
+import { MessageSquare } from "lucide-react";
+import { format } from "date-fns";
+
+export default function ClockInPage() {
+  const [showNote, setShowNote] = useState(false);
+  const [note, setNote] = useState("");
+  const { success, error } = useNotification();
+  const queryClient = useQueryClient();
+
+  const { data: todayStatus, isLoading } = useQuery({
+    queryKey: ["clock", "today"],
+    queryFn: () => api.get("/clock/today"),
+  });
+
+  const clockInMutation = useMutation({
+    mutationFn: () => api.post("/clock/in", { note: note || undefined }),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ["clock", "today"] });
+      success("上班打卡成功", `打卡時間 ${format(new Date(data.clock_in), "HH:mm:ss")}`);
+      setNote("");
+      setShowNote(false);
+    },
+    onError: (err) => {
+      const messages: Record<string, string> = {
+        ALREADY_CLOCKED_IN: "今日已打過上班卡",
+      };
+      error("打卡失敗", messages[err.code] || "請稍後再試");
+    },
+  });
+
+  const clockOutMutation = useMutation({
+    mutationFn: () => api.post("/clock/out", { note: note || undefined }),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ["clock", "today"] });
+      success("下班打卡成功", `打卡時間 ${format(new Date(data.clock_out), "HH:mm:ss")}`);
+      setNote("");
+      setShowNote(false);
+    },
+    onError: (err) => {
+      const messages: Record<string, string> = {
+        NOT_CLOCKED_IN: "請先打上班卡",
+        ALREADY_CLOCKED_OUT: "今日已打過下班卡",
+      };
+      error("打卡失敗", messages[err.code] || "請稍後再試");
+    },
+  });
+
+  const status = !todayStatus?.clock_in
+    ? "idle"
+    : !todayStatus?.clock_out
+      ? "clocked_in"
+      : "clocked_out";
+
+  return (
+    <AppLayout breadcrumbs={[{ label: "Dashboard", href: "/" }, { label: "打卡" }]}>
+      <div className="flex min-h-[60vh] flex-col items-center justify-center">
+        <ClockButton
+          status={status}
+          clockInTime={todayStatus?.clock_in}
+          clockOutTime={todayStatus?.clock_out}
+          onClockIn={() => clockInMutation.mutate()}
+          onClockOut={() => clockOutMutation.mutate()}
+          isLoading={clockInMutation.isPending || clockOutMutation.isPending}
+        />
+
+        {/* 備註區 */}
+        {status !== "clocked_out" && (
+          <div className="mt-6 w-full max-w-xs">
+            {showNote ? (
+              <div className="space-y-2">
+                <Textarea
+                  placeholder="輸入備註（選填，如：外出開會晚到）"
+                  value={note}
+                  onChange={(e) => setNote(e.target.value)}
+                  rows={2}
+                  maxLength={500}
+                />
+                <p className="text-right text-xs text-muted-foreground">
+                  {note.length}/500
+                </p>
+              </div>
+            ) : (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="w-full text-muted-foreground"
+                onClick={() => setShowNote(true)}
+              >
+                <MessageSquare className="mr-2 h-4 w-4" />
+                加入備註
+              </Button>
+            )}
+          </div>
+        )}
+      </div>
+    </AppLayout>
+  );
+}
+```
+
+## 響應式行為
+
+| 斷點 | 按鈕大小 | 時鐘字體 | 備註區寬度 |
+|------|---------|---------|-----------|
+| >= 768px | w-48 h-48 | text-5xl | max-w-xs |
+| < 768px | w-40 h-40 | text-4xl | full width, px-4 |
+
+## PWA 考量
+
+- 打卡按鈕足夠大，單手操作友善
+- 即時時鐘使用 `tabular-nums` 避免跳動
+- 離線狀態下顯示提示 "目前離線，請確認網路連線後再打卡"
+- 打卡動作需要網路，不支援離線打卡（時間以 server 為準）

--- a/design/pages/clock-records.md
+++ b/design/pages/clock-records.md
@@ -1,0 +1,282 @@
+# 打卡紀錄頁
+
+## 對應 Feature
+
+#8 F-001: 打卡（上班/下班）
+
+## Layout
+
+```
+┌──────────────────────────────────────────────────┐
+│ Header: [≡] 打卡紀錄              [Avatar ▼]     │
+├────────────┬─────────────────────────────────────┤
+│ Sidebar    │ Main Content                        │
+│            │                                     │
+│   Dashboard│ ┌── PageHeader ──────────────────┐  │
+│   打卡     │ │ 打卡紀錄                       │  │
+│ > 打卡紀錄 │ │ 查看您的出勤紀錄               │  │
+│   ─────    │ └────────────────────────────────┘  │
+│   員工管理 │                                     │
+│   部門管理 │ ┌── Controls ────────────────────┐  │
+│            │ │ [◀] 2026年4月 [▶]  [列表|月曆] │  │
+│            │ │ [狀態▼]                         │  │
+│            │ └────────────────────────────────┘  │
+│            │                                     │
+│            │ ┌── Calendar View ────────────────┐ │
+│            │ │ 一  二  三  四  五  六  日      │  │
+│            │ │          1   2   3   4   5      │  │
+│            │ │          ✓   ✓   ✓   ✓   -      │  │
+│            │ │ 6   7   8   9  10  11  12      │  │
+│            │ │ -   !   ✓   ✓   ✓   ✓   -      │  │
+│            │ │ ...                              │ │
+│            │ └────────────────────────────────┘  │
+│            │                                     │
+│            │ ─── 或 ───                           │
+│            │                                     │
+│            │ ┌── List View ───────────────────┐  │
+│            │ │ 日期    上班    下班    狀態     │  │
+│            │ │ 04/07  09:00  18:05  [正常]    │  │
+│            │ │ 04/06  09:15  18:00  [遲到]    │  │
+│            │ │ 04/05  --:--  --:--  [缺席]    │  │
+│            │ │ ...                             │  │
+│            │ ├────────────────────────────────┤  │
+│            │ │ 共 22 筆  [< 1/2 >]            │  │
+│            │ └────────────────────────────────┘  │
+└────────────┴─────────────────────────────────────┘
+```
+
+## 頁面規格
+
+| 項目 | 說明 |
+|------|------|
+| 路由 | `/clock/records` |
+| 認證 | 需要（所有角色） |
+| Layout | `AppLayout` |
+| Breadcrumb | `[Dashboard, 打卡紀錄]` |
+
+## 使用的元件
+
+| 元件 | 來源 | 用途 |
+|------|------|------|
+| AppLayout | `components/layout` | 頁面框架 |
+| PageHeader | `components/layout` | 頁面標題 |
+| DataTable | `components/data-table` | 列表視圖 |
+| StatusBadge | `components/status-badge` | 出勤狀態 |
+| Button | shadcn/ui | 月份切換、視圖切換 |
+| Tabs | shadcn/ui | 列表/月曆切換 |
+| EmptyState | `components/empty-state` | 無紀錄狀態 |
+
+## 視圖切換
+
+### 月曆視圖
+
+以月曆形式顯示每日出勤狀態。
+
+| 部位 | 樣式 |
+|------|------|
+| 月份選擇 | `flex items-center gap-2`，左右箭頭 + 月份文字 |
+| 月曆格子 | 7 欄 grid，每格 `aspect-square rounded-lg` |
+| 格子內容 | 日期數字 + 狀態 icon |
+| 狀態 icon | 正常=綠點、遲到=橙點、早退=橙點、缺席=紅點、未打卡=灰 |
+| 今日 | `ring-2 ring-primary` 標示 |
+| 假日 | `text-muted-foreground`，灰色背景 |
+
+```tsx
+function CalendarView({ records, month, onMonthChange }) {
+  const days = getDaysInMonth(month);
+
+  return (
+    <div>
+      {/* 月份選擇器 */}
+      <div className="mb-4 flex items-center justify-center gap-4">
+        <Button variant="outline" size="icon" onClick={() => onMonthChange(-1)}>
+          <ChevronLeft className="h-4 w-4" />
+        </Button>
+        <span className="text-lg font-semibold">
+          {format(month, "yyyy年M月")}
+        </span>
+        <Button variant="outline" size="icon" onClick={() => onMonthChange(1)}>
+          <ChevronRight className="h-4 w-4" />
+        </Button>
+      </div>
+
+      {/* 星期 Header */}
+      <div className="grid grid-cols-7 text-center text-sm font-medium text-muted-foreground">
+        {["一", "二", "三", "四", "五", "六", "日"].map((d) => (
+          <div key={d} className="py-2">{d}</div>
+        ))}
+      </div>
+
+      {/* 日期格子 */}
+      <div className="grid grid-cols-7 gap-1">
+        {days.map((day) => {
+          const record = records.find((r) => r.date === day.dateStr);
+          const isToday = isSameDay(day.date, new Date());
+
+          return (
+            <div
+              key={day.dateStr}
+              className={cn(
+                "flex aspect-square flex-col items-center justify-center rounded-lg p-1 text-sm",
+                isToday && "ring-2 ring-primary",
+                day.isWeekend && "bg-muted/50 text-muted-foreground"
+              )}
+            >
+              <span>{day.dayOfMonth}</span>
+              {record && (
+                <span
+                  className={cn(
+                    "mt-0.5 h-2 w-2 rounded-full",
+                    record.status === "normal" && "bg-green-500",
+                    record.status === "late" && "bg-amber-500",
+                    record.status === "early_leave" && "bg-orange-500",
+                    record.status === "absent" && "bg-red-500",
+                    record.status === "amended" && "bg-blue-500"
+                  )}
+                />
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* 圖例 */}
+      <div className="mt-4 flex flex-wrap justify-center gap-4 text-xs text-muted-foreground">
+        <span className="flex items-center gap-1">
+          <span className="h-2 w-2 rounded-full bg-green-500" /> 正常
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="h-2 w-2 rounded-full bg-amber-500" /> 遲到
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="h-2 w-2 rounded-full bg-orange-500" /> 早退
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="h-2 w-2 rounded-full bg-red-500" /> 缺席
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="h-2 w-2 rounded-full bg-blue-500" /> 已補打卡
+        </span>
+      </div>
+    </div>
+  );
+}
+```
+
+### 列表視圖
+
+使用 DataTable 顯示。
+
+| 欄位 | Header | 說明 |
+|------|--------|------|
+| date | 日期 | `yyyy-MM-dd (週X)` 格式 |
+| clock_in | 上班 | `HH:mm:ss` 或 `--:--:--` |
+| clock_out | 下班 | `HH:mm:ss` 或 `--:--:--` |
+| status | 狀態 | StatusBadge(type="attendance") |
+| note | 備註 | 截斷顯示，hover 顯示全文 |
+
+## 互動行為
+
+### 月份切換
+
+- 左右箭頭切換月份
+- 最遠可查到 90 天前的紀錄
+- 切換時呼叫 `GET /api/v1/clock/records?start_date=...&end_date=...`
+
+### 視圖切換
+
+- 使用 `Tabs` 元件切換月曆/列表
+- 記住使用者偏好（localStorage）
+
+### 月曆格子點擊
+
+- 點擊有紀錄的日期，顯示詳細資訊（Popover）
+- 包含：上班時間、下班時間、狀態、備註
+
+## 範例程式碼（頁面組裝）
+
+```tsx
+"use client";
+
+import { useState } from "react";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { CalendarDays, List } from "lucide-react";
+
+export default function ClockRecordsPage() {
+  const [month, setMonth] = useState(new Date());
+  const [view, setView] = useState<"calendar" | "list">("calendar");
+
+  const { data: records, isLoading } = useQuery({
+    queryKey: ["clock", "records", format(month, "yyyy-MM")],
+    queryFn: () =>
+      api.get("/clock/records", {
+        params: {
+          start_date: startOfMonth(month).toISOString().split("T")[0],
+          end_date: endOfMonth(month).toISOString().split("T")[0],
+          limit: 100,
+        },
+      }),
+  });
+
+  return (
+    <AppLayout
+      breadcrumbs={[
+        { label: "Dashboard", href: "/" },
+        { label: "打卡紀錄" },
+      ]}
+    >
+      <PageHeader title="打卡紀錄" description="查看您的出勤紀錄" />
+
+      <Tabs value={view} onValueChange={(v) => setView(v as any)}>
+        <div className="mb-4 flex items-center justify-between">
+          <div>{/* 月份選擇器放這裡 */}</div>
+          <TabsList>
+            <TabsTrigger value="calendar">
+              <CalendarDays className="mr-2 h-4 w-4" />
+              月曆
+            </TabsTrigger>
+            <TabsTrigger value="list">
+              <List className="mr-2 h-4 w-4" />
+              列表
+            </TabsTrigger>
+          </TabsList>
+        </div>
+
+        <TabsContent value="calendar">
+          <CalendarView
+            records={records?.data || []}
+            month={month}
+            onMonthChange={(dir) =>
+              setMonth((prev) => addMonths(prev, dir))
+            }
+          />
+        </TabsContent>
+
+        <TabsContent value="list">
+          <DataTable
+            columns={clockRecordColumns}
+            data={records?.data || []}
+            isLoading={isLoading}
+            emptyMessage="這個月沒有打卡紀錄"
+          />
+        </TabsContent>
+      </Tabs>
+    </AppLayout>
+  );
+}
+```
+
+## 響應式行為
+
+| 斷點 | 月曆 | 列表 |
+|------|------|------|
+| >= 768px (md) | 正常大小 | 完整欄位 |
+| < 768px | 緊湊版（數字 + 小點） | 隱藏備註欄位 |
+
+月曆視圖在手機上仍可操作，但格子較小。列表視圖可能更適合手機使用。
+
+## API 呼叫
+
+```
+GET /api/v1/clock/records?start_date={yyyy-MM-dd}&end_date={yyyy-MM-dd}&page=1&limit=100
+```

--- a/design/pages/dashboard.md
+++ b/design/pages/dashboard.md
@@ -1,0 +1,190 @@
+# Dashboard
+
+## 對應 Feature
+
+#8 F-001: 打卡 + #6 F-000: 認證系統
+
+## Layout
+
+```
+┌──────────────────────────────────────────────────┐
+│ Header: [≡] Dashboard              [Avatar ▼]    │
+├────────────┬─────────────────────────────────────┤
+│ Sidebar    │ Main Content                        │
+│            │                                     │
+│ Dashboard  │ ┌── PageHeader ──────────────────┐  │
+│ > 打卡     │ │ Dashboard                      │  │
+│   打卡紀錄 │ │ 歡迎回來，王小明               │  │
+│   ─────    │ └────────────────────────────────┘  │
+│   員工管理 │                                     │
+│   部門管理 │ ┌── Stats Cards (grid-cols-4) ───┐  │
+│            │ │ [今日打卡] [準時率] [遲到] [...] │  │
+│            │ └────────────────────────────────┘  │
+│            │                                     │
+│            │ ┌── Quick Actions ────────────────┐ │
+│            │ │ [前往打卡]  [查看紀錄]          │ │
+│            │ └────────────────────────────────┘  │
+│            │                                     │
+│            │ ┌── 今日打卡狀態 ─────────────────┐ │
+│            │ │ 上班: 09:00:15  下班: --:--:-- │  │
+│            │ └────────────────────────────────┘  │
+└────────────┴─────────────────────────────────────┘
+```
+
+## 頁面規格
+
+| 項目 | 說明 |
+|------|------|
+| 路由 | `/` |
+| 認證 | 需要 |
+| Layout | `AppLayout` |
+| Breadcrumb | `[Dashboard]` |
+
+## 內容區塊（依角色）
+
+### 員工（employee）
+
+1. **歡迎訊息**：PageHeader "Dashboard"，描述 "歡迎回來，{name}"
+2. **今日打卡狀態卡片**：上班時間 / 下班時間 / 今日狀態
+3. **快速操作**：前往打卡、查看紀錄
+
+### 主管（manager）
+
+同員工 + 額外：
+4. **團隊出勤摘要**：今日出勤人數、遲到人數
+
+### Admin
+
+同主管 + 額外：
+5. **全公司統計**：總員工數、今日出勤率、本月遲到率
+
+## 使用的元件
+
+| 元件 | 來源 | 用途 |
+|------|------|------|
+| AppLayout | `components/layout` | 頁面框架 |
+| PageHeader | `components/layout` | 頁面標題 |
+| CardStats | `components/card-stats` | 統計卡片 |
+| StatusBadge | `components/status-badge` | 打卡狀態標示 |
+| Button | shadcn/ui | 快速操作按鈕 |
+| Card | shadcn/ui | 今日狀態卡片 |
+
+## 互動行為
+
+1. 頁面載入時呼叫 `GET /api/v1/clock/today` 取得今日打卡狀態
+2. Admin 額外呼叫統計 API
+3. 卡片數據每 60 秒自動刷新（使用 react-query refetchInterval）
+4. 快速操作按鈕導向對應頁面
+
+## 範例程式碼
+
+```tsx
+import { AppLayout } from "@/components/layout";
+import { PageHeader } from "@/components/page-header";
+import { CardStats } from "@/components/card-stats";
+import { StatusBadge } from "@/components/status-badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import {
+  Clock,
+  CalendarDays,
+  Users,
+  CheckCircle2,
+  AlertTriangle,
+  LogIn,
+  LogOut,
+} from "lucide-react";
+import Link from "next/link";
+
+export default function DashboardPage() {
+  // const { data: todayStatus } = useQuery(...)
+  // const { data: stats } = useQuery(...)
+
+  return (
+    <AppLayout breadcrumbs={[{ label: "Dashboard" }]}>
+      <PageHeader
+        title="Dashboard"
+        description={`歡迎回來，${user.name}`}
+      />
+
+      {/* 統計卡片 — Admin 看到全部，員工看到個人 */}
+      {user.role === "admin" && (
+        <div className="mb-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <CardStats title="今日出勤" value={42} icon={Users} />
+          <CardStats title="準時率" value="95%" icon={CheckCircle2} />
+          <CardStats title="遲到人數" value={2} icon={AlertTriangle} />
+          <CardStats title="總員工數" value={50} icon={Users} />
+        </div>
+      )}
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        {/* 今日打卡狀態 */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">今日打卡狀態</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2 text-sm">
+                <LogIn className="h-4 w-4 text-muted-foreground" />
+                <span>上班打卡</span>
+              </div>
+              <span className="font-medium">
+                {todayStatus?.clock_in
+                  ? format(new Date(todayStatus.clock_in), "HH:mm:ss")
+                  : "--:--:--"}
+              </span>
+            </div>
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2 text-sm">
+                <LogOut className="h-4 w-4 text-muted-foreground" />
+                <span>下班打卡</span>
+              </div>
+              <span className="font-medium">
+                {todayStatus?.clock_out
+                  ? format(new Date(todayStatus.clock_out), "HH:mm:ss")
+                  : "--:--:--"}
+              </span>
+            </div>
+            {todayStatus?.status && (
+              <div className="flex items-center justify-between">
+                <span className="text-sm">狀態</span>
+                <StatusBadge type="attendance" value={todayStatus.status} />
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* 快速操作 */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">快速操作</CardTitle>
+          </CardHeader>
+          <CardContent className="grid gap-3 sm:grid-cols-2">
+            <Button asChild variant="outline" className="h-auto flex-col gap-2 py-6">
+              <Link href="/clock">
+                <Clock className="h-8 w-8 text-primary" />
+                <span>前往打卡</span>
+              </Link>
+            </Button>
+            <Button asChild variant="outline" className="h-auto flex-col gap-2 py-6">
+              <Link href="/clock/records">
+                <CalendarDays className="h-8 w-8 text-primary" />
+                <span>查看紀錄</span>
+              </Link>
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    </AppLayout>
+  );
+}
+```
+
+## 響應式行為
+
+| 斷點 | Stats Grid | 內容 Grid |
+|------|-----------|----------|
+| >= 1024px (lg) | 4 欄 | 2 欄 |
+| 640-1023px (sm-lg) | 2 欄 | 1 欄 |
+| < 640px | 1 欄 | 1 欄 |

--- a/design/pages/department-form.md
+++ b/design/pages/department-form.md
@@ -1,0 +1,267 @@
+# 部門新增/編輯表單
+
+## 對應 Feature
+
+#7 F-008: 員工/部門管理
+
+## Layout
+
+使用 Dialog，從部門列表頁觸發。
+
+```
+┌─────────────── Dialog ──────────────────┐
+│ [X]                                     │
+│ 新增部門 / 編輯部門                       │
+│ 填寫部門基本資料                          │
+│                                         │
+│ 部門名稱 *                               │
+│ [________________________]               │
+│                                         │
+│ 部門代碼 *                               │
+│ [________________________]               │
+│ 僅允許英數字和連字號                       │
+│                                         │
+│ 部門主管                                 │
+│ [搜尋主管... ▼]                          │
+│ 選填，僅限 manager 角色                   │
+│                                         │
+│ 上級部門                                 │
+│ [請選擇上級部門 ▼]                        │
+│ 選填，最多 3 層                           │
+│                                         │
+│                    [取消]  [儲存]        │
+└─────────────────────────────────────────┘
+```
+
+## 頁面規格
+
+| 項目 | 說明 |
+|------|------|
+| 觸發方式 | 部門列表的「新增部門」按鈕 / 卡片操作「編輯」 |
+| 容器 | `Dialog`，`max-w-md`（448px） |
+| 認證 | 需要（role: admin） |
+
+## 使用的元件
+
+| 元件 | 來源 | 用途 |
+|------|------|------|
+| Dialog | shadcn/ui | 容器 |
+| Form | react-hook-form + zod | 表單驗證 |
+| Input | shadcn/ui | 名稱、代碼 |
+| Combobox | shadcn/ui (Popover + Command) | 主管選擇 |
+| Select | shadcn/ui | 上級部門選擇 |
+| Button | shadcn/ui | 送出/取消 |
+
+## 表單欄位
+
+| 欄位 | Label | Type | 必填 | 新增 | 編輯 | 驗證 |
+|------|-------|------|------|------|------|------|
+| name | 部門名稱 | text | 是 | 可編輯 | 可編輯 | max 100, unique |
+| code | 部門代碼 | text | 是 | 可編輯 | 唯讀 | max 20, unique, alphanumeric+hyphen |
+| manager_id | 部門主管 | combobox | 否 | 可選 | 可選 | role=manager |
+| parent_id | 上級部門 | select | 否 | 可選 | 可選 | valid dept, max 3 layers |
+
+## 範例程式碼
+
+```tsx
+"use client";
+
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Loader2 } from "lucide-react";
+import { departmentFormSchema, type DepartmentFormValues } from "@/lib/schemas";
+
+interface DepartmentFormProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  mode: "create" | "edit";
+  defaultValues?: Partial<DepartmentFormValues>;
+  departments: { id: string; name: string }[];  // 可選的上級部門
+  managers: { id: string; name: string }[];
+  onSubmit: (data: DepartmentFormValues) => Promise<void>;
+}
+
+export function DepartmentForm({
+  open,
+  onOpenChange,
+  mode,
+  defaultValues,
+  departments,
+  managers,
+  onSubmit,
+}: DepartmentFormProps) {
+  const form = useForm<DepartmentFormValues>({
+    resolver: zodResolver(departmentFormSchema),
+    defaultValues: defaultValues || {
+      name: "",
+      code: "",
+      manager_id: "",
+      parent_id: "",
+    },
+  });
+
+  const isSubmitting = form.formState.isSubmitting;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            {mode === "create" ? "新增部門" : "編輯部門"}
+          </DialogTitle>
+          <DialogDescription>填寫部門基本資料</DialogDescription>
+        </DialogHeader>
+
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>部門名稱 *</FormLabel>
+                  <FormControl>
+                    <Input placeholder="例：工程部" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="code"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>部門代碼 *</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder="例：ENG"
+                      className="font-mono uppercase"
+                      disabled={mode === "edit"}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormDescription>僅允許英數字和連字號</FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* 部門主管（Combobox） */}
+            <FormField
+              control={form.control}
+              name="manager_id"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>部門主管</FormLabel>
+                  <Select onValueChange={field.onChange} defaultValue={field.value}>
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder="請選擇主管（選填）" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="">不指定</SelectItem>
+                      {managers.map((m) => (
+                        <SelectItem key={m.id} value={m.id}>
+                          {m.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormDescription>選填，僅限 manager 角色</FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* 上級部門 */}
+            <FormField
+              control={form.control}
+              name="parent_id"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>上級部門</FormLabel>
+                  <Select onValueChange={field.onChange} defaultValue={field.value}>
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder="請選擇上級部門（選填）" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="">無上級部門</SelectItem>
+                      {departments.map((d) => (
+                        <SelectItem key={d.id} value={d.id}>
+                          {d.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormDescription>選填，部門最多 3 層</FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+                disabled={isSubmitting}
+              >
+                取消
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                {mode === "create" ? "新增" : "儲存"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+```
+
+## 錯誤處理
+
+| API 錯誤碼 | 前端行為 |
+|-----------|---------|
+| `DUPLICATE_NAME` | 表單 name 欄位顯示 "部門名稱已存在" |
+| `DUPLICATE_CODE` | 表單 code 欄位顯示 "部門代碼已存在" |
+| `INVALID_INPUT` | 對應欄位顯示錯誤 |
+
+## 互動行為
+
+- 編輯模式下 code 欄位唯讀（`disabled`）
+- 上級部門不可選擇自己或自己的子部門（避免循環）
+- 主管下拉只顯示 `role=manager` 的使用者

--- a/design/pages/department-list.md
+++ b/design/pages/department-list.md
@@ -1,0 +1,253 @@
+# 部門列表頁
+
+## 對應 Feature
+
+#7 F-008: 員工/部門管理
+
+## Layout
+
+```
+┌──────────────────────────────────────────────────┐
+│ Header: [≡] 部門管理              [Avatar ▼]     │
+├────────────┬─────────────────────────────────────┤
+│ Sidebar    │ Main Content                        │
+│            │                                     │
+│   Dashboard│ ┌── PageHeader ──────────────────┐  │
+│   打卡     │ │ 部門管理           [+ 新增部門] │  │
+│   打卡紀錄 │ │ 管理公司組織架構                │  │
+│   ─────    │ └────────────────────────────────┘  │
+│   員工管理 │                                     │
+│ > 部門管理 │ ┌── SearchFilter ────────────────┐  │
+│            │ │ [🔍 搜尋部門名稱或代碼...]      │  │
+│            │ └────────────────────────────────┘  │
+│            │                                     │
+│            │ ┌── Department Cards ─────────────┐ │
+│            │ │ ┌──────────┐  ┌──────────┐      │ │
+│            │ │ │ 工程部    │  │ 產品部    │      │ │
+│            │ │ │ ENG      │  │ PROD     │      │ │
+│            │ │ │ 主管:李華 │  │ 主管:張三 │      │ │
+│            │ │ │ 15 人    │  │ 8 人     │      │ │
+│            │ │ │ [編輯][刪]│  │ [編輯][刪]│      │ │
+│            │ │ └──────────┘  └──────────┘      │ │
+│            │ │                                  │ │
+│            │ │ ┌──────────┐  ┌──────────┐      │ │
+│            │ │ │ 前端組    │  │ 後端組    │      │ │
+│            │ │ │ ENG-FE   │  │ ENG-BE   │      │ │
+│            │ │ │ ↳ 工程部  │  │ ↳ 工程部  │      │ │
+│            │ │ │ 6 人     │  │ 9 人     │      │ │
+│            │ │ └──────────┘  └──────────┘      │ │
+│            │ └────────────────────────────────┘  │
+└────────────┴─────────────────────────────────────┘
+```
+
+## 頁面規格
+
+| 項目 | 說明 |
+|------|------|
+| 路由 | `/departments` |
+| 認證 | 需要（role: admin） |
+| Layout | `AppLayout` |
+| Breadcrumb | `[Dashboard, 部門管理]` |
+
+## 使用的元件
+
+| 元件 | 來源 | 用途 |
+|------|------|------|
+| AppLayout | `components/layout` | 頁面框架 |
+| PageHeader | `components/layout` | 頁面標題 + 新增按鈕 |
+| SearchFilter | `components/search-filter` | 搜尋 |
+| Card | shadcn/ui | 部門卡片 |
+| Button | shadcn/ui | 操作按鈕 |
+| ConfirmDialog | `components/confirm-dialog` | 刪除確認 |
+| EmptyState | `components/empty-state` | 無資料狀態 |
+| Toast | shadcn/ui | 操作回饋 |
+
+## 部門卡片規格
+
+```
+┌──────────────────────────────┐
+│ 工程部                  [⋯]  │
+│ ENG                          │
+│                              │
+│ 👤 主管：李大華              │
+│ ↳  上級：（無）              │
+│ 👥 成員：15 人               │
+│                              │
+│ 建立於 2024-03-01            │
+└──────────────────────────────┘
+```
+
+| 部位 | 樣式 |
+|------|------|
+| 容器 | `rounded-lg border bg-card p-5 hover:shadow-md transition-shadow` |
+| 部門名稱 | `text-lg font-semibold` |
+| 部門代碼 | `text-sm font-mono text-muted-foreground` |
+| 資訊行 | `text-sm text-muted-foreground`，icon + 文字 |
+| 操作選單 | 右上角 DropdownMenu（編輯、刪除） |
+
+## 範例程式碼
+
+```tsx
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Building2,
+  MoreHorizontal,
+  Pencil,
+  Trash2,
+  User,
+  Users,
+  GitBranch,
+} from "lucide-react";
+
+interface Department {
+  id: string;
+  name: string;
+  code: string;
+  manager: { id: string; name: string } | null;
+  parent: { id: string; name: string } | null;
+  member_count: number;
+  created_at: string;
+}
+
+function DepartmentCard({
+  department,
+  onEdit,
+  onDelete,
+}: {
+  department: Department;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  return (
+    <Card className="transition-shadow hover:shadow-md">
+      <CardHeader className="flex flex-row items-start justify-between pb-3">
+        <div>
+          <h3 className="text-lg font-semibold">{department.name}</h3>
+          <p className="font-mono text-sm text-muted-foreground">
+            {department.code}
+          </p>
+        </div>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="icon" className="h-8 w-8">
+              <MoreHorizontal className="h-4 w-4" />
+              <span className="sr-only">操作選單</span>
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onClick={onEdit}>
+              <Pencil className="mr-2 h-4 w-4" />
+              編輯
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={onDelete} className="text-destructive">
+              <Trash2 className="mr-2 h-4 w-4" />
+              刪除
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </CardHeader>
+      <CardContent className="space-y-2 text-sm">
+        <div className="flex items-center gap-2 text-muted-foreground">
+          <User className="h-4 w-4" />
+          <span>主管：{department.manager?.name || "未指定"}</span>
+        </div>
+        {department.parent && (
+          <div className="flex items-center gap-2 text-muted-foreground">
+            <GitBranch className="h-4 w-4" />
+            <span>上級：{department.parent.name}</span>
+          </div>
+        )}
+        <div className="flex items-center gap-2 text-muted-foreground">
+          <Users className="h-4 w-4" />
+          <span>成員：{department.member_count} 人</span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// 頁面
+export default function DepartmentListPage() {
+  return (
+    <AppLayout breadcrumbs={[{ label: "Dashboard", href: "/" }, { label: "部門管理" }]}>
+      <PageHeader
+        title="部門管理"
+        description="管理公司組織架構"
+        actions={
+          <Button onClick={() => setShowForm(true)}>
+            <Plus className="mr-2 h-4 w-4" />
+            新增部門
+          </Button>
+        }
+      />
+
+      <SearchFilter
+        searchValue={search}
+        onSearchChange={setSearch}
+        searchPlaceholder="搜尋部門名稱或代碼..."
+        onReset={() => setSearch("")}
+      />
+
+      <div className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {departments.map((dept) => (
+          <DepartmentCard
+            key={dept.id}
+            department={dept}
+            onEdit={() => handleEdit(dept)}
+            onDelete={() => handleDelete(dept)}
+          />
+        ))}
+      </div>
+
+      {departments.length === 0 && (
+        <EmptyState
+          icon={Building2}
+          title="尚無部門"
+          description="建立部門來組織您的團隊結構"
+          action={
+            <Button onClick={() => setShowForm(true)}>
+              <Plus className="mr-2 h-4 w-4" />
+              新增部門
+            </Button>
+          }
+        />
+      )}
+    </AppLayout>
+  );
+}
+```
+
+## 互動行為
+
+### 搜尋
+
+- 模糊搜尋部門名稱和代碼
+- 即時過濾（client-side，資料量小）
+
+### 新增部門
+
+1. 點擊「新增部門」
+2. 開啟 Dialog（見 `department-form.md`）
+3. 成功後刷新列表
+
+### 刪除部門
+
+1. 點擊操作選單「刪除」
+2. ConfirmDialog: "確定要刪除「{name}」嗎？"
+3. API: `DELETE /api/v1/departments/:id`
+4. 如果有員工（`HAS_MEMBERS`），Toast 提示 "部門仍有員工，無法刪除"
+
+## 響應式行為
+
+| 斷點 | Grid |
+|------|------|
+| >= 1024px (lg) | 3 欄 |
+| 640-1023px (sm-lg) | 2 欄 |
+| < 640px | 1 欄 |

--- a/design/pages/employee-form.md
+++ b/design/pages/employee-form.md
@@ -1,0 +1,341 @@
+# 員工新增/編輯表單
+
+## 對應 Feature
+
+#7 F-008: 員工/部門管理
+
+## Layout
+
+使用 Dialog（非獨立頁面），從員工列表頁觸發。
+
+```
+┌─────────────── Dialog ──────────────────┐
+│ [X]                                     │
+│ 新增員工 / 編輯員工                       │
+│ 填寫員工基本資料                          │
+│                                         │
+│ ┌─ Grid (2 cols) ────────────────────┐  │
+│ │ 員工編號 *         Email *          │  │
+│ │ [EMP___]          [___@company.com] │  │
+│ │                                    │  │
+│ │ 姓名 *             角色 *           │  │
+│ │ [___________]     [員工 ▼]          │  │
+│ │                                    │  │
+│ │ 部門 *             直屬主管          │  │
+│ │ [請選擇部門 ▼]    [搜尋主管... ▼]   │  │
+│ │                                    │  │
+│ │ 到職日 *           密碼 * (新增才有) │  │
+│ │ [📅 選擇日期]     [_________ 👁]    │  │
+│ └────────────────────────────────────┘  │
+│                                         │
+│                    [取消]  [儲存]        │
+└─────────────────────────────────────────┘
+```
+
+## 頁面規格
+
+| 項目 | 說明 |
+|------|------|
+| 觸發方式 | 員工列表的「新增員工」按鈕 / 行操作「編輯」 |
+| 容器 | `Dialog`，`max-w-2xl`（672px） |
+| 認證 | 需要（role: admin） |
+
+## 使用的元件
+
+| 元件 | 來源 | 用途 |
+|------|------|------|
+| Dialog | shadcn/ui | 容器 |
+| Form | react-hook-form + zod | 表單驗證 |
+| Input | shadcn/ui | 文字欄位 |
+| Select | shadcn/ui | 角色、部門下拉 |
+| Combobox | shadcn/ui (Popover + Command) | 主管選擇 |
+| Calendar | shadcn/ui | 到職日選擇 |
+| PasswordInput | `components/form-field` | 密碼欄位 |
+| Button | shadcn/ui | 送出/取消 |
+
+## 表單欄位
+
+| 欄位 | Label | Type | 必填 | 新增 | 編輯 | 驗證 |
+|------|-------|------|------|------|------|------|
+| employee_id | 員工編號 | text | 是 | 可編輯 | 唯讀 | max 20, unique |
+| email | Email | email | 是 | 可編輯 | 可編輯 | valid email, unique |
+| name | 姓名 | text | 是 | 可編輯 | 可編輯 | max 100 |
+| role | 角色 | select | 是 | 可選 | 可選 | enum |
+| department_id | 部門 | select | 是 | 可選 | 可選 | valid uuid |
+| manager_id | 直屬主管 | combobox | 否 | 可選 | 可選 | role=manager |
+| hire_date | 到職日 | date | 是 | 可選 | 可選 | valid date |
+| password | 密碼 | password | 是(新增) | 可編輯 | 不顯示 | min 8 |
+
+## 互動行為
+
+### 新增模式
+
+1. 開啟 Dialog，所有欄位為空
+2. Title: "新增員工"
+3. 送出：`POST /api/v1/employees`
+4. 成功：關閉 Dialog + Toast "新增成功" + 刷新列表
+5. 失敗：根據錯誤碼顯示（DUPLICATE_EMPLOYEE_ID / DUPLICATE_EMAIL 等）
+
+### 編輯模式
+
+1. 開啟 Dialog，預填現有資料
+2. Title: "編輯員工"
+3. employee_id 欄位設為 `disabled`（唯讀）
+4. 不顯示密碼欄位
+5. 送出：`PUT /api/v1/employees/:id`
+6. 成功：關閉 Dialog + Toast "更新成功" + 刷新列表
+
+### 角色與主管連動
+
+- 選擇角色為 `manager` 或 `admin` 時，主管欄位可以為空
+- 主管下拉只顯示 `role=manager` 的使用者
+- 切換部門時，主管欄位重置（因為主管通常在同部門）
+
+## 範例程式碼
+
+```tsx
+"use client";
+
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Loader2 } from "lucide-react";
+import { employeeFormSchema, type EmployeeFormValues } from "@/lib/schemas";
+
+interface EmployeeFormProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  mode: "create" | "edit";
+  defaultValues?: Partial<EmployeeFormValues>;
+  departments: { id: string; name: string }[];
+  managers: { id: string; name: string; department: string }[];
+  onSubmit: (data: EmployeeFormValues) => Promise<void>;
+}
+
+export function EmployeeForm({
+  open,
+  onOpenChange,
+  mode,
+  defaultValues,
+  departments,
+  managers,
+  onSubmit,
+}: EmployeeFormProps) {
+  const form = useForm<EmployeeFormValues>({
+    resolver: zodResolver(employeeFormSchema),
+    defaultValues: defaultValues || {
+      employee_id: "",
+      email: "",
+      name: "",
+      role: "employee",
+      department_id: "",
+      manager_id: "",
+      hire_date: undefined,
+      password: "",
+    },
+  });
+
+  const isSubmitting = form.formState.isSubmitting;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>
+            {mode === "create" ? "新增員工" : "編輯員工"}
+          </DialogTitle>
+          <DialogDescription>
+            填寫員工基本資料
+          </DialogDescription>
+        </DialogHeader>
+
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <div className="grid gap-4 sm:grid-cols-2">
+              {/* 員工編號 */}
+              <FormField
+                control={form.control}
+                name="employee_id"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>員工編號 *</FormLabel>
+                    <FormControl>
+                      <Input
+                        placeholder="EMP001"
+                        disabled={mode === "edit"}
+                        className="font-mono"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              {/* Email */}
+              <FormField
+                control={form.control}
+                name="email"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Email *</FormLabel>
+                    <FormControl>
+                      <Input type="email" placeholder="user@company.com" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              {/* 姓名 */}
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>姓名 *</FormLabel>
+                    <FormControl>
+                      <Input placeholder="請輸入姓名" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              {/* 角色 */}
+              <FormField
+                control={form.control}
+                name="role"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>角色 *</FormLabel>
+                    <Select onValueChange={field.onChange} defaultValue={field.value}>
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder="請選擇角色" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        <SelectItem value="employee">員工</SelectItem>
+                        <SelectItem value="manager">主管</SelectItem>
+                        <SelectItem value="admin">管理員</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              {/* 部門 */}
+              <FormField
+                control={form.control}
+                name="department_id"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>部門 *</FormLabel>
+                    <Select onValueChange={field.onChange} defaultValue={field.value}>
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder="請選擇部門" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {departments.map((dept) => (
+                          <SelectItem key={dept.id} value={dept.id}>
+                            {dept.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              {/* 直屬主管（Combobox — 見 form-field.md） */}
+              {/* ... Combobox 元件 ... */}
+
+              {/* 到職日（DatePicker — 見 form-field.md） */}
+              {/* ... DatePicker 元件 ... */}
+
+              {/* 密碼（僅新增模式） */}
+              {mode === "create" && (
+                <FormField
+                  control={form.control}
+                  name="password"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>初始密碼 *</FormLabel>
+                      <FormControl>
+                        <Input type="password" placeholder="至少 8 個字元" {...field} />
+                      </FormControl>
+                      <FormDescription>員工登入後可自行變更</FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              )}
+            </div>
+
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+                disabled={isSubmitting}
+              >
+                取消
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                {mode === "create" ? "新增" : "儲存"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+```
+
+## 錯誤處理
+
+| API 錯誤碼 | 前端行為 |
+|-----------|---------|
+| `DUPLICATE_EMPLOYEE_ID` | 表單 employee_id 欄位顯示 "員工編號已存在" |
+| `DUPLICATE_EMAIL` | 表單 email 欄位顯示 "Email 已存在" |
+| `DEPARTMENT_NOT_FOUND` | Toast "所選部門不存在" |
+| `INVALID_INPUT` | 對應欄位顯示錯誤（由 zod 前端攔截） |
+
+## 響應式行為
+
+| 斷點 | Grid | Dialog 寬度 |
+|------|------|------------|
+| >= 640px (sm) | 2 欄 | 672px |
+| < 640px | 1 欄 | full width |

--- a/design/pages/employee-list.md
+++ b/design/pages/employee-list.md
@@ -1,0 +1,121 @@
+# 員工列表頁
+
+## 對應 Feature
+
+#7 F-008: 員工/部門管理
+
+## Layout
+
+```
+┌──────────────────────────────────────────────────┐
+│ Header: [≡] 員工管理              [Avatar ▼]     │
+├────────────┬─────────────────────────────────────┤
+│ Sidebar    │ Main Content                        │
+│            │                                     │
+│   Dashboard│ ┌── PageHeader ──────────────────┐  │
+│   打卡     │ │ 員工管理           [+ 新增員工] │  │
+│   打卡紀錄 │ │ 管理公司員工帳號與資料          │  │
+│   ─────    │ └────────────────────────────────┘  │
+│ > 員工管理 │                                     │
+│   部門管理 │ ┌── SearchFilter ────────────────┐  │
+│            │ │ [🔍 搜尋...] [部門▼] [角色▼]   │  │
+│            │ │              [狀態▼] [重置]     │  │
+│            │ └────────────────────────────────┘  │
+│            │                                     │
+│            │ ┌── DataTable ───────────────────┐  │
+│            │ │ 編號  姓名  Email  部門  角色   │  │
+│            │ │ 狀態  到職日  操作              │  │
+│            │ │ ──────────────────────────────  │  │
+│            │ │ EMP001 王小明 ...  工程部 員工  │  │
+│            │ │ EMP002 李大華 ...  工程部 主管  │  │
+│            │ │ ...                             │  │
+│            │ ├────────────────────────────────┤  │
+│            │ │ 共 50 筆  [20筆/頁▼] [< 1/3 >] │  │
+│            │ └────────────────────────────────┘  │
+└────────────┴─────────────────────────────────────┘
+```
+
+## 頁面規格
+
+| 項目 | 說明 |
+|------|------|
+| 路由 | `/employees` |
+| 認證 | 需要（role: admin） |
+| Layout | `AppLayout` |
+| Breadcrumb | `[Dashboard, 員工管理]` |
+
+## 使用的元件
+
+| 元件 | 來源 | 用途 |
+|------|------|------|
+| AppLayout | `components/layout` | 頁面框架 |
+| PageHeader | `components/layout` | 頁面標題 + 新增按鈕 |
+| SearchFilter | `components/search-filter` | 搜尋 + 篩選 |
+| DataTable | `components/data-table` | 員工表格 |
+| StatusBadge | `components/status-badge` | 角色/狀態標籤 |
+| ConfirmDialog | `components/confirm-dialog` | 停用確認 |
+| EmptyState | `components/empty-state` | 無資料狀態 |
+| Toast | shadcn/ui | 操作回饋 |
+
+## 表格欄位
+
+| 欄位 | Header | 寬度 | 可排序 | 說明 |
+|------|--------|------|--------|------|
+| employee_id | 員工編號 | 100px | - | `font-mono text-sm` |
+| name | 姓名 | auto | 可排序 | 預設排序欄位 |
+| email | Email | auto | - | `text-muted-foreground` |
+| department.name | 部門 | 120px | - | 可篩選 |
+| role | 角色 | 80px | - | StatusBadge(type="role") |
+| status | 狀態 | 80px | - | StatusBadge(type="account") |
+| hire_date | 到職日 | 120px | 可排序 | yyyy-MM-dd 格式 |
+| actions | 操作 | 60px | - | DropdownMenu |
+
+## 篩選器
+
+| 篩選 | Key | 選項 |
+|------|-----|------|
+| 部門 | `department_id` | 動態載入部門列表 |
+| 角色 | `role` | employee / manager / admin |
+| 狀態 | `status` | active / inactive / suspended |
+
+## 互動行為
+
+### 搜尋
+
+- 模糊搜尋姓名、員工編號、Email
+- Debounce 300ms，避免頻繁 API 呼叫
+- 搜尋時呼叫 `GET /api/v1/employees?search=...`
+
+### 新增員工
+
+1. 點擊「新增員工」按鈕
+2. 開啟員工表單 Dialog（見 `employee-form.md`）
+3. 送出成功後刷新列表 + Toast "新增成功"
+
+### 行操作（DropdownMenu）
+
+| 操作 | Icon | 說明 |
+|------|------|------|
+| 編輯 | `Pencil` | 開啟員工表單 Dialog（預填資料） |
+| 重設密碼 | `KeyRound` | ConfirmDialog -> 重設密碼 API |
+| 停用帳號 | `UserX` | ConfirmDialog(destructive) -> 更新 status |
+
+### 分頁
+
+- 預設每頁 20 筆
+- 可選 10 / 20 / 50 筆
+- Server-side 分頁（API 回傳 meta.total, meta.totalPages）
+
+## 響應式行為
+
+| 斷點 | 變化 |
+|------|------|
+| >= 1024px (lg) | 完整表格，所有欄位可見 |
+| 768-1023px (md) | 隱藏 email 欄位 |
+| < 768px (sm) | 隱藏 email + hire_date，篩選器堆疊 |
+
+## API 呼叫
+
+```
+GET /api/v1/employees?search={search}&department_id={dept}&role={role}&status={status}&page={page}&limit={limit}
+```

--- a/design/pages/login.md
+++ b/design/pages/login.md
@@ -1,0 +1,259 @@
+# 登入頁
+
+## 對應 Feature
+
+#6 F-000: 認證系統
+
+## Layout
+
+```
+┌──────────────────────────────────────────────────┐
+│                                                  │
+│                                                  │
+│              ┌──────────────────┐                │
+│              │  [Clock Icon]    │                │
+│              │  HR 工時管理系統  │                │
+│              │                  │                │
+│              │  ┌────────────┐  │                │
+│              │  │ Email      │  │                │
+│              │  └────────────┘  │                │
+│              │  ┌────────────┐  │                │
+│              │  │ Password 👁│  │                │
+│              │  └────────────┘  │                │
+│              │                  │                │
+│              │  [    登入    ]  │                │
+│              │                  │                │
+│              │  ⚠ 錯誤訊息     │                │
+│              └──────────────────┘                │
+│                                                  │
+└──────────────────────────────────────────────────┘
+```
+
+不使用 AppLayout。登入頁為獨立的全頁面。
+
+## 頁面規格
+
+| 項目 | 說明 |
+|------|------|
+| 路由 | `/login` |
+| 認證 | 不需要（公開頁面） |
+| 背景 | `bg-muted`，整頁高度 `min-h-screen` |
+| 卡片 | 置中，`max-w-sm`（400px），白色背景，`shadow-md rounded-xl p-8` |
+| Logo 區域 | Clock icon + 系統名稱，置中，`mb-8` |
+
+## 使用的元件
+
+| 元件 | 來源 | 說明 |
+|------|------|------|
+| Card | shadcn/ui | 登入卡片容器 |
+| Input | shadcn/ui | Email 輸入框 |
+| PasswordInput | `components/form-field` | 密碼輸入框（含顯示/隱藏） |
+| Button | shadcn/ui | 登入按鈕 |
+| Form | react-hook-form + zod | 表單驗證 |
+| Toast | shadcn/ui | 錯誤提示 |
+
+## 互動行為
+
+### 登入流程
+
+1. 使用者輸入 email + password
+2. 點擊「登入」或按 Enter 送出
+3. 按鈕進入 loading 狀態（顯示 spinner + "登入中..."）
+4. 成功：導向 `/`（Dashboard）
+5. 失敗：根據錯誤碼顯示對應訊息
+
+### 錯誤處理
+
+| API 錯誤碼 | 前端顯示 |
+|-----------|---------|
+| `INVALID_INPUT` | 表單欄位驗證（即時，不打 API） |
+| `INVALID_CREDENTIALS` | 在表單下方顯示 "Email 或密碼不正確" |
+| `ACCOUNT_SUSPENDED` | 在表單下方顯示 "帳號已停用，請聯繫管理員" |
+| `ACCOUNT_LOCKED` | 在表單下方顯示 "帳號已鎖定，請 15 分鐘後再試" |
+| 網路錯誤 | Toast 顯示 "無法連線到伺服器" |
+
+### 表單驗證
+
+| 欄位 | 即時驗證 | blur 驗證 |
+|------|---------|----------|
+| Email | - | 格式檢查 |
+| Password | - | 不為空 |
+
+## 範例程式碼
+
+```tsx
+"use client";
+
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Clock, Loader2, Eye, EyeOff, AlertCircle } from "lucide-react";
+
+const loginSchema = z.object({
+  email: z.string().min(1, "請輸入 Email").email("Email 格式不正確"),
+  password: z.string().min(1, "請輸入密碼"),
+});
+
+type LoginValues = z.infer<typeof loginSchema>;
+
+export default function LoginPage() {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [showPassword, setShowPassword] = useState(false);
+
+  const form = useForm<LoginValues>({
+    resolver: zodResolver(loginSchema),
+    defaultValues: { email: "", password: "" },
+  });
+
+  async function onSubmit(data: LoginValues) {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/v1/auth/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+      });
+      if (!res.ok) {
+        const body = await res.json();
+        const messages: Record<string, string> = {
+          INVALID_CREDENTIALS: "Email 或密碼不正確",
+          ACCOUNT_SUSPENDED: "帳號已停用，請聯繫管理員",
+          ACCOUNT_LOCKED: "帳號已鎖定，請 15 分鐘後再試",
+        };
+        setError(messages[body.code] || "登入失敗，請稍後再試");
+        return;
+      }
+      // 儲存 token，導向 Dashboard
+      const { access_token, refresh_token } = await res.json();
+      // ... store tokens and redirect
+    } catch {
+      setError("無法連線到伺服器，請檢查網路連線");
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-muted p-4">
+      <Card className="w-full max-w-sm shadow-md">
+        <CardHeader className="text-center">
+          <div className="mx-auto mb-2 flex h-12 w-12 items-center justify-center rounded-xl bg-primary">
+            <Clock className="h-6 w-6 text-primary-foreground" />
+          </div>
+          <h1 className="text-2xl font-bold">HR 工時管理系統</h1>
+          <p className="text-sm text-muted-foreground">請登入您的帳號</p>
+        </CardHeader>
+        <CardContent>
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+              {error && (
+                <Alert variant="destructive">
+                  <AlertCircle className="h-4 w-4" />
+                  <AlertDescription>{error}</AlertDescription>
+                </Alert>
+              )}
+
+              <FormField
+                control={form.control}
+                name="email"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Email</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="email"
+                        placeholder="your@company.com"
+                        autoComplete="email"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="password"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>密碼</FormLabel>
+                    <FormControl>
+                      <div className="relative">
+                        <Input
+                          type={showPassword ? "text" : "password"}
+                          placeholder="請輸入密碼"
+                          autoComplete="current-password"
+                          {...field}
+                        />
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          className="absolute right-0 top-0 h-full px-3 hover:bg-transparent"
+                          onClick={() => setShowPassword(!showPassword)}
+                          tabIndex={-1}
+                          aria-label={showPassword ? "隱藏密碼" : "顯示密碼"}
+                        >
+                          {showPassword ? (
+                            <EyeOff className="h-4 w-4 text-muted-foreground" />
+                          ) : (
+                            <Eye className="h-4 w-4 text-muted-foreground" />
+                          )}
+                        </Button>
+                      </div>
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <Button type="submit" className="w-full" disabled={isLoading}>
+                {isLoading ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    登入中...
+                  </>
+                ) : (
+                  "登入"
+                )}
+              </Button>
+            </form>
+          </Form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+```
+
+## 響應式行為
+
+| 斷點 | 變化 |
+|------|------|
+| >= 640px | 卡片 400px 置中 |
+| < 640px | 卡片 full width，左右 padding 16px |
+
+## Accessibility
+
+- 表單使用語意化 `<form>` + label 關聯
+- Email 欄位有 `autoComplete="email"`
+- Password 欄位有 `autoComplete="current-password"`
+- 錯誤訊息使用 `Alert` + `role="alert"`
+- Enter 鍵送出表單
+- Tab 順序：Email -> Password -> 顯示/隱藏 -> 登入按鈕

--- a/design/tokens/colors.css
+++ b/design/tokens/colors.css
@@ -1,0 +1,220 @@
+/*
+ * Design Tokens - Color System
+ * HR 工時管理系統 (shadcn/ui + Tailwind CSS)
+ *
+ * 使用 HSL 格式，與 shadcn/ui 預設一致。
+ * 在 Tailwind CSS 4 中透過 @theme inline 註冊為 utility。
+ * 支援 Light / Dark 兩種主題。
+ */
+
+@layer base {
+  :root {
+    /* ========================================
+     * Primitive Colors（原始色票）
+     * 這些是基礎色值，不直接用於元件。
+     * ======================================== */
+
+    /* --- Blue (Primary) --- */
+    --blue-50: 214 100% 97%;
+    --blue-100: 214 95% 93%;
+    --blue-200: 213 97% 87%;
+    --blue-300: 212 96% 78%;
+    --blue-400: 213 94% 68%;
+    --blue-500: 217 91% 60%;
+    --blue-600: 221 83% 53%;
+    --blue-700: 224 76% 48%;
+    --blue-800: 226 71% 40%;
+    --blue-900: 224 64% 33%;
+
+    /* --- Green (Success) --- */
+    --green-50: 138 76% 97%;
+    --green-100: 141 84% 93%;
+    --green-500: 142 71% 45%;
+    --green-600: 142 76% 36%;
+    --green-700: 142 72% 29%;
+
+    /* --- Amber (Warning) --- */
+    --amber-50: 48 100% 96%;
+    --amber-100: 48 96% 89%;
+    --amber-500: 38 92% 50%;
+    --amber-600: 32 95% 44%;
+    --amber-700: 26 90% 37%;
+
+    /* --- Red (Destructive / Error) --- */
+    --red-50: 0 86% 97%;
+    --red-100: 0 93% 94%;
+    --red-500: 0 84% 60%;
+    --red-600: 0 72% 51%;
+    --red-700: 0 74% 42%;
+
+    /* --- Neutral (Gray) --- */
+    --neutral-50: 0 0% 98%;
+    --neutral-100: 0 0% 96%;
+    --neutral-200: 0 0% 90%;
+    --neutral-300: 0 0% 83%;
+    --neutral-400: 0 0% 64%;
+    --neutral-500: 0 0% 45%;
+    --neutral-600: 0 0% 32%;
+    --neutral-700: 0 0% 25%;
+    --neutral-800: 0 0% 15%;
+    --neutral-900: 0 0% 9%;
+    --neutral-950: 0 0% 4%;
+
+    /* ========================================
+     * Semantic Tokens（語意色票）
+     * 元件直接引用這些 token。
+     * ======================================== */
+
+    /* --- Background --- */
+    --background: 0 0% 100%;
+    --foreground: 0 0% 4%;
+
+    /* --- Card --- */
+    --card: 0 0% 100%;
+    --card-foreground: 0 0% 4%;
+
+    /* --- Popover --- */
+    --popover: 0 0% 100%;
+    --popover-foreground: 0 0% 4%;
+
+    /* --- Primary --- */
+    --primary: 221 83% 53%;
+    --primary-foreground: 0 0% 100%;
+
+    /* --- Secondary --- */
+    --secondary: 0 0% 96%;
+    --secondary-foreground: 0 0% 9%;
+
+    /* --- Muted --- */
+    --muted: 0 0% 96%;
+    --muted-foreground: 0 0% 45%;
+
+    /* --- Accent --- */
+    --accent: 0 0% 96%;
+    --accent-foreground: 0 0% 9%;
+
+    /* --- Destructive --- */
+    --destructive: 0 84% 60%;
+    --destructive-foreground: 0 0% 100%;
+
+    /* --- Success（自訂，shadcn/ui 預設無此 token） --- */
+    --success: 142 71% 45%;
+    --success-foreground: 0 0% 100%;
+
+    /* --- Warning（自訂） --- */
+    --warning: 38 92% 50%;
+    --warning-foreground: 0 0% 9%;
+
+    /* --- Border / Input / Ring --- */
+    --border: 0 0% 90%;
+    --input: 0 0% 90%;
+    --ring: 221 83% 53%;
+
+    /* --- Chart（圖表用色） --- */
+    --chart-1: 217 91% 60%;
+    --chart-2: 142 71% 45%;
+    --chart-3: 38 92% 50%;
+    --chart-4: 0 84% 60%;
+    --chart-5: 262 83% 58%;
+
+    /* --- Sidebar --- */
+    --sidebar-background: 0 0% 98%;
+    --sidebar-foreground: 0 0% 25%;
+    --sidebar-primary: 221 83% 53%;
+    --sidebar-primary-foreground: 0 0% 100%;
+    --sidebar-accent: 0 0% 96%;
+    --sidebar-accent-foreground: 0 0% 9%;
+    --sidebar-border: 0 0% 90%;
+    --sidebar-ring: 221 83% 53%;
+
+    /* --- Radius --- */
+    --radius: 0.5rem;
+  }
+
+  .dark {
+    /* --- Background --- */
+    --background: 0 0% 4%;
+    --foreground: 0 0% 98%;
+
+    /* --- Card --- */
+    --card: 0 0% 4%;
+    --card-foreground: 0 0% 98%;
+
+    /* --- Popover --- */
+    --popover: 0 0% 4%;
+    --popover-foreground: 0 0% 98%;
+
+    /* --- Primary --- */
+    --primary: 217 91% 60%;
+    --primary-foreground: 0 0% 4%;
+
+    /* --- Secondary --- */
+    --secondary: 0 0% 15%;
+    --secondary-foreground: 0 0% 98%;
+
+    /* --- Muted --- */
+    --muted: 0 0% 15%;
+    --muted-foreground: 0 0% 64%;
+
+    /* --- Accent --- */
+    --accent: 0 0% 15%;
+    --accent-foreground: 0 0% 98%;
+
+    /* --- Destructive --- */
+    --destructive: 0 63% 31%;
+    --destructive-foreground: 0 0% 98%;
+
+    /* --- Success --- */
+    --success: 142 76% 36%;
+    --success-foreground: 0 0% 98%;
+
+    /* --- Warning --- */
+    --warning: 32 95% 44%;
+    --warning-foreground: 0 0% 98%;
+
+    /* --- Border / Input / Ring --- */
+    --border: 0 0% 15%;
+    --input: 0 0% 15%;
+    --ring: 217 91% 60%;
+
+    /* --- Chart --- */
+    --chart-1: 213 94% 68%;
+    --chart-2: 141 84% 93%;
+    --chart-3: 48 96% 89%;
+    --chart-4: 0 93% 94%;
+    --chart-5: 262 83% 58%;
+
+    /* --- Sidebar --- */
+    --sidebar-background: 0 0% 7%;
+    --sidebar-foreground: 0 0% 83%;
+    --sidebar-primary: 217 91% 60%;
+    --sidebar-primary-foreground: 0 0% 4%;
+    --sidebar-accent: 0 0% 15%;
+    --sidebar-accent-foreground: 0 0% 98%;
+    --sidebar-border: 0 0% 15%;
+    --sidebar-ring: 217 91% 60%;
+  }
+}
+
+/*
+ * 狀態專用色（出勤系統）
+ * 這些 token 供 StatusBadge 等元件使用。
+ */
+:root {
+  /* 出勤狀態 */
+  --status-normal: 142 71% 45%;        /* 綠 — 正常 */
+  --status-late: 38 92% 50%;           /* 橙 — 遲到 */
+  --status-early-leave: 32 95% 44%;    /* 深橙 — 早退 */
+  --status-absent: 0 84% 60%;          /* 紅 — 缺席 */
+  --status-amended: 217 91% 60%;       /* 藍 — 已補打卡 */
+
+  /* 帳號狀態 */
+  --status-active: 142 71% 45%;        /* 綠 — 啟用 */
+  --status-inactive: 0 0% 45%;         /* 灰 — 停用 */
+  --status-suspended: 0 84% 60%;       /* 紅 — 凍結 */
+
+  /* 角色標籤 */
+  --role-admin: 262 83% 58%;           /* 紫 — Admin */
+  --role-manager: 217 91% 60%;         /* 藍 — 主管 */
+  --role-employee: 0 0% 45%;           /* 灰 — 員工 */
+}

--- a/design/tokens/spacing.css
+++ b/design/tokens/spacing.css
@@ -1,0 +1,115 @@
+/*
+ * Design Tokens - Spacing System
+ * HR 工時管理系統 (shadcn/ui + Tailwind CSS)
+ *
+ * 間距系統基於 4px grid（0.25rem）。
+ * 搭配 Tailwind CSS 的 p-*, m-*, gap-* utility 使用。
+ */
+
+@layer base {
+  :root {
+    /* ========================================
+     * Spacing Scale
+     * Tailwind 預設，列出供參考。
+     * 元件文件中以 spacing-{n} 標記。
+     * ======================================== */
+
+    /*  spacing-0:   0        (0px)   */
+    /*  spacing-0.5: 0.125rem (2px)   */
+    /*  spacing-1:   0.25rem  (4px)   */
+    /*  spacing-1.5: 0.375rem (6px)   */
+    /*  spacing-2:   0.5rem   (8px)   */
+    /*  spacing-2.5: 0.625rem (10px)  */
+    /*  spacing-3:   0.75rem  (12px)  */
+    /*  spacing-3.5: 0.875rem (14px)  */
+    /*  spacing-4:   1rem     (16px)  */
+    /*  spacing-5:   1.25rem  (20px)  */
+    /*  spacing-6:   1.5rem   (24px)  */
+    /*  spacing-8:   2rem     (32px)  */
+    /*  spacing-10:  2.5rem   (40px)  */
+    /*  spacing-12:  3rem     (48px)  */
+    /*  spacing-16:  4rem     (64px)  */
+    /*  spacing-20:  5rem     (80px)  */
+    /*  spacing-24:  6rem     (96px)  */
+
+    /* ========================================
+     * Layout Dimensions
+     * 固定的 layout 尺寸 token。
+     * ======================================== */
+
+    /* --- Sidebar --- */
+    --sidebar-width: 16rem;          /* 256px — 展開 */
+    --sidebar-width-collapsed: 4rem; /* 64px — 收合（icon only） */
+
+    /* --- Header --- */
+    --header-height: 4rem;           /* 64px */
+
+    /* --- Content --- */
+    --content-max-width: 80rem;      /* 1280px */
+    --content-padding: 1.5rem;       /* 24px */
+    --content-padding-mobile: 1rem;  /* 16px */
+
+    /* --- Page --- */
+    --page-padding-x: 1.5rem;        /* 24px */
+    --page-padding-y: 1.5rem;        /* 24px */
+
+    /* ========================================
+     * Border Radius
+     * shadcn/ui 使用 --radius 作為基準，
+     * 其他 radius 依此推導。
+     * ======================================== */
+
+    /* --radius: 0.5rem;  (定義於 colors.css) */
+    /* 推導規則：
+     *   radius-sm:  calc(var(--radius) - 4px)  = 0.25rem
+     *   radius-md:  calc(var(--radius) - 2px)  = 0.375rem
+     *   radius-lg:  var(--radius)              = 0.5rem
+     *   radius-xl:  calc(var(--radius) + 4px)  = 0.75rem
+     *   radius-2xl: calc(var(--radius) + 8px)  = 1rem
+     *   radius-full: 9999px
+     */
+
+    /* ========================================
+     * Shadow
+     * 搭配 Tailwind 的 shadow-* utility。
+     * ======================================== */
+
+    /*  shadow-sm:  0 1px 2px 0 rgb(0 0 0 / 0.05)                                  */
+    /*  shadow:     0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1)  */
+    /*  shadow-md:  0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1) */
+    /*  shadow-lg:  0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1) */
+
+    /* ========================================
+     * Z-Index Scale
+     * 統一管理堆疊順序。
+     * ======================================== */
+    --z-dropdown: 50;
+    --z-sticky: 40;
+    --z-fixed: 30;
+    --z-overlay: 60;
+    --z-modal: 70;
+    --z-popover: 80;
+    --z-toast: 90;
+
+    /* ========================================
+     * Breakpoints（參考用）
+     * Tailwind 預設斷點，不需額外定義。
+     * ======================================== */
+
+    /*  sm:  640px   — 小螢幕手機橫向   */
+    /*  md:  768px   — 平板直向         */
+    /*  lg:  1024px  — 平板橫向/小筆電  */
+    /*  xl:  1280px  — 桌面             */
+    /*  2xl: 1536px  — 大桌面           */
+
+    /* ========================================
+     * Animation / Transition
+     * ======================================== */
+    --duration-fast: 150ms;
+    --duration-normal: 200ms;
+    --duration-slow: 300ms;
+    --easing-default: cubic-bezier(0.4, 0, 0.2, 1);
+    --easing-in: cubic-bezier(0.4, 0, 1, 1);
+    --easing-out: cubic-bezier(0, 0, 0.2, 1);
+  }
+}

--- a/design/tokens/tokens.md
+++ b/design/tokens/tokens.md
@@ -1,0 +1,159 @@
+# Design Tokens 總覽
+
+本文件彙整 HR 工時管理系統的所有 design tokens，供 engineer 快速查閱。
+
+## 技術基礎
+
+- **UI 元件庫**: shadcn/ui (copy-paste 模式)
+- **CSS 框架**: Tailwind CSS 4
+- **色彩格式**: HSL（與 shadcn/ui 預設一致）
+- **主題切換**: CSS Variables（`:root` / `.dark`）
+
+## 檔案結構
+
+| 檔案 | 內容 |
+|------|------|
+| `colors.css` | 原始色票 + 語意色票 + 狀態色票 |
+| `typography.css` | 字型、字級、字重、行高 |
+| `spacing.css` | 間距、Layout 尺寸、圓角、陰影、z-index、動畫 |
+
+## 色彩系統
+
+### 語意色（Semantic Colors）
+
+元件中使用 Tailwind utility 引用，例如 `bg-primary`、`text-destructive`。
+
+| Token | 用途 | Light | Tailwind Class |
+|-------|------|-------|---------------|
+| `--primary` | 主要操作 | Blue-600 | `bg-primary text-primary-foreground` |
+| `--secondary` | 次要操作 | Neutral-100 | `bg-secondary text-secondary-foreground` |
+| `--destructive` | 破壞性操作 | Red-500 | `bg-destructive text-destructive-foreground` |
+| `--success` | 成功狀態 | Green-500 | 自訂 `bg-[hsl(var(--success))]` |
+| `--warning` | 警告狀態 | Amber-500 | 自訂 `bg-[hsl(var(--warning))]` |
+| `--muted` | 低調背景 | Neutral-100 | `bg-muted text-muted-foreground` |
+| `--accent` | 強調 | Neutral-100 | `bg-accent text-accent-foreground` |
+
+### 出勤狀態色
+
+| 狀態 | Token | 顏色 | 說明 |
+|------|-------|------|------|
+| 正常 | `--status-normal` | Green | 準時上下班 |
+| 遲到 | `--status-late` | Amber | clock_in > 09:00 |
+| 早退 | `--status-early-leave` | Deep Amber | clock_out < 18:00 |
+| 缺席 | `--status-absent` | Red | 當日無打卡紀錄 |
+| 已補打卡 | `--status-amended` | Blue | 補打卡核准 |
+
+### 帳號狀態色
+
+| 狀態 | Token | 顏色 |
+|------|-------|------|
+| 啟用 | `--status-active` | Green |
+| 停用 | `--status-inactive` | Gray |
+| 凍結 | `--status-suspended` | Red |
+
+### 角色標籤色
+
+| 角色 | Token | 顏色 |
+|------|-------|------|
+| Admin | `--role-admin` | Purple |
+| 主管 | `--role-manager` | Blue |
+| 員工 | `--role-employee` | Gray |
+
+## 字型系統
+
+### Font Family
+
+| Token | 值 | 用途 |
+|-------|---|------|
+| `--font-sans` | Inter, system-ui, Noto Sans TC | 一般文字 |
+| `--font-mono` | JetBrains Mono, monospace | 員工編號、代碼 |
+
+### Type Scale
+
+| 名稱 | Size | Line Height | Weight | 用途 | Tailwind |
+|------|------|-------------|--------|------|----------|
+| Display | 36px | 40px | Bold | Dashboard 數字 | `text-4xl font-bold` |
+| H1 | 30px | 36px | Bold | 頁面標題 | `text-3xl font-bold` |
+| H2 | 24px | 32px | Semibold | 區塊標題 | `text-2xl font-semibold` |
+| H3 | 20px | 28px | Semibold | 卡片標題 | `text-xl font-semibold` |
+| H4 | 18px | 28px | Semibold | 小區塊標題 | `text-lg font-semibold` |
+| Body | 16px | 24px | Normal | 內文 | `text-base` |
+| Small | 14px | 20px | Normal | 表格、輔助文字 | `text-sm` |
+| Caption | 12px | 16px | Normal | Badge、標籤 | `text-xs` |
+
+## 間距系統
+
+基於 4px grid，使用 Tailwind spacing utility（`p-4` = 16px）。
+
+### 常用間距
+
+| Tailwind | 值 | 用途 |
+|----------|---|------|
+| `gap-1` / `p-1` | 4px | 極小間距（icon 與文字） |
+| `gap-2` / `p-2` | 8px | 緊湊間距（Badge 內距） |
+| `gap-3` / `p-3` | 12px | 小間距（表格 cell） |
+| `gap-4` / `p-4` | 16px | 標準間距（Card 內距） |
+| `gap-6` / `p-6` | 24px | 中間距（區塊間距） |
+| `gap-8` / `p-8` | 32px | 大間距（頁面區塊） |
+
+### Layout 尺寸
+
+| Token | 值 | 說明 |
+|-------|---|------|
+| `--sidebar-width` | 256px | Sidebar 展開寬度 |
+| `--sidebar-width-collapsed` | 64px | Sidebar 收合寬度 |
+| `--header-height` | 64px | Header 高度 |
+| `--content-max-width` | 1280px | 內容區最大寬度 |
+| `--content-padding` | 24px | 內容區內距（桌面） |
+| `--content-padding-mobile` | 16px | 內容區內距（手機） |
+
+## 圓角
+
+shadcn/ui 使用 `--radius` 作為基準（0.5rem = 8px），其他圓角依此推導。
+
+| Tailwind | 值 | 用途 |
+|----------|---|------|
+| `rounded-sm` | 4px | Badge、小元件 |
+| `rounded-md` | 6px | Input、Select |
+| `rounded-lg` | 8px | Card、Dialog |
+| `rounded-xl` | 12px | 大卡片 |
+| `rounded-full` | 9999px | Avatar、圓形按鈕 |
+
+## 陰影
+
+| Tailwind | 用途 |
+|----------|------|
+| `shadow-sm` | Card hover 前 |
+| `shadow` | Card 預設 |
+| `shadow-md` | Dropdown、Popover |
+| `shadow-lg` | Modal、Dialog |
+
+## 響應式斷點
+
+| Tailwind Prefix | 寬度 | 裝置 |
+|----------------|------|------|
+| `sm:` | >= 640px | 手機橫向 |
+| `md:` | >= 768px | 平板 |
+| `lg:` | >= 1024px | 小筆電 |
+| `xl:` | >= 1280px | 桌面 |
+| `2xl:` | >= 1536px | 大桌面 |
+
+## Z-Index
+
+| Token | 值 | 用途 |
+|-------|---|------|
+| `--z-fixed` | 30 | 固定 Header |
+| `--z-sticky` | 40 | Sticky 元素 |
+| `--z-dropdown` | 50 | 下拉選單 |
+| `--z-overlay` | 60 | Overlay 遮罩 |
+| `--z-modal` | 70 | Modal / Dialog |
+| `--z-popover` | 80 | Popover / Tooltip |
+| `--z-toast` | 90 | Toast 通知 |
+
+## 動畫
+
+| Token | 值 | 用途 |
+|-------|---|------|
+| `--duration-fast` | 150ms | Hover 效果 |
+| `--duration-normal` | 200ms | 一般過渡 |
+| `--duration-slow` | 300ms | 展開/收合 |

--- a/design/tokens/typography.css
+++ b/design/tokens/typography.css
@@ -1,0 +1,118 @@
+/*
+ * Design Tokens - Typography System
+ * HR 工時管理系統 (shadcn/ui + Tailwind CSS)
+ *
+ * 字型系統基於 4px grid，使用 rem 單位。
+ * 搭配 Tailwind CSS 的 text-* utility 使用。
+ */
+
+@layer base {
+  :root {
+    /* ========================================
+     * Font Family
+     * ======================================== */
+    --font-sans: "Inter", ui-sans-serif, system-ui, -apple-system,
+      BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial,
+      "Noto Sans TC", sans-serif;
+    --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, "SF Mono",
+      Menlo, Consolas, "Liberation Mono", monospace;
+
+    /* ========================================
+     * Font Size + Line Height
+     * 格式：font-size / line-height
+     * ======================================== */
+
+    /* --- Display（大標題 — 用於 Dashboard 數據卡片） --- */
+    --text-display: 2.25rem;     /* 36px */
+    --leading-display: 2.5rem;   /* 40px */
+
+    /* --- Heading 1（頁面標題） --- */
+    --text-h1: 1.875rem;         /* 30px */
+    --leading-h1: 2.25rem;       /* 36px */
+
+    /* --- Heading 2（區塊標題） --- */
+    --text-h2: 1.5rem;           /* 24px */
+    --leading-h2: 2rem;          /* 32px */
+
+    /* --- Heading 3（卡片/Modal 標題） --- */
+    --text-h3: 1.25rem;          /* 20px */
+    --leading-h3: 1.75rem;       /* 28px */
+
+    /* --- Heading 4（小區塊標題） --- */
+    --text-h4: 1.125rem;         /* 18px */
+    --leading-h4: 1.75rem;       /* 28px */
+
+    /* --- Body Large --- */
+    --text-lg: 1.125rem;         /* 18px */
+    --leading-lg: 1.75rem;       /* 28px */
+
+    /* --- Body（預設內文） --- */
+    --text-base: 1rem;           /* 16px */
+    --leading-base: 1.5rem;      /* 24px */
+
+    /* --- Body Small（表格、輔助文字） --- */
+    --text-sm: 0.875rem;         /* 14px */
+    --leading-sm: 1.25rem;       /* 20px */
+
+    /* --- Caption（標籤、Badge） --- */
+    --text-xs: 0.75rem;          /* 12px */
+    --leading-xs: 1rem;          /* 16px */
+
+    /* ========================================
+     * Font Weight
+     * ======================================== */
+    --font-normal: 400;
+    --font-medium: 500;
+    --font-semibold: 600;
+    --font-bold: 700;
+
+    /* ========================================
+     * Letter Spacing
+     * ======================================== */
+    --tracking-tight: -0.025em;
+    --tracking-normal: 0em;
+    --tracking-wide: 0.025em;
+  }
+}
+
+/*
+ * Typography 預設樣式
+ * 可在 globals.css 中引入。
+ */
+@layer base {
+  body {
+    font-family: var(--font-sans);
+    font-size: var(--text-base);
+    line-height: var(--leading-base);
+    font-weight: var(--font-normal);
+    color: hsl(var(--foreground));
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+
+  h1 {
+    font-size: var(--text-h1);
+    line-height: var(--leading-h1);
+    font-weight: var(--font-bold);
+    letter-spacing: var(--tracking-tight);
+  }
+
+  h2 {
+    font-size: var(--text-h2);
+    line-height: var(--leading-h2);
+    font-weight: var(--font-semibold);
+    letter-spacing: var(--tracking-tight);
+  }
+
+  h3 {
+    font-size: var(--text-h3);
+    line-height: var(--leading-h3);
+    font-weight: var(--font-semibold);
+  }
+
+  h4 {
+    font-size: var(--text-h4);
+    line-height: var(--leading-h4);
+    font-weight: var(--font-semibold);
+  }
+}


### PR DESCRIPTION
## Summary
Sprint 1 的 UI component dataset，供前端 engineer 開發使用。基於 shadcn/ui + Tailwind CSS + Radix UI。

## Design Tokens
- `design/tokens/colors.css` — 色彩系統（primary, success, warning, error, neutral, 出勤/帳號/角色狀態色）
- `design/tokens/typography.css` — 字型系統（Inter + JetBrains Mono, type scale, font weight）
- `design/tokens/spacing.css` — 間距、layout 尺寸、圓角、陰影、z-index、動畫
- `design/tokens/tokens.md` — Design tokens 總覽文件

## Components (12)
| 元件 | Spec | 說明 |
|------|------|------|
| AppLayout | `design/components/layout.md` | Sidebar + Header + Content + PageHeader |
| DataTable | `design/components/data-table.md` | @tanstack/react-table 表格 |
| FormField | `design/components/form-field.md` | react-hook-form + zod 表單欄位 |
| StatusBadge | `design/components/status-badge.md` | 出勤/帳號/角色狀態標籤 |
| ClockButton | `design/components/clock-button.md` | 打卡大按鈕 + 即時時鐘 |
| SearchFilter | `design/components/search-filter.md` | 搜尋 + 篩選組合 |
| ConfirmDialog | `design/components/confirm-dialog.md` | 確認對話框 |
| PasswordForm | `design/components/password-form.md` | 變更密碼 Modal |
| Toast | `design/components/toast-notification.md` | 通知提示 |
| CardStats | `design/components/card-stats.md` | Dashboard 統計卡片 |
| EmptyState | `design/components/empty-state.md` | 無資料狀態 |
| LoadingState | `design/components/loading-state.md` | 骨架屏 + Spinner |

## Pages (8)
| 頁面 | Spec | 對應 Feature |
|------|------|-------------|
| 登入頁 | `design/pages/login.md` | #6 F-000 |
| Dashboard | `design/pages/dashboard.md` | #8 #6 |
| 員工列表 | `design/pages/employee-list.md` | #7 F-008 |
| 員工表單 | `design/pages/employee-form.md` | #7 F-008 |
| 部門列表 | `design/pages/department-list.md` | #7 F-008 |
| 部門表單 | `design/pages/department-form.md` | #7 F-008 |
| 打卡頁 | `design/pages/clock-in.md` | #8 F-001 |
| 打卡紀錄 | `design/pages/clock-records.md` | #8 F-001 |

## 設計重點
- CSS Variables 驅動，支援 Light/Dark 主題切換
- 所有元件含完整的 Props 定義、variants、範例程式碼
- 響應式設計（桌面 + 平板 + 手機 PWA）
- WCAG 2.1 AA 無障礙支援
- 角色權限對應的 UI 差異（employee / manager / admin）

Refs #10