### PR TITLE
[Feature] F-001: 打卡（上班/下班）

### DIFF
--- a/dev/__tests__/clock/clock.controller.spec.ts
+++ b/dev/__tests__/clock/clock.controller.spec.ts
@@ -1,0 +1,126 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ClockController } from '../../src/clock/clock.controller';
+import { ClockService } from '../../src/clock/clock.service';
+
+describe('ClockController', () => {
+  let controller: ClockController;
+  let clockService: {
+    clockIn: jest.Mock;
+    clockOut: jest.Mock;
+    getToday: jest.Mock;
+    getRecords: jest.Mock;
+  };
+
+  const mockUser = {
+    userId: 'user-uuid-1',
+    role: 'EMPLOYEE',
+    departmentId: 'dept-uuid-1',
+  };
+
+  beforeEach(async () => {
+    clockService = {
+      clockIn: jest.fn(),
+      clockOut: jest.fn(),
+      getToday: jest.fn(),
+      getRecords: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ClockController],
+      providers: [
+        { provide: ClockService, useValue: clockService },
+      ],
+    }).compile();
+
+    controller = module.get<ClockController>(ClockController);
+  });
+
+  describe('clockIn', () => {
+    it('should call clockService.clockIn with userId and dto', async () => {
+      const dto = { note: '外出開會' };
+      const expected = {
+        id: 'record-uuid-1',
+        user_id: 'user-uuid-1',
+        date: '2026-04-07',
+        clock_in: '2026-04-07T01:00:00.000Z',
+        clock_out: null,
+        status: 'normal',
+        note: '外出開會',
+        created_at: '2026-04-07T01:00:00.000Z',
+      };
+
+      clockService.clockIn.mockResolvedValue(expected);
+
+      const result = await controller.clockIn(mockUser, dto);
+
+      expect(clockService.clockIn).toHaveBeenCalledWith('user-uuid-1', dto);
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('clockOut', () => {
+    it('should call clockService.clockOut with userId and dto', async () => {
+      const dto = {};
+      const expected = {
+        id: 'record-uuid-1',
+        user_id: 'user-uuid-1',
+        date: '2026-04-07',
+        clock_in: '2026-04-07T01:00:00.000Z',
+        clock_out: '2026-04-07T10:00:00.000Z',
+        status: 'normal',
+        note: null,
+        created_at: '2026-04-07T01:00:00.000Z',
+        updated_at: '2026-04-07T10:00:00.000Z',
+      };
+
+      clockService.clockOut.mockResolvedValue(expected);
+
+      const result = await controller.clockOut(mockUser, dto);
+
+      expect(clockService.clockOut).toHaveBeenCalledWith('user-uuid-1', dto);
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('getToday', () => {
+    it('should call clockService.getToday with userId', async () => {
+      const expected = {
+        id: 'record-uuid-1',
+        date: '2026-04-07',
+        clock_in: '2026-04-07T01:00:00.000Z',
+        clock_out: null,
+        status: 'late',
+        note: null,
+      };
+
+      clockService.getToday.mockResolvedValue(expected);
+
+      const result = await controller.getToday(mockUser);
+
+      expect(clockService.getToday).toHaveBeenCalledWith('user-uuid-1');
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('getRecords', () => {
+    it('should call clockService.getRecords with userId and query', async () => {
+      const query = {
+        start_date: '2026-03-01',
+        end_date: '2026-03-31',
+        page: 1,
+        limit: 20,
+      };
+      const expected = {
+        data: [],
+        meta: { total: 0, page: 1, limit: 20, totalPages: 0 },
+      };
+
+      clockService.getRecords.mockResolvedValue(expected);
+
+      const result = await controller.getRecords(mockUser, query);
+
+      expect(clockService.getRecords).toHaveBeenCalledWith('user-uuid-1', query);
+      expect(result).toEqual(expected);
+    });
+  });
+});

--- a/dev/__tests__/clock/clock.service.spec.ts
+++ b/dev/__tests__/clock/clock.service.spec.ts
@@ -1,0 +1,584 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HttpException, HttpStatus } from '@nestjs/common';
+import { ClockService } from '../../src/clock/clock.service';
+import { PrismaService } from '../../src/prisma/prisma.service';
+
+describe('ClockService', () => {
+  let service: ClockService;
+  let prisma: {
+    clockRecord: {
+      findUnique: jest.Mock;
+      findMany: jest.Mock;
+      create: jest.Mock;
+      update: jest.Mock;
+      count: jest.Mock;
+    };
+  };
+
+  const mockUserId = 'user-uuid-1';
+
+  /**
+   * 建立指定 UTC+8 時間的 Date 物件
+   * 例如 makeUTC8Date(2026, 4, 7, 8, 55) => UTC+8 08:55 => UTC 00:55
+   */
+  function makeUTC8Date(
+    year: number,
+    month: number,
+    day: number,
+    hour: number,
+    minute: number,
+  ): Date {
+    const utcHour = hour - 8;
+    return new Date(Date.UTC(year, month - 1, day, utcHour, minute, 0, 0));
+  }
+
+  /**
+   * 建立日期物件（UTC 00:00:00），用於 date 欄位
+   */
+  function makeDateOnly(year: number, month: number, day: number): Date {
+    return new Date(Date.UTC(year, month - 1, day, 0, 0, 0, 0));
+  }
+
+  beforeEach(async () => {
+    prisma = {
+      clockRecord: {
+        findUnique: jest.fn(),
+        findMany: jest.fn(),
+        create: jest.fn(),
+        update: jest.fn(),
+        count: jest.fn(),
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ClockService,
+        { provide: PrismaService, useValue: prisma },
+      ],
+    }).compile();
+
+    service = module.get<ClockService>(ClockService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  describe('clockIn', () => {
+    it('should create a clock-in record successfully when no record exists today', async () => {
+      // UTC+8 08:55 => UTC 00:55
+      const now = makeUTC8Date(2026, 4, 7, 8, 55);
+      jest.spyOn(global, 'Date').mockImplementation(
+        (((...args: unknown[]) => {
+          if (args.length === 0) return now;
+          // @ts-expect-error - date constructor overloads
+          return new (Function.prototype.bind.apply(OriginalDate, [null, ...args]))();
+        }) as unknown) as DateConstructor,
+      );
+      const OriginalDate = global.Date;
+      // Restore Date for internal usage
+      jest.restoreAllMocks();
+
+      // Use a simpler approach: mock Date.now()
+      jest.spyOn(Date, 'now').mockReturnValue(now.getTime());
+
+      prisma.clockRecord.findUnique.mockResolvedValue(null);
+
+      const mockRecord = {
+        id: 'record-uuid-1',
+        userId: mockUserId,
+        date: makeDateOnly(2026, 4, 7),
+        clockIn: now,
+        clockOut: null,
+        status: 'NORMAL',
+        note: null,
+        createdAt: now,
+        updatedAt: now,
+      };
+      prisma.clockRecord.create.mockResolvedValue(mockRecord);
+
+      const result = await service.clockIn(mockUserId, {});
+
+      expect(prisma.clockRecord.findUnique).toHaveBeenCalled();
+      expect(prisma.clockRecord.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          userId: mockUserId,
+          status: 'NORMAL',
+          note: null,
+        }),
+      });
+      expect(result.id).toBe('record-uuid-1');
+      expect(result.user_id).toBe(mockUserId);
+      expect(result.clock_out).toBeNull();
+      expect(result.status).toBe('normal');
+    });
+
+    it('should throw ALREADY_CLOCKED_IN when a record exists for today', async () => {
+      const now = makeUTC8Date(2026, 4, 7, 9, 30);
+      jest.spyOn(Date, 'now').mockReturnValue(now.getTime());
+
+      prisma.clockRecord.findUnique.mockResolvedValue({
+        id: 'existing-record',
+        userId: mockUserId,
+        date: makeDateOnly(2026, 4, 7),
+        clockIn: makeUTC8Date(2026, 4, 7, 9, 0),
+        clockOut: null,
+        status: 'NORMAL',
+      });
+
+      await expect(service.clockIn(mockUserId, {})).rejects.toThrow(HttpException);
+
+      try {
+        await service.clockIn(mockUserId, {});
+      } catch (e) {
+        const exception = e as HttpException;
+        expect(exception.getStatus()).toBe(HttpStatus.CONFLICT);
+        const response = exception.getResponse() as Record<string, string>;
+        expect(response.code).toBe('ALREADY_CLOCKED_IN');
+      }
+    });
+
+    it('should set status to LATE when clocking in after 09:00 UTC+8', async () => {
+      // UTC+8 09:05 => UTC 01:05
+      const now = makeUTC8Date(2026, 4, 7, 9, 5);
+      jest.spyOn(Date, 'now').mockReturnValue(now.getTime());
+
+      prisma.clockRecord.findUnique.mockResolvedValue(null);
+
+      const mockRecord = {
+        id: 'record-uuid-2',
+        userId: mockUserId,
+        date: makeDateOnly(2026, 4, 7),
+        clockIn: now,
+        clockOut: null,
+        status: 'LATE',
+        note: null,
+        createdAt: now,
+        updatedAt: now,
+      };
+      prisma.clockRecord.create.mockResolvedValue(mockRecord);
+
+      const result = await service.clockIn(mockUserId, {});
+
+      expect(prisma.clockRecord.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          status: 'LATE',
+        }),
+      });
+      expect(result.status).toBe('late');
+    });
+
+    it('should set status to NORMAL when clocking in at exactly 09:00 UTC+8', async () => {
+      const now = makeUTC8Date(2026, 4, 7, 9, 0);
+      jest.spyOn(Date, 'now').mockReturnValue(now.getTime());
+
+      prisma.clockRecord.findUnique.mockResolvedValue(null);
+
+      const mockRecord = {
+        id: 'record-uuid-3',
+        userId: mockUserId,
+        date: makeDateOnly(2026, 4, 7),
+        clockIn: now,
+        clockOut: null,
+        status: 'NORMAL',
+        note: null,
+        createdAt: now,
+        updatedAt: now,
+      };
+      prisma.clockRecord.create.mockResolvedValue(mockRecord);
+
+      const result = await service.clockIn(mockUserId, {});
+
+      expect(prisma.clockRecord.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          status: 'NORMAL',
+        }),
+      });
+      expect(result.status).toBe('normal');
+    });
+
+    it('should save note when provided', async () => {
+      const now = makeUTC8Date(2026, 4, 7, 9, 10);
+      jest.spyOn(Date, 'now').mockReturnValue(now.getTime());
+
+      prisma.clockRecord.findUnique.mockResolvedValue(null);
+
+      const mockRecord = {
+        id: 'record-uuid-4',
+        userId: mockUserId,
+        date: makeDateOnly(2026, 4, 7),
+        clockIn: now,
+        clockOut: null,
+        status: 'LATE',
+        note: '外出開會晚到',
+        createdAt: now,
+        updatedAt: now,
+      };
+      prisma.clockRecord.create.mockResolvedValue(mockRecord);
+
+      const result = await service.clockIn(mockUserId, {
+        note: '外出開會晚到',
+      });
+
+      expect(prisma.clockRecord.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          note: '外出開會晚到',
+        }),
+      });
+      expect(result.note).toBe('外出開會晚到');
+    });
+  });
+
+  describe('clockOut', () => {
+    it('should update clock-out record successfully', async () => {
+      const clockInTime = makeUTC8Date(2026, 4, 7, 8, 55);
+      const clockOutTime = makeUTC8Date(2026, 4, 7, 18, 30);
+      jest.spyOn(Date, 'now').mockReturnValue(clockOutTime.getTime());
+
+      const existingRecord = {
+        id: 'record-uuid-1',
+        userId: mockUserId,
+        date: makeDateOnly(2026, 4, 7),
+        clockIn: clockInTime,
+        clockOut: null,
+        status: 'NORMAL',
+        note: null,
+        createdAt: clockInTime,
+        updatedAt: clockInTime,
+      };
+
+      // findUnique for today returns open record
+      prisma.clockRecord.findUnique.mockResolvedValue(existingRecord);
+
+      const updatedRecord = {
+        ...existingRecord,
+        clockOut: clockOutTime,
+        status: 'NORMAL',
+        updatedAt: clockOutTime,
+      };
+      prisma.clockRecord.update.mockResolvedValue(updatedRecord);
+
+      const result = await service.clockOut(mockUserId, {});
+
+      expect(prisma.clockRecord.update).toHaveBeenCalledWith({
+        where: { id: 'record-uuid-1' },
+        data: expect.objectContaining({
+          status: 'NORMAL',
+        }),
+      });
+      expect(result.clock_out).toBeTruthy();
+      expect(result.status).toBe('normal');
+    });
+
+    it('should set status to EARLY_LEAVE when clocking out before 18:00 UTC+8', async () => {
+      const clockInTime = makeUTC8Date(2026, 4, 7, 8, 50);
+      const clockOutTime = makeUTC8Date(2026, 4, 7, 17, 0);
+      jest.spyOn(Date, 'now').mockReturnValue(clockOutTime.getTime());
+
+      const existingRecord = {
+        id: 'record-uuid-1',
+        userId: mockUserId,
+        date: makeDateOnly(2026, 4, 7),
+        clockIn: clockInTime,
+        clockOut: null,
+        status: 'NORMAL',
+        note: null,
+        createdAt: clockInTime,
+        updatedAt: clockInTime,
+      };
+
+      prisma.clockRecord.findUnique.mockResolvedValue(existingRecord);
+
+      const updatedRecord = {
+        ...existingRecord,
+        clockOut: clockOutTime,
+        status: 'EARLY_LEAVE',
+        updatedAt: clockOutTime,
+      };
+      prisma.clockRecord.update.mockResolvedValue(updatedRecord);
+
+      const result = await service.clockOut(mockUserId, {});
+
+      expect(prisma.clockRecord.update).toHaveBeenCalledWith({
+        where: { id: 'record-uuid-1' },
+        data: expect.objectContaining({
+          status: 'EARLY_LEAVE',
+        }),
+      });
+      expect(result.status).toBe('early_leave');
+    });
+
+    it('should keep LATE status when both late and early leave', async () => {
+      const clockInTime = makeUTC8Date(2026, 4, 7, 9, 30);
+      const clockOutTime = makeUTC8Date(2026, 4, 7, 17, 0);
+      jest.spyOn(Date, 'now').mockReturnValue(clockOutTime.getTime());
+
+      const existingRecord = {
+        id: 'record-uuid-1',
+        userId: mockUserId,
+        date: makeDateOnly(2026, 4, 7),
+        clockIn: clockInTime,
+        clockOut: null,
+        status: 'LATE',
+        note: null,
+        createdAt: clockInTime,
+        updatedAt: clockInTime,
+      };
+
+      prisma.clockRecord.findUnique.mockResolvedValue(existingRecord);
+
+      const updatedRecord = {
+        ...existingRecord,
+        clockOut: clockOutTime,
+        status: 'LATE',
+        updatedAt: clockOutTime,
+      };
+      prisma.clockRecord.update.mockResolvedValue(updatedRecord);
+
+      const result = await service.clockOut(mockUserId, {});
+
+      expect(prisma.clockRecord.update).toHaveBeenCalledWith({
+        where: { id: 'record-uuid-1' },
+        data: expect.objectContaining({
+          status: 'LATE',
+        }),
+      });
+      expect(result.status).toBe('late');
+    });
+
+    it('should throw NOT_CLOCKED_IN when no clock-in record exists', async () => {
+      const now = makeUTC8Date(2026, 4, 7, 18, 0);
+      jest.spyOn(Date, 'now').mockReturnValue(now.getTime());
+
+      // No record for today or yesterday
+      prisma.clockRecord.findUnique.mockResolvedValue(null);
+
+      await expect(service.clockOut(mockUserId, {})).rejects.toThrow(HttpException);
+
+      try {
+        await service.clockOut(mockUserId, {});
+      } catch (e) {
+        const exception = e as HttpException;
+        expect(exception.getStatus()).toBe(HttpStatus.UNPROCESSABLE_ENTITY);
+        const response = exception.getResponse() as Record<string, string>;
+        expect(response.code).toBe('NOT_CLOCKED_IN');
+      }
+    });
+
+    it('should throw ALREADY_CLOCKED_OUT when clock-out already exists', async () => {
+      const clockInTime = makeUTC8Date(2026, 4, 7, 8, 55);
+      const clockOutTime = makeUTC8Date(2026, 4, 7, 18, 5);
+      const now = makeUTC8Date(2026, 4, 7, 19, 0);
+      jest.spyOn(Date, 'now').mockReturnValue(now.getTime());
+
+      const existingRecord = {
+        id: 'record-uuid-1',
+        userId: mockUserId,
+        date: makeDateOnly(2026, 4, 7),
+        clockIn: clockInTime,
+        clockOut: clockOutTime,
+        status: 'NORMAL',
+        note: null,
+        createdAt: clockInTime,
+        updatedAt: clockOutTime,
+      };
+
+      // Today's record exists but has clock_out (findUnique returns it)
+      prisma.clockRecord.findUnique.mockResolvedValue(existingRecord);
+
+      await expect(service.clockOut(mockUserId, {})).rejects.toThrow(HttpException);
+
+      try {
+        await service.clockOut(mockUserId, {});
+      } catch (e) {
+        const exception = e as HttpException;
+        expect(exception.getStatus()).toBe(HttpStatus.CONFLICT);
+        const response = exception.getResponse() as Record<string, string>;
+        expect(response.code).toBe('ALREADY_CLOCKED_OUT');
+      }
+    });
+
+    it('should handle cross-day clock-out (past midnight)', async () => {
+      const clockInTime = makeUTC8Date(2026, 4, 7, 22, 0);
+      // Next day 01:30 UTC+8
+      const clockOutTime = makeUTC8Date(2026, 4, 8, 1, 30);
+      jest.spyOn(Date, 'now').mockReturnValue(clockOutTime.getTime());
+
+      const existingRecord = {
+        id: 'record-uuid-1',
+        userId: mockUserId,
+        date: makeDateOnly(2026, 4, 7),
+        clockIn: clockInTime,
+        clockOut: null,
+        status: 'NORMAL',
+        note: null,
+        createdAt: clockInTime,
+        updatedAt: clockInTime,
+      };
+
+      // First call (today 4/8) returns null, second call (yesterday 4/7) returns open record
+      prisma.clockRecord.findUnique
+        .mockResolvedValueOnce(null) // today (4/8) no record
+        .mockResolvedValueOnce(existingRecord); // yesterday (4/7) open record
+
+      const updatedRecord = {
+        ...existingRecord,
+        clockOut: clockOutTime,
+        status: 'NORMAL',
+        updatedAt: clockOutTime,
+      };
+      prisma.clockRecord.update.mockResolvedValue(updatedRecord);
+
+      const result = await service.clockOut(mockUserId, {});
+
+      // date should still be 2026-04-07 (original clock-in date)
+      expect(result.date).toBe('2026-04-07');
+      expect(result.clock_out).toBeTruthy();
+    });
+  });
+
+  describe('getToday', () => {
+    it('should return today clock record when exists', async () => {
+      const clockInTime = makeUTC8Date(2026, 4, 7, 9, 5);
+      const now = makeUTC8Date(2026, 4, 7, 12, 0);
+      jest.spyOn(Date, 'now').mockReturnValue(now.getTime());
+
+      const record = {
+        id: 'record-uuid-1',
+        userId: mockUserId,
+        date: makeDateOnly(2026, 4, 7),
+        clockIn: clockInTime,
+        clockOut: null,
+        status: 'LATE',
+        note: null,
+        createdAt: clockInTime,
+        updatedAt: clockInTime,
+      };
+
+      prisma.clockRecord.findUnique.mockResolvedValue(record);
+
+      const result = await service.getToday(mockUserId);
+
+      expect(result.id).toBe('record-uuid-1');
+      expect(result.clock_in).toBeTruthy();
+      expect(result.clock_out).toBeNull();
+      expect(result.status).toBe('late');
+    });
+
+    it('should return null fields when no record exists today', async () => {
+      const now = makeUTC8Date(2026, 4, 7, 8, 0);
+      jest.spyOn(Date, 'now').mockReturnValue(now.getTime());
+
+      prisma.clockRecord.findUnique.mockResolvedValue(null);
+
+      const result = await service.getToday(mockUserId);
+
+      expect(result.id).toBeNull();
+      expect(result.date).toBe('2026-04-07');
+      expect(result.clock_in).toBeNull();
+      expect(result.clock_out).toBeNull();
+      expect(result.status).toBeNull();
+      expect(result.note).toBeNull();
+    });
+  });
+
+  describe('getRecords', () => {
+    it('should return paginated records', async () => {
+      const records = [
+        {
+          id: 'record-1',
+          userId: mockUserId,
+          date: makeDateOnly(2026, 3, 15),
+          clockIn: makeUTC8Date(2026, 3, 15, 8, 50),
+          clockOut: makeUTC8Date(2026, 3, 15, 18, 10),
+          status: 'NORMAL',
+          note: null,
+          createdAt: makeUTC8Date(2026, 3, 15, 8, 50),
+          updatedAt: makeUTC8Date(2026, 3, 15, 18, 10),
+        },
+      ];
+
+      prisma.clockRecord.findMany.mockResolvedValue(records);
+      prisma.clockRecord.count.mockResolvedValue(22);
+
+      const result = await service.getRecords(mockUserId, {
+        start_date: '2026-03-01',
+        end_date: '2026-03-31',
+        page: 1,
+        limit: 20,
+      });
+
+      expect(result.data).toHaveLength(1);
+      expect(result.meta.total).toBe(22);
+      expect(result.meta.page).toBe(1);
+      expect(result.meta.limit).toBe(20);
+      expect(result.meta.totalPages).toBe(2);
+    });
+
+    it('should throw INVALID_INPUT when date range exceeds 90 days', async () => {
+      await expect(
+        service.getRecords(mockUserId, {
+          start_date: '2026-01-01',
+          end_date: '2026-06-30',
+          page: 1,
+          limit: 20,
+        }),
+      ).rejects.toThrow(HttpException);
+
+      try {
+        await service.getRecords(mockUserId, {
+          start_date: '2026-01-01',
+          end_date: '2026-06-30',
+          page: 1,
+          limit: 20,
+        });
+      } catch (e) {
+        const exception = e as HttpException;
+        expect(exception.getStatus()).toBe(HttpStatus.BAD_REQUEST);
+        const response = exception.getResponse() as Record<string, string>;
+        expect(response.code).toBe('INVALID_INPUT');
+        expect(response.message).toContain('90');
+      }
+    });
+
+    it('should throw INVALID_INPUT when end_date is before start_date', async () => {
+      await expect(
+        service.getRecords(mockUserId, {
+          start_date: '2026-04-10',
+          end_date: '2026-04-01',
+          page: 1,
+          limit: 20,
+        }),
+      ).rejects.toThrow(HttpException);
+
+      try {
+        await service.getRecords(mockUserId, {
+          start_date: '2026-04-10',
+          end_date: '2026-04-01',
+          page: 1,
+          limit: 20,
+        });
+      } catch (e) {
+        const exception = e as HttpException;
+        expect(exception.getStatus()).toBe(HttpStatus.BAD_REQUEST);
+        const response = exception.getResponse() as Record<string, string>;
+        expect(response.code).toBe('INVALID_INPUT');
+      }
+    });
+
+    it('should use default page=1 and limit=20 when not specified', async () => {
+      prisma.clockRecord.findMany.mockResolvedValue([]);
+      prisma.clockRecord.count.mockResolvedValue(0);
+
+      const result = await service.getRecords(mockUserId, {
+        start_date: '2026-04-01',
+        end_date: '2026-04-07',
+      });
+
+      expect(result.meta.page).toBe(1);
+      expect(result.meta.limit).toBe(20);
+      expect(result.meta.totalPages).toBe(0);
+    });
+  });
+});

--- a/dev/src/app.module.ts
+++ b/dev/src/app.module.ts
@@ -4,6 +4,7 @@ import { PrismaModule } from './prisma/prisma.module';
 import { AuthModule } from './auth/auth.module';
 import { DepartmentsModule } from './departments/departments.module';
 import { EmployeesModule } from './employees/employees.module';
+import { ClockModule } from './clock/clock.module';
 
 @Module({
   imports: [
@@ -15,6 +16,7 @@ import { EmployeesModule } from './employees/employees.module';
     AuthModule,
     DepartmentsModule,
     EmployeesModule,
+    ClockModule,
   ],
 })
 export class AppModule {}

--- a/dev/src/clock/clock.controller.ts
+++ b/dev/src/clock/clock.controller.ts
@@ -1,0 +1,53 @@
+import {
+  Controller,
+  Post,
+  Get,
+  Body,
+  Query,
+  UseGuards,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { ClockService } from './clock.service';
+import { ClockInDto } from './dto/clock-in.dto';
+import { ClockOutDto } from './dto/clock-out.dto';
+import { QueryClockRecordsDto } from './dto/query-clock-records.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { CurrentUser, CurrentUserData } from '../auth/decorators/current-user.decorator';
+
+@Controller('clock')
+@UseGuards(JwtAuthGuard)
+export class ClockController {
+  constructor(private readonly clockService: ClockService) {}
+
+  @Post('in')
+  @HttpCode(HttpStatus.CREATED)
+  async clockIn(
+    @CurrentUser() user: CurrentUserData,
+    @Body() dto: ClockInDto,
+  ) {
+    return this.clockService.clockIn(user.userId, dto);
+  }
+
+  @Post('out')
+  @HttpCode(HttpStatus.OK)
+  async clockOut(
+    @CurrentUser() user: CurrentUserData,
+    @Body() dto: ClockOutDto,
+  ) {
+    return this.clockService.clockOut(user.userId, dto);
+  }
+
+  @Get('today')
+  async getToday(@CurrentUser() user: CurrentUserData) {
+    return this.clockService.getToday(user.userId);
+  }
+
+  @Get('records')
+  async getRecords(
+    @CurrentUser() user: CurrentUserData,
+    @Query() query: QueryClockRecordsDto,
+  ) {
+    return this.clockService.getRecords(user.userId, query);
+  }
+}

--- a/dev/src/clock/clock.module.ts
+++ b/dev/src/clock/clock.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ClockController } from './clock.controller';
+import { ClockService } from './clock.service';
+
+@Module({
+  controllers: [ClockController],
+  providers: [ClockService],
+  exports: [ClockService],
+})
+export class ClockModule {}

--- a/dev/src/clock/clock.service.ts
+++ b/dev/src/clock/clock.service.ts
@@ -1,0 +1,376 @@
+import {
+  Injectable,
+  HttpException,
+  HttpStatus,
+} from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { ClockInDto } from './dto/clock-in.dto';
+import { ClockOutDto } from './dto/clock-out.dto';
+import { QueryClockRecordsDto } from './dto/query-clock-records.dto';
+import { PaginatedResult } from '../common/dto/pagination.dto';
+
+/** UTC+8 offset in milliseconds */
+const UTC8_OFFSET_MS = 8 * 60 * 60 * 1000;
+
+/** 上班時間 09:00 UTC+8 */
+const WORK_START_HOUR = 9;
+
+/** 下班時間 18:00 UTC+8 */
+const WORK_END_HOUR = 18;
+
+/** 查詢日期範圍上限（天） */
+const MAX_DATE_RANGE_DAYS = 90;
+
+@Injectable()
+export class ClockService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * 上班打卡
+   */
+  async clockIn(userId: string, dto: ClockInDto) {
+    const now = new Date();
+    const todayDate = this.getTodayDateUTC8(now);
+
+    // 檢查今日是否已有打卡紀錄
+    const existing = await this.prisma.clockRecord.findUnique({
+      where: {
+        userId_date: {
+          userId,
+          date: todayDate,
+        },
+      },
+    });
+
+    if (existing) {
+      throw new HttpException(
+        {
+          code: 'ALREADY_CLOCKED_IN',
+          message: '今日已打過上班卡',
+        },
+        HttpStatus.CONFLICT,
+      );
+    }
+
+    // 計算 status
+    const status = this.calculateClockInStatus(now);
+
+    const record = await this.prisma.clockRecord.create({
+      data: {
+        userId,
+        date: todayDate,
+        clockIn: now,
+        status,
+        note: dto.note || null,
+      },
+    });
+
+    return this.formatClockRecord(record);
+  }
+
+  /**
+   * 下班打卡
+   */
+  async clockOut(userId: string, dto: ClockOutDto) {
+    const now = new Date();
+
+    // 找到今日（或跨日）的打卡紀錄：取最近一筆尚未打下班卡的紀錄
+    const record = await this.findOpenClockRecord(userId, now);
+
+    if (!record) {
+      // 檢查是否已經打過下班卡
+      const todayDate = this.getTodayDateUTC8(now);
+      const todayRecord = await this.prisma.clockRecord.findUnique({
+        where: {
+          userId_date: {
+            userId,
+            date: todayDate,
+          },
+        },
+      });
+
+      if (todayRecord && todayRecord.clockOut) {
+        throw new HttpException(
+          {
+            code: 'ALREADY_CLOCKED_OUT',
+            message: '今日已打過下班卡',
+          },
+          HttpStatus.CONFLICT,
+        );
+      }
+
+      throw new HttpException(
+        {
+          code: 'NOT_CLOCKED_IN',
+          message: '今日尚未打上班卡',
+        },
+        HttpStatus.UNPROCESSABLE_ENTITY,
+      );
+    }
+
+    // 更新備註：若有提供新備註就附加，否則保留原本的
+    const note = dto.note || record.note;
+
+    // 計算最終 status（考慮遲到和早退）
+    const status = this.calculateFinalStatus(record.clockIn, now);
+
+    const updated = await this.prisma.clockRecord.update({
+      where: { id: record.id },
+      data: {
+        clockOut: now,
+        status,
+        note,
+      },
+    });
+
+    return this.formatClockRecord(updated);
+  }
+
+  /**
+   * 查詢今日打卡狀態
+   */
+  async getToday(userId: string) {
+    const now = new Date();
+    const todayDate = this.getTodayDateUTC8(now);
+
+    const record = await this.prisma.clockRecord.findUnique({
+      where: {
+        userId_date: {
+          userId,
+          date: todayDate,
+        },
+      },
+    });
+
+    if (!record) {
+      const dateStr = todayDate.toISOString().split('T')[0];
+      return {
+        id: null,
+        date: dateStr,
+        clock_in: null,
+        clock_out: null,
+        status: null,
+        note: null,
+      };
+    }
+
+    return {
+      id: record.id,
+      date: record.date.toISOString().split('T')[0],
+      clock_in: record.clockIn.toISOString(),
+      clock_out: record.clockOut ? record.clockOut.toISOString() : null,
+      status: record.status.toLowerCase(),
+      note: record.note,
+    };
+  }
+
+  /**
+   * 查詢打卡紀錄（分頁）
+   */
+  async getRecords(
+    userId: string,
+    query: QueryClockRecordsDto,
+  ): Promise<PaginatedResult<unknown>> {
+    const { start_date, end_date, page = 1, limit = 20 } = query;
+
+    // 驗證日期格式
+    const startDate = new Date(start_date);
+    const endDate = new Date(end_date);
+
+    if (isNaN(startDate.getTime()) || isNaN(endDate.getTime())) {
+      throw new HttpException(
+        {
+          code: 'INVALID_INPUT',
+          message: '日期格式錯誤，請使用 YYYY-MM-DD 格式',
+        },
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    if (endDate < startDate) {
+      throw new HttpException(
+        {
+          code: 'INVALID_INPUT',
+          message: 'end_date 不可早於 start_date',
+        },
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    // 檢查日期範圍不超過 90 天
+    const diffMs = endDate.getTime() - startDate.getTime();
+    const diffDays = diffMs / (1000 * 60 * 60 * 24);
+    if (diffDays > MAX_DATE_RANGE_DAYS) {
+      throw new HttpException(
+        {
+          code: 'INVALID_INPUT',
+          message: `查詢日期範圍不可超過 ${MAX_DATE_RANGE_DAYS} 天`,
+        },
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    // 查詢結束日期需要加一天才能包含 end_date 當天
+    const endDateInclusive = new Date(endDate);
+    endDateInclusive.setDate(endDateInclusive.getDate() + 1);
+
+    const where = {
+      userId,
+      date: {
+        gte: startDate,
+        lt: endDateInclusive,
+      },
+    };
+
+    const [records, total] = await Promise.all([
+      this.prisma.clockRecord.findMany({
+        where,
+        skip: (page - 1) * limit,
+        take: limit,
+        orderBy: { date: 'desc' },
+      }),
+      this.prisma.clockRecord.count({ where }),
+    ]);
+
+    return {
+      data: records.map((record) => ({
+        id: record.id,
+        date: record.date.toISOString().split('T')[0],
+        clock_in: record.clockIn.toISOString(),
+        clock_out: record.clockOut ? record.clockOut.toISOString() : null,
+        status: record.status.toLowerCase(),
+        note: record.note,
+      })),
+      meta: {
+        total,
+        page,
+        limit,
+        totalPages: Math.ceil(total / limit),
+      },
+    };
+  }
+
+  // ── Private Methods ──
+
+  /**
+   * 取得今日日期（UTC+8 時區），回傳 UTC 的 Date 物件（時間部分為 00:00:00）
+   */
+  private getTodayDateUTC8(now: Date): Date {
+    const utc8Time = new Date(now.getTime() + UTC8_OFFSET_MS);
+    const dateStr = utc8Time.toISOString().split('T')[0];
+    return new Date(dateStr + 'T00:00:00.000Z');
+  }
+
+  /**
+   * 根據上班打卡時間計算 status
+   */
+  private calculateClockInStatus(clockIn: Date): 'NORMAL' | 'LATE' {
+    const utc8Time = new Date(clockIn.getTime() + UTC8_OFFSET_MS);
+    const hour = utc8Time.getUTCHours();
+    const minute = utc8Time.getUTCMinutes();
+
+    if (hour > WORK_START_HOUR || (hour === WORK_START_HOUR && minute > 0)) {
+      return 'LATE';
+    }
+    return 'NORMAL';
+  }
+
+  /**
+   * 計算最終 status（打下班卡時，綜合考慮遲到和早退）
+   * 規則：遲到優先（以較嚴重的為準）
+   */
+  private calculateFinalStatus(
+    clockIn: Date,
+    clockOut: Date,
+  ): 'NORMAL' | 'LATE' | 'EARLY_LEAVE' {
+    const clockInUTC8 = new Date(clockIn.getTime() + UTC8_OFFSET_MS);
+    const clockInHour = clockInUTC8.getUTCHours();
+    const clockInMinute = clockInUTC8.getUTCMinutes();
+
+    const isLate =
+      clockInHour > WORK_START_HOUR ||
+      (clockInHour === WORK_START_HOUR && clockInMinute > 0);
+
+    // 遲到優先
+    if (isLate) {
+      return 'LATE';
+    }
+
+    const clockOutUTC8 = new Date(clockOut.getTime() + UTC8_OFFSET_MS);
+    const clockOutHour = clockOutUTC8.getUTCHours();
+
+    if (clockOutHour < WORK_END_HOUR) {
+      return 'EARLY_LEAVE';
+    }
+
+    return 'NORMAL';
+  }
+
+  /**
+   * 尋找使用者尚未打下班卡的紀錄（支援跨日打卡）
+   * 先查今日，若無則查昨日（跨日情境）
+   */
+  private async findOpenClockRecord(userId: string, now: Date) {
+    const todayDate = this.getTodayDateUTC8(now);
+
+    // 先查今日
+    const todayRecord = await this.prisma.clockRecord.findUnique({
+      where: {
+        userId_date: {
+          userId,
+          date: todayDate,
+        },
+      },
+    });
+
+    if (todayRecord && !todayRecord.clockOut) {
+      return todayRecord;
+    }
+
+    // 跨日：查昨日是否有未打下班卡的紀錄
+    const yesterdayDate = new Date(todayDate);
+    yesterdayDate.setDate(yesterdayDate.getDate() - 1);
+
+    const yesterdayRecord = await this.prisma.clockRecord.findUnique({
+      where: {
+        userId_date: {
+          userId,
+          date: yesterdayDate,
+        },
+      },
+    });
+
+    if (yesterdayRecord && !yesterdayRecord.clockOut) {
+      return yesterdayRecord;
+    }
+
+    return null;
+  }
+
+  /**
+   * 格式化打卡紀錄為 API 回應格式
+   */
+  private formatClockRecord(record: {
+    id: string;
+    userId: string;
+    date: Date;
+    clockIn: Date;
+    clockOut: Date | null;
+    status: string;
+    note: string | null;
+    createdAt: Date;
+    updatedAt: Date;
+  }) {
+    return {
+      id: record.id,
+      user_id: record.userId,
+      date: record.date.toISOString().split('T')[0],
+      clock_in: record.clockIn.toISOString(),
+      clock_out: record.clockOut ? record.clockOut.toISOString() : null,
+      status: record.status.toLowerCase(),
+      note: record.note,
+      created_at: record.createdAt.toISOString(),
+      updated_at: record.updatedAt.toISOString(),
+    };
+  }
+}

--- a/dev/src/clock/dto/clock-in.dto.ts
+++ b/dev/src/clock/dto/clock-in.dto.ts
@@ -1,0 +1,8 @@
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class ClockInDto {
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  note?: string;
+}

--- a/dev/src/clock/dto/clock-out.dto.ts
+++ b/dev/src/clock/dto/clock-out.dto.ts
@@ -1,0 +1,8 @@
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class ClockOutDto {
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  note?: string;
+}

--- a/dev/src/clock/dto/query-clock-records.dto.ts
+++ b/dev/src/clock/dto/query-clock-records.dto.ts
@@ -1,0 +1,20 @@
+import { IsDateString, IsOptional, IsInt, Min, Max } from 'class-validator';
+
+export class QueryClockRecordsDto {
+  @IsDateString()
+  start_date!: string;
+
+  @IsDateString()
+  end_date!: string;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+}


### PR DESCRIPTION
## Summary
- Clock module：上班打卡、下班打卡、今日狀態、紀錄查詢
- 自動 status 計算（NORMAL/LATE/EARLY_LEAVE），以 Asia/Taipei 時區判定
- Server-side timestamp，不接受 client 傳入時間
- 支援跨日打卡（午夜後下班）
- 日期範圍查詢最大 90 天 + 分頁

## Changes
- `dev/src/clock/` - 打卡模組（controller, service, DTOs）
- `dev/src/app.module.ts` - 註冊 ClockModule
- `dev/__tests__/clock/` - 單元測試

## 驗收標準檢查
- [x] POST /api/v1/clock/in — 上班打卡
- [x] POST /api/v1/clock/out — 下班打卡 + status 自動計算
- [x] GET /api/v1/clock/today — 今日狀態（含無紀錄情況）
- [x] GET /api/v1/clock/records — 紀錄查詢（分頁 + 90 天限制）
- [x] 409 ALREADY_CLOCKED_IN / 422 NOT_CLOCKED_IN / 409 ALREADY_CLOCKED_OUT

## Test plan
- [x] clock.service.spec.ts 單元測試
- [x] clock.controller.spec.ts 單元測試
- [ ] 待 QA E2E 測試驗證

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)