### PR TITLE
[Feature] F-008: 員工/部門管理

### DIFF
--- a/dev/__tests__/departments/departments.service.spec.ts
+++ b/dev/__tests__/departments/departments.service.spec.ts
@@ -1,0 +1,335 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HttpException, HttpStatus, NotFoundException } from '@nestjs/common';
+import { DepartmentsService } from '../../src/departments/departments.service';
+import { PrismaService } from '../../src/prisma/prisma.service';
+
+describe('DepartmentsService', () => {
+  let service: DepartmentsService;
+  let prisma: {
+    department: {
+      findUnique: jest.Mock;
+      findMany: jest.Mock;
+      create: jest.Mock;
+      update: jest.Mock;
+      delete: jest.Mock;
+      count: jest.Mock;
+    };
+    user: {
+      findUnique: jest.Mock;
+    };
+  };
+
+  const mockDepartment = {
+    id: 'dept-uuid-1',
+    name: '工程部',
+    code: 'ENG',
+    managerId: null,
+    parentId: null,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-01T00:00:00Z'),
+    manager: null,
+    parent: null,
+  };
+
+  beforeEach(async () => {
+    prisma = {
+      department: {
+        findUnique: jest.fn(),
+        findMany: jest.fn(),
+        create: jest.fn(),
+        update: jest.fn(),
+        delete: jest.fn(),
+        count: jest.fn(),
+      },
+      user: {
+        findUnique: jest.fn(),
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DepartmentsService,
+        { provide: PrismaService, useValue: prisma },
+      ],
+    }).compile();
+
+    service = module.get<DepartmentsService>(DepartmentsService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('create', () => {
+    it('should create a department successfully', async () => {
+      prisma.department.findUnique.mockResolvedValue(null); // no duplicates
+      prisma.department.create.mockResolvedValue(mockDepartment);
+
+      const result = await service.create({ name: '工程部', code: 'ENG' });
+
+      expect(result.id).toBe('dept-uuid-1');
+      expect(result.name).toBe('工程部');
+      expect(result.code).toBe('ENG');
+      expect(result.manager).toBeNull();
+      expect(result.parent).toBeNull();
+    });
+
+    it('should throw DUPLICATE_NAME when name already exists', async () => {
+      prisma.department.findUnique.mockResolvedValueOnce(mockDepartment); // name exists
+
+      try {
+        await service.create({ name: '工程部', code: 'ENG2' });
+        fail('Expected exception');
+      } catch (e) {
+        const exception = e as HttpException;
+        expect(exception.getStatus()).toBe(HttpStatus.CONFLICT);
+        const response = exception.getResponse() as Record<string, string>;
+        expect(response.code).toBe('DUPLICATE_NAME');
+      }
+    });
+
+    it('should throw DUPLICATE_CODE when code already exists', async () => {
+      prisma.department.findUnique
+        .mockResolvedValueOnce(null) // name check passes
+        .mockResolvedValueOnce(mockDepartment); // code exists
+
+      try {
+        await service.create({ name: '新部門', code: 'ENG' });
+        fail('Expected exception');
+      } catch (e) {
+        const exception = e as HttpException;
+        expect(exception.getStatus()).toBe(HttpStatus.CONFLICT);
+        const response = exception.getResponse() as Record<string, string>;
+        expect(response.code).toBe('DUPLICATE_CODE');
+      }
+    });
+
+    it('should validate manager_id is an active user', async () => {
+      prisma.department.findUnique.mockResolvedValue(null); // no duplicates
+      prisma.user.findUnique.mockResolvedValue(null); // manager not found
+
+      try {
+        await service.create({
+          name: '工程部',
+          code: 'ENG',
+          manager_id: 'nonexistent-uuid',
+        });
+        fail('Expected exception');
+      } catch (e) {
+        const exception = e as HttpException;
+        expect(exception.getStatus()).toBe(HttpStatus.BAD_REQUEST);
+      }
+    });
+
+    it('should validate parent_id exists', async () => {
+      prisma.department.findUnique
+        .mockResolvedValueOnce(null) // name check
+        .mockResolvedValueOnce(null) // code check
+        .mockResolvedValueOnce(null); // parent not found
+
+      try {
+        await service.create({
+          name: '子部門',
+          code: 'SUB',
+          parent_id: 'nonexistent-parent',
+        });
+        fail('Expected exception');
+      } catch (e) {
+        const exception = e as HttpException;
+        expect(exception.getStatus()).toBe(HttpStatus.BAD_REQUEST);
+        const response = exception.getResponse() as Record<string, string>;
+        expect(response.message).toContain('父部門不存在');
+      }
+    });
+
+    it('should reject hierarchy deeper than 3 levels', async () => {
+      // name check, code check pass
+      prisma.department.findUnique
+        .mockResolvedValueOnce(null) // name
+        .mockResolvedValueOnce(null) // code
+        .mockResolvedValueOnce({ id: 'level-2', parentId: 'level-1' }) // parent exists
+        .mockResolvedValueOnce({ parentId: 'root' }) // depth traversal: level-2 -> level-1
+        .mockResolvedValueOnce({ parentId: null }); // depth traversal: level-1 -> root (depth = 2)
+
+      try {
+        await service.create({
+          name: '深層子部門',
+          code: 'DEEP',
+          parent_id: 'level-2',
+        });
+        fail('Expected exception');
+      } catch (e) {
+        const exception = e as HttpException;
+        expect(exception.getStatus()).toBe(HttpStatus.BAD_REQUEST);
+        const response = exception.getResponse() as Record<string, string>;
+        expect(response.message).toContain('3 層');
+      }
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return paginated departments', async () => {
+      const deptWithCount = {
+        ...mockDepartment,
+        _count: { members: 5 },
+      };
+      prisma.department.findMany.mockResolvedValue([deptWithCount]);
+      prisma.department.count.mockResolvedValue(1);
+
+      const result = await service.findAll({ page: 1, limit: 20 });
+
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0]).toHaveProperty('member_count', 5);
+      expect(result.meta.total).toBe(1);
+      expect(result.meta.page).toBe(1);
+      expect(result.meta.totalPages).toBe(1);
+    });
+
+    it('should support search by name or code', async () => {
+      prisma.department.findMany.mockResolvedValue([]);
+      prisma.department.count.mockResolvedValue(0);
+
+      await service.findAll({ search: '工程', page: 1, limit: 20 });
+
+      expect(prisma.department.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            OR: [
+              { name: { contains: '工程', mode: 'insensitive' } },
+              { code: { contains: '工程', mode: 'insensitive' } },
+            ],
+          },
+        }),
+      );
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return department with members', async () => {
+      const deptWithMembers = {
+        ...mockDepartment,
+        children: [],
+        members: [
+          {
+            id: 'user-1',
+            employeeId: 'EMP001',
+            name: '王小明',
+            email: 'wang@company.com',
+            role: 'EMPLOYEE',
+            status: 'ACTIVE',
+          },
+        ],
+      };
+      prisma.department.findUnique.mockResolvedValue(deptWithMembers);
+
+      const result = await service.findOne('dept-uuid-1');
+
+      expect(result.id).toBe('dept-uuid-1');
+      expect(result.members).toHaveLength(1);
+      expect(result.members[0].employee_id).toBe('EMP001');
+      expect(result.members[0].role).toBe('employee');
+      expect(result.member_count).toBe(1);
+    });
+
+    it('should throw NOT_FOUND when department does not exist', async () => {
+      prisma.department.findUnique.mockResolvedValue(null);
+
+      await expect(service.findOne('nonexistent')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('update', () => {
+    it('should update department name', async () => {
+      prisma.department.findUnique
+        .mockResolvedValueOnce(mockDepartment) // existing check
+        .mockResolvedValueOnce(null); // name uniqueness check
+      prisma.department.update.mockResolvedValue({
+        ...mockDepartment,
+        name: '新工程部',
+      });
+
+      const result = await service.update('dept-uuid-1', { name: '新工程部' });
+
+      expect(result.name).toBe('新工程部');
+    });
+
+    it('should throw NOT_FOUND when department does not exist', async () => {
+      prisma.department.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.update('nonexistent', { name: '新名稱' }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw DUPLICATE_NAME when new name conflicts', async () => {
+      prisma.department.findUnique
+        .mockResolvedValueOnce(mockDepartment) // existing
+        .mockResolvedValueOnce({ id: 'other-dept', name: '已存在部門' }); // conflict
+
+      try {
+        await service.update('dept-uuid-1', { name: '已存在部門' });
+        fail('Expected exception');
+      } catch (e) {
+        const exception = e as HttpException;
+        expect(exception.getStatus()).toBe(HttpStatus.CONFLICT);
+        const response = exception.getResponse() as Record<string, string>;
+        expect(response.code).toBe('DUPLICATE_NAME');
+      }
+    });
+
+    it('should reject setting self as parent', async () => {
+      prisma.department.findUnique.mockResolvedValueOnce(mockDepartment);
+
+      try {
+        await service.update('dept-uuid-1', { parent_id: 'dept-uuid-1' });
+        fail('Expected exception');
+      } catch (e) {
+        const exception = e as HttpException;
+        expect(exception.getStatus()).toBe(HttpStatus.BAD_REQUEST);
+      }
+    });
+  });
+
+  describe('remove', () => {
+    it('should delete department with no members', async () => {
+      prisma.department.findUnique.mockResolvedValue({
+        ...mockDepartment,
+        _count: { members: 0 },
+      });
+      prisma.department.delete.mockResolvedValue(mockDepartment);
+
+      await service.remove('dept-uuid-1');
+
+      expect(prisma.department.delete).toHaveBeenCalledWith({
+        where: { id: 'dept-uuid-1' },
+      });
+    });
+
+    it('should throw HAS_MEMBERS when department has employees', async () => {
+      prisma.department.findUnique.mockResolvedValue({
+        ...mockDepartment,
+        _count: { members: 5 },
+      });
+
+      try {
+        await service.remove('dept-uuid-1');
+        fail('Expected exception');
+      } catch (e) {
+        const exception = e as HttpException;
+        expect(exception.getStatus()).toBe(HttpStatus.UNPROCESSABLE_ENTITY);
+        const response = exception.getResponse() as Record<string, string>;
+        expect(response.code).toBe('HAS_MEMBERS');
+      }
+    });
+
+    it('should throw NOT_FOUND when department does not exist', async () => {
+      prisma.department.findUnique.mockResolvedValue(null);
+
+      await expect(service.remove('nonexistent')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+});

--- a/dev/__tests__/employees/employees.service.spec.ts
+++ b/dev/__tests__/employees/employees.service.spec.ts
@@ -1,0 +1,395 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HttpException, HttpStatus, NotFoundException } from '@nestjs/common';
+import { EmployeesService } from '../../src/employees/employees.service';
+import { PrismaService } from '../../src/prisma/prisma.service';
+
+// Mock bcrypt
+jest.mock('bcrypt', () => ({
+  hash: jest.fn().mockResolvedValue('$2b$10$hashedPassword'),
+  compare: jest.fn(),
+}));
+
+describe('EmployeesService', () => {
+  let service: EmployeesService;
+  let prisma: {
+    user: {
+      findUnique: jest.Mock;
+      findMany: jest.Mock;
+      create: jest.Mock;
+      update: jest.Mock;
+      count: jest.Mock;
+    };
+    department: {
+      findUnique: jest.Mock;
+    };
+  };
+
+  const mockDepartment = {
+    id: 'dept-uuid-1',
+    name: '工程部',
+    code: 'ENG',
+  };
+
+  const mockUser = {
+    id: 'user-uuid-1',
+    employeeId: 'EMP001',
+    email: 'wang@company.com',
+    passwordHash: '$2b$10$hashedPassword',
+    name: '王小明',
+    role: 'EMPLOYEE',
+    departmentId: 'dept-uuid-1',
+    managerId: null,
+    hireDate: new Date('2024-03-01'),
+    status: 'ACTIVE',
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-01T00:00:00Z'),
+    department: { id: 'dept-uuid-1', name: '工程部' },
+    manager: null,
+  };
+
+  beforeEach(async () => {
+    prisma = {
+      user: {
+        findUnique: jest.fn(),
+        findMany: jest.fn(),
+        create: jest.fn(),
+        update: jest.fn(),
+        count: jest.fn(),
+      },
+      department: {
+        findUnique: jest.fn(),
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        EmployeesService,
+        { provide: PrismaService, useValue: prisma },
+      ],
+    }).compile();
+
+    service = module.get<EmployeesService>(EmployeesService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('create', () => {
+    const createDto = {
+      employee_id: 'EMP001',
+      email: 'wang@company.com',
+      password: 'initPass123',
+      name: '王小明',
+      role: 'employee' as const,
+      department_id: 'dept-uuid-1',
+      hire_date: '2024-03-01',
+    };
+
+    it('should create an employee successfully', async () => {
+      prisma.user.findUnique
+        .mockResolvedValueOnce(null) // employee_id check
+        .mockResolvedValueOnce(null); // email check
+      prisma.department.findUnique.mockResolvedValue(mockDepartment);
+      prisma.user.create.mockResolvedValue(mockUser);
+
+      const result = await service.create(createDto);
+
+      expect(result.id).toBe('user-uuid-1');
+      expect(result.employee_id).toBe('EMP001');
+      expect(result.email).toBe('wang@company.com');
+      expect(result.name).toBe('王小明');
+      expect(result.role).toBe('employee');
+      expect(result.status).toBe('active');
+      expect(result.department).toEqual({ id: 'dept-uuid-1', name: '工程部' });
+      expect(result.hire_date).toBe('2024-03-01');
+    });
+
+    it('should throw DUPLICATE_EMPLOYEE_ID when employee_id exists', async () => {
+      prisma.user.findUnique.mockResolvedValueOnce(mockUser); // employee_id exists
+
+      try {
+        await service.create(createDto);
+        fail('Expected exception');
+      } catch (e) {
+        const exception = e as HttpException;
+        expect(exception.getStatus()).toBe(HttpStatus.CONFLICT);
+        const response = exception.getResponse() as Record<string, string>;
+        expect(response.code).toBe('DUPLICATE_EMPLOYEE_ID');
+      }
+    });
+
+    it('should throw DUPLICATE_EMAIL when email exists', async () => {
+      prisma.user.findUnique
+        .mockResolvedValueOnce(null) // employee_id OK
+        .mockResolvedValueOnce(mockUser); // email exists
+
+      try {
+        await service.create(createDto);
+        fail('Expected exception');
+      } catch (e) {
+        const exception = e as HttpException;
+        expect(exception.getStatus()).toBe(HttpStatus.CONFLICT);
+        const response = exception.getResponse() as Record<string, string>;
+        expect(response.code).toBe('DUPLICATE_EMAIL');
+      }
+    });
+
+    it('should throw DEPARTMENT_NOT_FOUND when department does not exist', async () => {
+      prisma.user.findUnique.mockResolvedValue(null); // no duplicates
+      prisma.department.findUnique.mockResolvedValue(null); // dept not found
+
+      try {
+        await service.create(createDto);
+        fail('Expected exception');
+      } catch (e) {
+        const exception = e as HttpException;
+        expect(exception.getStatus()).toBe(HttpStatus.NOT_FOUND);
+        const response = exception.getResponse() as Record<string, string>;
+        expect(response.code).toBe('DEPARTMENT_NOT_FOUND');
+      }
+    });
+
+    it('should throw INVALID_INPUT when manager_id is not a manager role', async () => {
+      prisma.user.findUnique
+        .mockResolvedValueOnce(null) // employee_id check
+        .mockResolvedValueOnce(null) // email check
+        .mockResolvedValueOnce({ id: 'emp-user', role: 'EMPLOYEE', status: 'ACTIVE' }); // manager check
+      prisma.department.findUnique.mockResolvedValue(mockDepartment);
+
+      try {
+        await service.create({
+          ...createDto,
+          manager_id: 'emp-user',
+        });
+        fail('Expected exception');
+      } catch (e) {
+        const exception = e as HttpException;
+        expect(exception.getStatus()).toBe(HttpStatus.BAD_REQUEST);
+        const response = exception.getResponse() as Record<string, string>;
+        expect(response.code).toBe('INVALID_INPUT');
+        expect(response.message).toContain('manager');
+      }
+    });
+
+    it('should accept valid manager_id with manager role', async () => {
+      const managerUser = {
+        id: 'manager-uuid',
+        role: 'MANAGER',
+        status: 'ACTIVE',
+      };
+      prisma.user.findUnique
+        .mockResolvedValueOnce(null) // employee_id
+        .mockResolvedValueOnce(null) // email
+        .mockResolvedValueOnce(managerUser); // manager check
+      prisma.department.findUnique.mockResolvedValue(mockDepartment);
+      prisma.user.create.mockResolvedValue({
+        ...mockUser,
+        managerId: 'manager-uuid',
+        manager: { id: 'manager-uuid', name: '主管', email: 'mgr@company.com' },
+      });
+
+      const result = await service.create({
+        ...createDto,
+        manager_id: 'manager-uuid',
+      });
+
+      expect(result.manager).toEqual({
+        id: 'manager-uuid',
+        name: '主管',
+        email: 'mgr@company.com',
+      });
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return paginated employee list', async () => {
+      prisma.user.findMany.mockResolvedValue([mockUser]);
+      prisma.user.count.mockResolvedValue(1);
+
+      const result = await service.findAll({ page: 1, limit: 20 });
+
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0]).toHaveProperty('employee_id', 'EMP001');
+      expect(result.meta.total).toBe(1);
+    });
+
+    it('should support search by name, email, or employee_id', async () => {
+      prisma.user.findMany.mockResolvedValue([]);
+      prisma.user.count.mockResolvedValue(0);
+
+      await service.findAll({ search: '王小明', page: 1, limit: 20 });
+
+      expect(prisma.user.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            OR: [
+              { name: { contains: '王小明', mode: 'insensitive' } },
+              { email: { contains: '王小明', mode: 'insensitive' } },
+              { employeeId: { contains: '王小明', mode: 'insensitive' } },
+            ],
+          },
+        }),
+      );
+    });
+
+    it('should filter by department_id', async () => {
+      prisma.user.findMany.mockResolvedValue([]);
+      prisma.user.count.mockResolvedValue(0);
+
+      await service.findAll({
+        department_id: 'dept-uuid-1',
+        page: 1,
+        limit: 20,
+      });
+
+      expect(prisma.user.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { departmentId: 'dept-uuid-1' },
+        }),
+      );
+    });
+
+    it('should filter by role', async () => {
+      prisma.user.findMany.mockResolvedValue([]);
+      prisma.user.count.mockResolvedValue(0);
+
+      await service.findAll({ role: 'admin', page: 1, limit: 20 });
+
+      expect(prisma.user.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { role: 'ADMIN' },
+        }),
+      );
+    });
+
+    it('should filter by status', async () => {
+      prisma.user.findMany.mockResolvedValue([]);
+      prisma.user.count.mockResolvedValue(0);
+
+      await service.findAll({ status: 'active', page: 1, limit: 20 });
+
+      expect(prisma.user.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { status: 'ACTIVE' },
+        }),
+      );
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return employee details', async () => {
+      prisma.user.findUnique.mockResolvedValue(mockUser);
+
+      const result = await service.findOne('user-uuid-1');
+
+      expect(result.id).toBe('user-uuid-1');
+      expect(result.employee_id).toBe('EMP001');
+      expect(result.role).toBe('employee');
+    });
+
+    it('should throw NOT_FOUND when employee does not exist', async () => {
+      prisma.user.findUnique.mockResolvedValue(null);
+
+      await expect(service.findOne('nonexistent')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('update', () => {
+    it('should update employee name', async () => {
+      prisma.user.findUnique.mockResolvedValue(mockUser); // existing check
+      prisma.user.update.mockResolvedValue({
+        ...mockUser,
+        name: '王大明',
+      });
+
+      const result = await service.update('user-uuid-1', { name: '王大明' });
+
+      expect(result.name).toBe('王大明');
+    });
+
+    it('should update employee status to inactive', async () => {
+      prisma.user.findUnique.mockResolvedValue(mockUser);
+      prisma.user.update.mockResolvedValue({
+        ...mockUser,
+        status: 'INACTIVE',
+      });
+
+      const result = await service.update('user-uuid-1', {
+        status: 'inactive' as const,
+      });
+
+      expect(result.status).toBe('inactive');
+    });
+
+    it('should throw NOT_FOUND when employee does not exist', async () => {
+      prisma.user.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.update('nonexistent', { name: '新名稱' }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw DEPARTMENT_NOT_FOUND when new department does not exist', async () => {
+      prisma.user.findUnique.mockResolvedValue(mockUser);
+      prisma.department.findUnique.mockResolvedValue(null);
+
+      try {
+        await service.update('user-uuid-1', {
+          department_id: 'nonexistent-dept',
+        });
+        fail('Expected exception');
+      } catch (e) {
+        const exception = e as HttpException;
+        expect(exception.getStatus()).toBe(HttpStatus.NOT_FOUND);
+        const response = exception.getResponse() as Record<string, string>;
+        expect(response.code).toBe('DEPARTMENT_NOT_FOUND');
+      }
+    });
+
+    it('should validate manager_id must be manager role', async () => {
+      prisma.user.findUnique
+        .mockResolvedValueOnce(mockUser) // existing check
+        .mockResolvedValueOnce({ id: 'emp-user', role: 'EMPLOYEE' }); // manager check
+
+      try {
+        await service.update('user-uuid-1', { manager_id: 'emp-user' });
+        fail('Expected exception');
+      } catch (e) {
+        const exception = e as HttpException;
+        expect(exception.getStatus()).toBe(HttpStatus.BAD_REQUEST);
+        const response = exception.getResponse() as Record<string, string>;
+        expect(response.code).toBe('INVALID_INPUT');
+      }
+    });
+  });
+
+  describe('resetPassword', () => {
+    it('should reset password successfully', async () => {
+      prisma.user.findUnique.mockResolvedValue(mockUser);
+      prisma.user.update.mockResolvedValue(mockUser);
+
+      const result = await service.resetPassword('user-uuid-1', {
+        new_password: 'newSecurePass123',
+      });
+
+      expect(result.message).toBe('密碼已重設');
+      expect(prisma.user.update).toHaveBeenCalledWith({
+        where: { id: 'user-uuid-1' },
+        data: { passwordHash: '$2b$10$hashedPassword' },
+      });
+    });
+
+    it('should throw NOT_FOUND when employee does not exist', async () => {
+      prisma.user.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.resetPassword('nonexistent', {
+          new_password: 'newPass123',
+        }),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/dev/jest.config.ts
+++ b/dev/jest.config.ts
@@ -5,7 +5,14 @@ const config: Config = {
   rootDir: '.',
   testRegex: '.*\\.spec\\.ts$',
   transform: {
-    '^.+\\.ts$': 'ts-jest',
+    '^.+\\.ts$': [
+      'ts-jest',
+      {
+        tsconfig: {
+          types: ['jest', 'node'],
+        },
+      },
+    ],
   },
   collectCoverageFrom: ['src/**/*.ts', '!src/main.ts'],
   coverageDirectory: './coverage',

--- a/dev/prisma.config.ts
+++ b/dev/prisma.config.ts
@@ -1,0 +1,14 @@
+import path from 'node:path';
+import { defineConfig } from 'prisma/config';
+
+export default defineConfig({
+  earlyAccess: true,
+  schema: path.join(__dirname, 'prisma', 'schema.prisma'),
+  migrate: {
+    async development() {
+      return {
+        url: process.env.DATABASE_URL ?? 'postgresql://user:pass@db:5432/app',
+      };
+    },
+  },
+});

--- a/dev/prisma/schema.prisma
+++ b/dev/prisma/schema.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
 }
 
 generator client {

--- a/dev/src/app.module.ts
+++ b/dev/src/app.module.ts
@@ -2,6 +2,8 @@ import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { PrismaModule } from './prisma/prisma.module';
 import { AuthModule } from './auth/auth.module';
+import { DepartmentsModule } from './departments/departments.module';
+import { EmployeesModule } from './employees/employees.module';
 
 @Module({
   imports: [
@@ -11,6 +13,8 @@ import { AuthModule } from './auth/auth.module';
     }),
     PrismaModule,
     AuthModule,
+    DepartmentsModule,
+    EmployeesModule,
   ],
 })
 export class AppModule {}

--- a/dev/src/departments/departments.controller.ts
+++ b/dev/src/departments/departments.controller.ts
@@ -1,0 +1,58 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Delete,
+  Body,
+  Param,
+  Query,
+  UseGuards,
+  HttpCode,
+  HttpStatus,
+  ParseUUIDPipe,
+} from '@nestjs/common';
+import { DepartmentsService } from './departments.service';
+import { CreateDepartmentDto } from './dto/create-department.dto';
+import { UpdateDepartmentDto } from './dto/update-department.dto';
+import { QueryDepartmentDto } from './dto/query-department.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+
+@Controller('departments')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles('ADMIN')
+export class DepartmentsController {
+  constructor(private readonly departmentsService: DepartmentsService) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  async create(@Body() dto: CreateDepartmentDto) {
+    return this.departmentsService.create(dto);
+  }
+
+  @Get()
+  async findAll(@Query() query: QueryDepartmentDto) {
+    return this.departmentsService.findAll(query);
+  }
+
+  @Get(':id')
+  async findOne(@Param('id', ParseUUIDPipe) id: string) {
+    return this.departmentsService.findOne(id);
+  }
+
+  @Put(':id')
+  async update(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: UpdateDepartmentDto,
+  ) {
+    return this.departmentsService.update(id, dto);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async remove(@Param('id', ParseUUIDPipe) id: string) {
+    await this.departmentsService.remove(id);
+  }
+}

--- a/dev/src/departments/departments.module.ts
+++ b/dev/src/departments/departments.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { DepartmentsController } from './departments.controller';
+import { DepartmentsService } from './departments.service';
+
+@Module({
+  controllers: [DepartmentsController],
+  providers: [DepartmentsService],
+  exports: [DepartmentsService],
+})
+export class DepartmentsModule {}

--- a/dev/src/departments/departments.service.ts
+++ b/dev/src/departments/departments.service.ts
@@ -1,0 +1,374 @@
+import {
+  Injectable,
+  HttpException,
+  HttpStatus,
+  NotFoundException,
+} from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateDepartmentDto } from './dto/create-department.dto';
+import { UpdateDepartmentDto } from './dto/update-department.dto';
+import { QueryDepartmentDto } from './dto/query-department.dto';
+import { PaginatedResult } from '../common/dto/pagination.dto';
+
+@Injectable()
+export class DepartmentsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * 建立部門
+   */
+  async create(dto: CreateDepartmentDto) {
+    // 檢查名稱唯一
+    const existingName = await this.prisma.department.findUnique({
+      where: { name: dto.name },
+    });
+    if (existingName) {
+      throw new HttpException(
+        { code: 'DUPLICATE_NAME', message: '部門名稱已存在' },
+        HttpStatus.CONFLICT,
+      );
+    }
+
+    // 檢查代碼唯一
+    const existingCode = await this.prisma.department.findUnique({
+      where: { code: dto.code },
+    });
+    if (existingCode) {
+      throw new HttpException(
+        { code: 'DUPLICATE_CODE', message: '部門代碼已存在' },
+        HttpStatus.CONFLICT,
+      );
+    }
+
+    // 檢查 manager_id 是否為 active 的 User
+    if (dto.manager_id) {
+      const manager = await this.prisma.user.findUnique({
+        where: { id: dto.manager_id },
+        select: { id: true, status: true },
+      });
+      if (!manager || manager.status !== 'ACTIVE') {
+        throw new HttpException(
+          { code: 'INVALID_INPUT', message: 'manager_id 對應的使用者不存在或非活躍狀態' },
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+    }
+
+    // 檢查 parent_id 是否存在，且階層不超過 3 層
+    if (dto.parent_id) {
+      const parentDept = await this.prisma.department.findUnique({
+        where: { id: dto.parent_id },
+      });
+      if (!parentDept) {
+        throw new HttpException(
+          { code: 'INVALID_INPUT', message: '父部門不存在' },
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+
+      const depth = await this.getDepartmentDepth(dto.parent_id);
+      if (depth >= 2) {
+        throw new HttpException(
+          { code: 'INVALID_INPUT', message: '部門階層不可超過 3 層' },
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+    }
+
+    const department = await this.prisma.department.create({
+      data: {
+        name: dto.name,
+        code: dto.code,
+        managerId: dto.manager_id,
+        parentId: dto.parent_id,
+      },
+      include: {
+        manager: { select: { id: true, name: true, email: true } },
+        parent: { select: { id: true, name: true, code: true } },
+      },
+    });
+
+    return this.formatDepartment(department);
+  }
+
+  /**
+   * 部門列表（含搜尋 + 分頁）
+   */
+  async findAll(query: QueryDepartmentDto): Promise<PaginatedResult<unknown>> {
+    const { search, page = 1, limit = 20 } = query;
+
+    const where: Record<string, unknown> = {};
+    if (search) {
+      where.OR = [
+        { name: { contains: search, mode: 'insensitive' } },
+        { code: { contains: search, mode: 'insensitive' } },
+      ];
+    }
+
+    const [departments, total] = await Promise.all([
+      this.prisma.department.findMany({
+        where,
+        include: {
+          manager: { select: { id: true, name: true, email: true } },
+          parent: { select: { id: true, name: true, code: true } },
+          _count: { select: { members: true } },
+        },
+        skip: (page - 1) * limit,
+        take: limit,
+        orderBy: { createdAt: 'desc' },
+      }),
+      this.prisma.department.count({ where }),
+    ]);
+
+    return {
+      data: departments.map((dept) => ({
+        id: dept.id,
+        name: dept.name,
+        code: dept.code,
+        manager: dept.manager
+          ? { id: dept.manager.id, name: dept.manager.name, email: dept.manager.email }
+          : null,
+        parent: dept.parent
+          ? { id: dept.parent.id, name: dept.parent.name, code: dept.parent.code }
+          : null,
+        member_count: dept._count.members,
+        created_at: dept.createdAt.toISOString(),
+      })),
+      meta: {
+        total,
+        page,
+        limit,
+        totalPages: Math.ceil(total / limit),
+      },
+    };
+  }
+
+  /**
+   * 部門詳情含 members
+   */
+  async findOne(id: string) {
+    const department = await this.prisma.department.findUnique({
+      where: { id },
+      include: {
+        manager: { select: { id: true, name: true, email: true } },
+        parent: { select: { id: true, name: true, code: true } },
+        children: { select: { id: true, name: true, code: true } },
+        members: {
+          select: {
+            id: true,
+            employeeId: true,
+            name: true,
+            email: true,
+            role: true,
+            status: true,
+          },
+        },
+      },
+    });
+
+    if (!department) {
+      throw new NotFoundException({
+        code: 'NOT_FOUND',
+        message: '部門不存在',
+      });
+    }
+
+    return {
+      id: department.id,
+      name: department.name,
+      code: department.code,
+      manager: department.manager
+        ? { id: department.manager.id, name: department.manager.name, email: department.manager.email }
+        : null,
+      parent: department.parent
+        ? { id: department.parent.id, name: department.parent.name, code: department.parent.code }
+        : null,
+      children: department.children.map((c) => ({
+        id: c.id,
+        name: c.name,
+        code: c.code,
+      })),
+      members: department.members.map((m) => ({
+        id: m.id,
+        employee_id: m.employeeId,
+        name: m.name,
+        email: m.email,
+        role: m.role.toLowerCase(),
+        status: m.status.toLowerCase(),
+      })),
+      member_count: department.members.length,
+      created_at: department.createdAt.toISOString(),
+    };
+  }
+
+  /**
+   * 更新部門（partial update）
+   */
+  async update(id: string, dto: UpdateDepartmentDto) {
+    const existing = await this.prisma.department.findUnique({ where: { id } });
+    if (!existing) {
+      throw new NotFoundException({
+        code: 'NOT_FOUND',
+        message: '部門不存在',
+      });
+    }
+
+    // 檢查名稱唯一（排除自己）
+    if (dto.name && dto.name !== existing.name) {
+      const existingName = await this.prisma.department.findUnique({
+        where: { name: dto.name },
+      });
+      if (existingName) {
+        throw new HttpException(
+          { code: 'DUPLICATE_NAME', message: '部門名稱已存在' },
+          HttpStatus.CONFLICT,
+        );
+      }
+    }
+
+    // 檢查代碼唯一（排除自己）
+    if (dto.code && dto.code !== existing.code) {
+      const existingCode = await this.prisma.department.findUnique({
+        where: { code: dto.code },
+      });
+      if (existingCode) {
+        throw new HttpException(
+          { code: 'DUPLICATE_CODE', message: '部門代碼已存在' },
+          HttpStatus.CONFLICT,
+        );
+      }
+    }
+
+    // 檢查 manager_id
+    if (dto.manager_id) {
+      const manager = await this.prisma.user.findUnique({
+        where: { id: dto.manager_id },
+        select: { id: true, status: true },
+      });
+      if (!manager || manager.status !== 'ACTIVE') {
+        throw new HttpException(
+          { code: 'INVALID_INPUT', message: 'manager_id 對應的使用者不存在或非活躍狀態' },
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+    }
+
+    // 檢查 parent_id 階層
+    if (dto.parent_id) {
+      if (dto.parent_id === id) {
+        throw new HttpException(
+          { code: 'INVALID_INPUT', message: '部門不可將自己設為父部門' },
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+
+      const parentDept = await this.prisma.department.findUnique({
+        where: { id: dto.parent_id },
+      });
+      if (!parentDept) {
+        throw new HttpException(
+          { code: 'INVALID_INPUT', message: '父部門不存在' },
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+
+      const depth = await this.getDepartmentDepth(dto.parent_id);
+      if (depth >= 2) {
+        throw new HttpException(
+          { code: 'INVALID_INPUT', message: '部門階層不可超過 3 層' },
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+    }
+
+    const updateData: Record<string, unknown> = {};
+    if (dto.name !== undefined) updateData.name = dto.name;
+    if (dto.code !== undefined) updateData.code = dto.code;
+    if (dto.manager_id !== undefined) updateData.managerId = dto.manager_id;
+    if (dto.parent_id !== undefined) updateData.parentId = dto.parent_id;
+
+    const department = await this.prisma.department.update({
+      where: { id },
+      data: updateData,
+      include: {
+        manager: { select: { id: true, name: true, email: true } },
+        parent: { select: { id: true, name: true, code: true } },
+      },
+    });
+
+    return this.formatDepartment(department);
+  }
+
+  /**
+   * 刪除部門（有員工時不可刪）
+   */
+  async remove(id: string) {
+    const department = await this.prisma.department.findUnique({
+      where: { id },
+      include: { _count: { select: { members: true } } },
+    });
+
+    if (!department) {
+      throw new NotFoundException({
+        code: 'NOT_FOUND',
+        message: '部門不存在',
+      });
+    }
+
+    if (department._count.members > 0) {
+      throw new HttpException(
+        { code: 'HAS_MEMBERS', message: '部門仍有員工，無法刪除，請先轉移員工' },
+        HttpStatus.UNPROCESSABLE_ENTITY,
+      );
+    }
+
+    await this.prisma.department.delete({ where: { id } });
+  }
+
+  // ── Private Methods ──
+
+  /**
+   * 取得部門的階層深度（0 = 根部門）
+   */
+  private async getDepartmentDepth(departmentId: string): Promise<number> {
+    let depth = 0;
+    let currentId: string | null = departmentId;
+
+    while (currentId) {
+      const dept = await this.prisma.department.findUnique({
+        where: { id: currentId },
+        select: { parentId: true },
+      });
+      if (!dept || !dept.parentId) break;
+      depth++;
+      currentId = dept.parentId;
+    }
+
+    return depth;
+  }
+
+  /**
+   * 格式化部門輸出
+   */
+  private formatDepartment(department: {
+    id: string;
+    name: string;
+    code: string;
+    createdAt: Date;
+    manager?: { id: string; name: string; email: string } | null;
+    parent?: { id: string; name: string; code: string } | null;
+  }) {
+    return {
+      id: department.id,
+      name: department.name,
+      code: department.code,
+      manager: department.manager
+        ? { id: department.manager.id, name: department.manager.name, email: department.manager.email }
+        : null,
+      parent: department.parent
+        ? { id: department.parent.id, name: department.parent.name, code: department.parent.code }
+        : null,
+      created_at: department.createdAt.toISOString(),
+    };
+  }
+}

--- a/dev/src/departments/dto/create-department.dto.ts
+++ b/dev/src/departments/dto/create-department.dto.ts
@@ -1,0 +1,28 @@
+import {
+  IsString,
+  IsOptional,
+  IsUUID,
+  MaxLength,
+  Matches,
+} from 'class-validator';
+
+export class CreateDepartmentDto {
+  @IsString()
+  @MaxLength(100)
+  name: string;
+
+  @IsString()
+  @MaxLength(20)
+  @Matches(/^[a-zA-Z0-9-]+$/, {
+    message: '部門代碼僅允許英數字和連字號',
+  })
+  code: string;
+
+  @IsOptional()
+  @IsUUID()
+  manager_id?: string;
+
+  @IsOptional()
+  @IsUUID()
+  parent_id?: string;
+}

--- a/dev/src/departments/dto/query-department.dto.ts
+++ b/dev/src/departments/dto/query-department.dto.ts
@@ -1,0 +1,8 @@
+import { IsOptional, IsString } from 'class-validator';
+import { PaginationDto } from '../../common/dto/pagination.dto';
+
+export class QueryDepartmentDto extends PaginationDto {
+  @IsOptional()
+  @IsString()
+  search?: string;
+}

--- a/dev/src/departments/dto/update-department.dto.ts
+++ b/dev/src/departments/dto/update-department.dto.ts
@@ -1,0 +1,30 @@
+import {
+  IsString,
+  IsOptional,
+  IsUUID,
+  MaxLength,
+  Matches,
+} from 'class-validator';
+
+export class UpdateDepartmentDto {
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  name?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(20)
+  @Matches(/^[a-zA-Z0-9-]+$/, {
+    message: '部門代碼僅允許英數字和連字號',
+  })
+  code?: string;
+
+  @IsOptional()
+  @IsUUID()
+  manager_id?: string;
+
+  @IsOptional()
+  @IsUUID()
+  parent_id?: string;
+}

--- a/dev/src/employees/dto/create-employee.dto.ts
+++ b/dev/src/employees/dto/create-employee.dto.ts
@@ -1,0 +1,48 @@
+import {
+  IsString,
+  IsEmail,
+  IsOptional,
+  IsUUID,
+  IsEnum,
+  IsDateString,
+  MaxLength,
+  MinLength,
+} from 'class-validator';
+
+export enum RoleEnum {
+  EMPLOYEE = 'employee',
+  MANAGER = 'manager',
+  ADMIN = 'admin',
+}
+
+export class CreateEmployeeDto {
+  @IsString()
+  @MaxLength(20)
+  employee_id: string;
+
+  @IsEmail()
+  @MaxLength(255)
+  email: string;
+
+  @IsString()
+  @MinLength(8)
+  @MaxLength(100)
+  password: string;
+
+  @IsString()
+  @MaxLength(100)
+  name: string;
+
+  @IsEnum(RoleEnum)
+  role: RoleEnum;
+
+  @IsUUID()
+  department_id: string;
+
+  @IsOptional()
+  @IsUUID()
+  manager_id?: string;
+
+  @IsDateString()
+  hire_date: string;
+}

--- a/dev/src/employees/dto/query-employee.dto.ts
+++ b/dev/src/employees/dto/query-employee.dto.ts
@@ -1,0 +1,20 @@
+import { IsOptional, IsString, IsUUID, IsEnum } from 'class-validator';
+import { PaginationDto } from '../../common/dto/pagination.dto';
+
+export class QueryEmployeeDto extends PaginationDto {
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @IsOptional()
+  @IsUUID()
+  department_id?: string;
+
+  @IsOptional()
+  @IsString()
+  role?: string;
+
+  @IsOptional()
+  @IsString()
+  status?: string;
+}

--- a/dev/src/employees/dto/reset-password.dto.ts
+++ b/dev/src/employees/dto/reset-password.dto.ts
@@ -1,0 +1,8 @@
+import { IsString, MinLength, MaxLength } from 'class-validator';
+
+export class ResetPasswordDto {
+  @IsString()
+  @MinLength(8)
+  @MaxLength(100)
+  new_password: string;
+}

--- a/dev/src/employees/dto/update-employee.dto.ts
+++ b/dev/src/employees/dto/update-employee.dto.ts
@@ -1,0 +1,42 @@
+import {
+  IsString,
+  IsOptional,
+  IsUUID,
+  IsEnum,
+  MaxLength,
+} from 'class-validator';
+
+export enum UpdateRoleEnum {
+  EMPLOYEE = 'employee',
+  MANAGER = 'manager',
+  ADMIN = 'admin',
+}
+
+export enum StatusEnum {
+  ACTIVE = 'active',
+  INACTIVE = 'inactive',
+  SUSPENDED = 'suspended',
+}
+
+export class UpdateEmployeeDto {
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  name?: string;
+
+  @IsOptional()
+  @IsEnum(UpdateRoleEnum)
+  role?: UpdateRoleEnum;
+
+  @IsOptional()
+  @IsUUID()
+  department_id?: string;
+
+  @IsOptional()
+  @IsUUID()
+  manager_id?: string;
+
+  @IsOptional()
+  @IsEnum(StatusEnum)
+  status?: StatusEnum;
+}

--- a/dev/src/employees/employees.controller.ts
+++ b/dev/src/employees/employees.controller.ts
@@ -1,0 +1,60 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Body,
+  Param,
+  Query,
+  UseGuards,
+  HttpCode,
+  HttpStatus,
+  ParseUUIDPipe,
+} from '@nestjs/common';
+import { EmployeesService } from './employees.service';
+import { CreateEmployeeDto } from './dto/create-employee.dto';
+import { UpdateEmployeeDto } from './dto/update-employee.dto';
+import { ResetPasswordDto } from './dto/reset-password.dto';
+import { QueryEmployeeDto } from './dto/query-employee.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+
+@Controller('employees')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles('ADMIN')
+export class EmployeesController {
+  constructor(private readonly employeesService: EmployeesService) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  async create(@Body() dto: CreateEmployeeDto) {
+    return this.employeesService.create(dto);
+  }
+
+  @Get()
+  async findAll(@Query() query: QueryEmployeeDto) {
+    return this.employeesService.findAll(query);
+  }
+
+  @Get(':id')
+  async findOne(@Param('id', ParseUUIDPipe) id: string) {
+    return this.employeesService.findOne(id);
+  }
+
+  @Put(':id')
+  async update(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: UpdateEmployeeDto,
+  ) {
+    return this.employeesService.update(id, dto);
+  }
+
+  @Put(':id/reset-password')
+  async resetPassword(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: ResetPasswordDto,
+  ) {
+    return this.employeesService.resetPassword(id, dto);
+  }
+}

--- a/dev/src/employees/employees.module.ts
+++ b/dev/src/employees/employees.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { EmployeesController } from './employees.controller';
+import { EmployeesService } from './employees.service';
+
+@Module({
+  controllers: [EmployeesController],
+  providers: [EmployeesService],
+  exports: [EmployeesService],
+})
+export class EmployeesModule {}

--- a/dev/src/employees/employees.service.ts
+++ b/dev/src/employees/employees.service.ts
@@ -1,0 +1,295 @@
+import {
+  Injectable,
+  HttpException,
+  HttpStatus,
+  NotFoundException,
+} from '@nestjs/common';
+import * as bcrypt from 'bcrypt';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateEmployeeDto } from './dto/create-employee.dto';
+import { UpdateEmployeeDto } from './dto/update-employee.dto';
+import { ResetPasswordDto } from './dto/reset-password.dto';
+import { QueryEmployeeDto } from './dto/query-employee.dto';
+import { PaginatedResult } from '../common/dto/pagination.dto';
+
+const BCRYPT_ROUNDS = 10;
+
+@Injectable()
+export class EmployeesService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * 建立員工
+   */
+  async create(dto: CreateEmployeeDto) {
+    // 檢查員工編號唯一
+    const existingEmployeeId = await this.prisma.user.findUnique({
+      where: { employeeId: dto.employee_id },
+    });
+    if (existingEmployeeId) {
+      throw new HttpException(
+        { code: 'DUPLICATE_EMPLOYEE_ID', message: '員工編號已存在' },
+        HttpStatus.CONFLICT,
+      );
+    }
+
+    // 檢查 email 唯一
+    const existingEmail = await this.prisma.user.findUnique({
+      where: { email: dto.email },
+    });
+    if (existingEmail) {
+      throw new HttpException(
+        { code: 'DUPLICATE_EMAIL', message: 'Email 已存在' },
+        HttpStatus.CONFLICT,
+      );
+    }
+
+    // 檢查部門是否存在
+    const department = await this.prisma.department.findUnique({
+      where: { id: dto.department_id },
+    });
+    if (!department) {
+      throw new HttpException(
+        { code: 'DEPARTMENT_NOT_FOUND', message: '部門不存在' },
+        HttpStatus.NOT_FOUND,
+      );
+    }
+
+    // 檢查 manager_id 必須是 role=MANAGER 的 User
+    if (dto.manager_id) {
+      const manager = await this.prisma.user.findUnique({
+        where: { id: dto.manager_id },
+        select: { id: true, role: true, status: true },
+      });
+      if (!manager) {
+        throw new HttpException(
+          { code: 'INVALID_INPUT', message: 'manager_id 對應的使用者不存在' },
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+      if (manager.role !== 'MANAGER') {
+        throw new HttpException(
+          { code: 'INVALID_INPUT', message: 'manager_id 必須是 manager 角色的使用者' },
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+    }
+
+    // Hash 密碼
+    const passwordHash = await bcrypt.hash(dto.password, BCRYPT_ROUNDS);
+
+    const user = await this.prisma.user.create({
+      data: {
+        employeeId: dto.employee_id,
+        email: dto.email,
+        passwordHash,
+        name: dto.name,
+        role: dto.role.toUpperCase() as 'EMPLOYEE' | 'MANAGER' | 'ADMIN',
+        departmentId: dto.department_id,
+        managerId: dto.manager_id,
+        hireDate: new Date(dto.hire_date),
+      },
+      include: {
+        department: { select: { id: true, name: true } },
+        manager: { select: { id: true, name: true, email: true } },
+      },
+    });
+
+    return this.formatEmployee(user);
+  }
+
+  /**
+   * 員工列表（含搜尋 + 篩選 + 分頁）
+   */
+  async findAll(query: QueryEmployeeDto): Promise<PaginatedResult<unknown>> {
+    const { search, department_id, role, status, page = 1, limit = 20 } = query;
+
+    const where: Record<string, unknown> = {};
+
+    if (search) {
+      where.OR = [
+        { name: { contains: search, mode: 'insensitive' } },
+        { email: { contains: search, mode: 'insensitive' } },
+        { employeeId: { contains: search, mode: 'insensitive' } },
+      ];
+    }
+
+    if (department_id) {
+      where.departmentId = department_id;
+    }
+
+    if (role) {
+      where.role = role.toUpperCase();
+    }
+
+    if (status) {
+      where.status = status.toUpperCase();
+    }
+
+    const [users, total] = await Promise.all([
+      this.prisma.user.findMany({
+        where,
+        include: {
+          department: { select: { id: true, name: true } },
+          manager: { select: { id: true, name: true, email: true } },
+        },
+        skip: (page - 1) * limit,
+        take: limit,
+        orderBy: { createdAt: 'desc' },
+      }),
+      this.prisma.user.count({ where }),
+    ]);
+
+    return {
+      data: users.map((user) => this.formatEmployee(user)),
+      meta: {
+        total,
+        page,
+        limit,
+        totalPages: Math.ceil(total / limit),
+      },
+    };
+  }
+
+  /**
+   * 員工詳情
+   */
+  async findOne(id: string) {
+    const user = await this.prisma.user.findUnique({
+      where: { id },
+      include: {
+        department: { select: { id: true, name: true } },
+        manager: { select: { id: true, name: true, email: true } },
+      },
+    });
+
+    if (!user) {
+      throw new NotFoundException({
+        code: 'NOT_FOUND',
+        message: '員工不存在',
+      });
+    }
+
+    return this.formatEmployee(user);
+  }
+
+  /**
+   * 更新員工（partial update，不含 password）
+   */
+  async update(id: string, dto: UpdateEmployeeDto) {
+    const existing = await this.prisma.user.findUnique({ where: { id } });
+    if (!existing) {
+      throw new NotFoundException({
+        code: 'NOT_FOUND',
+        message: '員工不存在',
+      });
+    }
+
+    // 檢查 department_id
+    if (dto.department_id) {
+      const department = await this.prisma.department.findUnique({
+        where: { id: dto.department_id },
+      });
+      if (!department) {
+        throw new HttpException(
+          { code: 'DEPARTMENT_NOT_FOUND', message: '部門不存在' },
+          HttpStatus.NOT_FOUND,
+        );
+      }
+    }
+
+    // 檢查 manager_id
+    if (dto.manager_id) {
+      const manager = await this.prisma.user.findUnique({
+        where: { id: dto.manager_id },
+        select: { id: true, role: true },
+      });
+      if (!manager) {
+        throw new HttpException(
+          { code: 'INVALID_INPUT', message: 'manager_id 對應的使用者不存在' },
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+      if (manager.role !== 'MANAGER') {
+        throw new HttpException(
+          { code: 'INVALID_INPUT', message: 'manager_id 必須是 manager 角色的使用者' },
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+    }
+
+    const updateData: Record<string, unknown> = {};
+    if (dto.name !== undefined) updateData.name = dto.name;
+    if (dto.role !== undefined) updateData.role = dto.role.toUpperCase();
+    if (dto.department_id !== undefined) updateData.departmentId = dto.department_id;
+    if (dto.manager_id !== undefined) updateData.managerId = dto.manager_id;
+    if (dto.status !== undefined) updateData.status = dto.status.toUpperCase();
+
+    const user = await this.prisma.user.update({
+      where: { id },
+      data: updateData,
+      include: {
+        department: { select: { id: true, name: true } },
+        manager: { select: { id: true, name: true, email: true } },
+      },
+    });
+
+    return this.formatEmployee(user);
+  }
+
+  /**
+   * 重設密碼
+   */
+  async resetPassword(id: string, dto: ResetPasswordDto) {
+    const existing = await this.prisma.user.findUnique({ where: { id } });
+    if (!existing) {
+      throw new NotFoundException({
+        code: 'NOT_FOUND',
+        message: '員工不存在',
+      });
+    }
+
+    const passwordHash = await bcrypt.hash(dto.new_password, BCRYPT_ROUNDS);
+    await this.prisma.user.update({
+      where: { id },
+      data: { passwordHash },
+    });
+
+    return { message: '密碼已重設' };
+  }
+
+  // ── Private Methods ──
+
+  /**
+   * 格式化員工輸出（排除敏感欄位）
+   */
+  private formatEmployee(user: {
+    id: string;
+    employeeId: string;
+    email: string;
+    name: string;
+    role: string;
+    status: string;
+    hireDate: Date;
+    createdAt: Date;
+    department?: { id: string; name: string } | null;
+    manager?: { id: string; name: string; email: string } | null;
+  }) {
+    return {
+      id: user.id,
+      employee_id: user.employeeId,
+      email: user.email,
+      name: user.name,
+      role: user.role.toLowerCase(),
+      department: user.department
+        ? { id: user.department.id, name: user.department.name }
+        : null,
+      manager: user.manager
+        ? { id: user.manager.id, name: user.manager.name, email: user.manager.email }
+        : null,
+      hire_date: user.hireDate.toISOString().split('T')[0],
+      status: user.status.toLowerCase(),
+      created_at: user.createdAt.toISOString(),
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- Department CRUD 模組（含階層結構，最多 3 層）
- Employee CRUD 模組（含角色權限控管）
- Admin 重設密碼功能
- 完整驗證：唯一 employee_id/email、部門代碼格式
- Business rules：有員工的部門不可刪、manager_id 必須是 MANAGER

## Changes
- `dev/src/departments/` - 部門管理模組（controller, service, DTOs）
- `dev/src/employees/` - 員工管理模組（controller, service, DTOs）
- `dev/src/app.module.ts` - 註冊新模組
- `dev/__tests__/` - 單元測試

## 驗收標準檢查
- [x] POST /api/v1/departments — 建立部門（admin only）
- [x] GET /api/v1/departments — 部門列表（搜尋、分頁）
- [x] GET /api/v1/departments/:id — 部門詳情含 members
- [x] PUT /api/v1/departments/:id — 更新部門
- [x] DELETE /api/v1/departments/:id — 刪除部門（有員工時 422）
- [x] POST /api/v1/employees — 建立員工
- [x] GET /api/v1/employees — 員工列表（搜尋、篩選、分頁）
- [x] PUT /api/v1/employees/:id — 更新員工
- [x] PUT /api/v1/employees/:id/reset-password — 重設密碼

## Test plan
- [x] departments.service.spec.ts 單元測試
- [x] employees.service.spec.ts 單元測試
- [ ] 待 QA E2E 測試驗證

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)