### PR TITLE
[Feature] F-009: 假別額度管理

### DIFF
--- a/dev/__tests__/leave-quotas/leave-quotas.service.spec.ts
+++ b/dev/__tests__/leave-quotas/leave-quotas.service.spec.ts
@@ -1,0 +1,376 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HttpException, HttpStatus, NotFoundException } from '@nestjs/common';
+import { LeaveQuotasService } from '../../src/leave-quotas/leave-quotas.service';
+import { PrismaService } from '../../src/prisma/prisma.service';
+import { Prisma } from '@prisma/client';
+
+const Decimal = Prisma.Decimal;
+
+describe('LeaveQuotasService', () => {
+  let service: LeaveQuotasService;
+  let prisma: {
+    user: {
+      findUnique: jest.Mock;
+      findMany: jest.Mock;
+    };
+    leaveQuota: {
+      findMany: jest.Mock;
+      findUnique: jest.Mock;
+      upsert: jest.Mock;
+    };
+    $transaction: jest.Mock;
+  };
+
+  const mockUser = {
+    id: 'user-uuid-1',
+    employeeId: 'EMP001',
+    email: 'wang@company.com',
+    name: '王小明',
+    role: 'EMPLOYEE',
+    departmentId: 'dept-uuid-1',
+    hireDate: new Date('2024-03-01'),
+    status: 'ACTIVE',
+  };
+
+  const mockQuotas = [
+    {
+      id: 'quota-1',
+      userId: 'user-uuid-1',
+      leaveType: 'ANNUAL',
+      year: 2026,
+      totalHours: new Decimal(56),
+      usedHours: new Decimal(16),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    {
+      id: 'quota-2',
+      userId: 'user-uuid-1',
+      leaveType: 'PERSONAL',
+      year: 2026,
+      totalHours: new Decimal(56),
+      usedHours: new Decimal(0),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    {
+      id: 'quota-3',
+      userId: 'user-uuid-1',
+      leaveType: 'SICK',
+      year: 2026,
+      totalHours: new Decimal(240),
+      usedHours: new Decimal(8),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+  ];
+
+  beforeEach(async () => {
+    prisma = {
+      user: {
+        findUnique: jest.fn(),
+        findMany: jest.fn(),
+      },
+      leaveQuota: {
+        findMany: jest.fn(),
+        findUnique: jest.fn(),
+        upsert: jest.fn(),
+      },
+      $transaction: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LeaveQuotasService,
+        { provide: PrismaService, useValue: prisma },
+      ],
+    }).compile();
+
+    service = module.get<LeaveQuotasService>(LeaveQuotasService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getQuotas', () => {
+    it('should return quotas for a user and year', async () => {
+      prisma.user.findUnique.mockResolvedValue(mockUser);
+      prisma.leaveQuota.findMany.mockResolvedValue(mockQuotas);
+
+      const result = await service.getQuotas('user-uuid-1', 2026);
+
+      expect(result.user_id).toBe('user-uuid-1');
+      expect(result.year).toBe(2026);
+      expect(result.quotas).toHaveLength(3);
+
+      const annual = result.quotas.find((q) => q.leave_type === 'annual');
+      expect(annual).toBeDefined();
+      expect(annual!.total_hours).toBe(56);
+      expect(annual!.used_hours).toBe(16);
+      expect(annual!.remaining_hours).toBe(40);
+      expect(annual!.leave_type_label).toBe('特休');
+    });
+
+    it('should default to current year when year not provided', async () => {
+      prisma.user.findUnique.mockResolvedValue(mockUser);
+      prisma.leaveQuota.findMany.mockResolvedValue([]);
+
+      const result = await service.getQuotas('user-uuid-1');
+
+      expect(result.year).toBe(new Date().getFullYear());
+      expect(prisma.leaveQuota.findMany).toHaveBeenCalledWith({
+        where: { userId: 'user-uuid-1', year: new Date().getFullYear() },
+        orderBy: { leaveType: 'asc' },
+      });
+    });
+
+    it('should throw NOT_FOUND when user does not exist', async () => {
+      prisma.user.findUnique.mockResolvedValue(null);
+
+      await expect(service.getQuotas('nonexistent', 2026)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should return empty quotas when no quotas exist for the year', async () => {
+      prisma.user.findUnique.mockResolvedValue(mockUser);
+      prisma.leaveQuota.findMany.mockResolvedValue([]);
+
+      const result = await service.getQuotas('user-uuid-1', 2025);
+
+      expect(result.quotas).toHaveLength(0);
+      expect(result.year).toBe(2025);
+    });
+
+    it('should include leave_type_label for all quota types', async () => {
+      prisma.user.findUnique.mockResolvedValue(mockUser);
+      prisma.leaveQuota.findMany.mockResolvedValue([
+        { ...mockQuotas[0], leaveType: 'SICK' },
+        { ...mockQuotas[0], leaveType: 'OFFICIAL' },
+      ]);
+
+      const result = await service.getQuotas('user-uuid-1', 2026);
+
+      expect(result.quotas[0].leave_type_label).toBe('病假');
+      expect(result.quotas[1].leave_type_label).toBe('公假');
+    });
+  });
+
+  describe('updateQuotas', () => {
+    const updateDto = {
+      year: 2026,
+      quotas: [
+        { leave_type: 'ANNUAL', total_hours: 120 },
+        { leave_type: 'PERSONAL', total_hours: 56 },
+      ],
+    };
+
+    it('should update quotas successfully', async () => {
+      prisma.user.findUnique.mockResolvedValue(mockUser);
+      prisma.leaveQuota.findUnique.mockResolvedValue(null); // no existing quota
+      prisma.$transaction.mockResolvedValue([
+        { ...mockQuotas[0], totalHours: new Decimal(120), updatedAt: new Date('2026-04-07T10:00:00Z') },
+        { ...mockQuotas[1], updatedAt: new Date('2026-04-07T10:00:00Z') },
+      ]);
+      prisma.leaveQuota.findMany.mockResolvedValue([
+        { ...mockQuotas[0], totalHours: new Decimal(120) },
+        { ...mockQuotas[1] },
+      ]);
+
+      const result = await service.updateQuotas('user-uuid-1', updateDto);
+
+      expect(result.user_id).toBe('user-uuid-1');
+      expect(result.year).toBe(2026);
+      expect(result.quotas).toHaveLength(2);
+      expect(result.updated_at).toBeDefined();
+    });
+
+    it('should throw NOT_FOUND when user does not exist', async () => {
+      prisma.user.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.updateQuotas('nonexistent', updateDto),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw QUOTA_BELOW_USED when total_hours < used_hours', async () => {
+      prisma.user.findUnique.mockResolvedValue(mockUser);
+      prisma.leaveQuota.findUnique.mockResolvedValue({
+        ...mockQuotas[0],
+        usedHours: new Decimal(24),
+      });
+
+      const belowUsedDto = {
+        year: 2026,
+        quotas: [{ leave_type: 'ANNUAL', total_hours: 16 }],
+      };
+
+      try {
+        await service.updateQuotas('user-uuid-1', belowUsedDto);
+        fail('Expected exception');
+      } catch (e) {
+        const exception = e as HttpException;
+        expect(exception.getStatus()).toBe(HttpStatus.UNPROCESSABLE_ENTITY);
+        const response = exception.getResponse() as Record<string, string>;
+        expect(response.code).toBe('QUOTA_BELOW_USED');
+      }
+    });
+
+    it('should allow setting total_hours equal to used_hours', async () => {
+      prisma.user.findUnique.mockResolvedValue(mockUser);
+      prisma.leaveQuota.findUnique.mockResolvedValue({
+        ...mockQuotas[0],
+        usedHours: new Decimal(24),
+      });
+      prisma.$transaction.mockResolvedValue([
+        { ...mockQuotas[0], totalHours: new Decimal(24), updatedAt: new Date() },
+      ]);
+      prisma.leaveQuota.findMany.mockResolvedValue([
+        { ...mockQuotas[0], totalHours: new Decimal(24) },
+      ]);
+
+      const equalDto = {
+        year: 2026,
+        quotas: [{ leave_type: 'ANNUAL', total_hours: 24 }],
+      };
+
+      const result = await service.updateQuotas('user-uuid-1', equalDto);
+      expect(result.user_id).toBe('user-uuid-1');
+    });
+  });
+
+  describe('batchUpdateQuotas', () => {
+    const batchDto = {
+      year: 2026,
+      department_id: 'dept-uuid-1',
+      quotas: [{ leave_type: 'PERSONAL', total_hours: 56 }],
+    };
+
+    it('should batch update quotas for department', async () => {
+      prisma.user.findMany.mockResolvedValue([
+        { id: 'user-1' },
+        { id: 'user-2' },
+        { id: 'user-3' },
+      ]);
+      prisma.$transaction.mockResolvedValue([]);
+
+      const result = await service.batchUpdateQuotas(batchDto);
+
+      expect(result.updated_count).toBe(3);
+      expect(result.year).toBe(2026);
+      expect(prisma.user.findMany).toHaveBeenCalledWith({
+        where: { departmentId: 'dept-uuid-1', status: 'ACTIVE' },
+        select: { id: true },
+      });
+    });
+
+    it('should batch update quotas for specific user_ids', async () => {
+      prisma.$transaction.mockResolvedValue([]);
+
+      const result = await service.batchUpdateQuotas({
+        year: 2026,
+        user_ids: ['user-1', 'user-2'],
+        quotas: [{ leave_type: 'SICK', total_hours: 240 }],
+      });
+
+      expect(result.updated_count).toBe(2);
+      expect(result.year).toBe(2026);
+    });
+
+    it('should throw INVALID_INPUT when neither department_id nor user_ids provided', async () => {
+      const invalidDto = {
+        year: 2026,
+        quotas: [{ leave_type: 'PERSONAL', total_hours: 56 }],
+      };
+
+      try {
+        await service.batchUpdateQuotas(invalidDto);
+        fail('Expected exception');
+      } catch (e) {
+        const exception = e as HttpException;
+        expect(exception.getStatus()).toBe(HttpStatus.BAD_REQUEST);
+        const response = exception.getResponse() as Record<string, string>;
+        expect(response.code).toBe('INVALID_INPUT');
+      }
+    });
+
+    it('should return updated_count 0 when no users found in department', async () => {
+      prisma.user.findMany.mockResolvedValue([]);
+
+      const result = await service.batchUpdateQuotas(batchDto);
+
+      expect(result.updated_count).toBe(0);
+    });
+  });
+
+  describe('calculateAnnualHours', () => {
+    it('should return 0 for less than 0.5 years', () => {
+      const hireDate = new Date('2025-09-01');
+      expect(service.calculateAnnualHours(hireDate, 2026)).toBe(0);
+    });
+
+    it('should return 24 for 0.5-1 years', () => {
+      const hireDate = new Date('2025-03-01');
+      expect(service.calculateAnnualHours(hireDate, 2026)).toBe(24);
+    });
+
+    it('should return 56 for 1-2 years', () => {
+      const hireDate = new Date('2024-06-01');
+      expect(service.calculateAnnualHours(hireDate, 2026)).toBe(56);
+    });
+
+    it('should return 80 for 2-3 years', () => {
+      const hireDate = new Date('2023-06-01');
+      expect(service.calculateAnnualHours(hireDate, 2026)).toBe(80);
+    });
+
+    it('should return 112 for 3-5 years', () => {
+      const hireDate = new Date('2022-06-01');
+      expect(service.calculateAnnualHours(hireDate, 2026)).toBe(112);
+    });
+
+    it('should return 120 for 5-10 years', () => {
+      const hireDate = new Date('2019-06-01');
+      expect(service.calculateAnnualHours(hireDate, 2026)).toBe(120);
+    });
+
+    it('should return 128 for exactly 10 years', () => {
+      const hireDate = new Date('2016-01-01');
+      expect(service.calculateAnnualHours(hireDate, 2026)).toBe(128);
+    });
+
+    it('should cap at 240 for very long tenure', () => {
+      const hireDate = new Date('1980-01-01');
+      expect(service.calculateAnnualHours(hireDate, 2026)).toBe(240);
+    });
+  });
+
+  describe('createDefaultQuotas', () => {
+    it('should create default quotas for all leave types', async () => {
+      prisma.$transaction.mockResolvedValue([]);
+
+      await service.createDefaultQuotas(
+        'user-uuid-1',
+        new Date('2024-03-01'),
+        2026,
+      );
+
+      expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+      // Should create 8 leave types
+      const operations = prisma.$transaction.mock.calls[0][0];
+      expect(operations).toHaveLength(8);
+    });
+
+    it('should default to current year when year not provided', async () => {
+      prisma.$transaction.mockResolvedValue([]);
+
+      await service.createDefaultQuotas(
+        'user-uuid-1',
+        new Date('2024-03-01'),
+      );
+
+      expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/dev/prisma/schema.prisma
+++ b/dev/prisma/schema.prisma
@@ -43,8 +43,11 @@ model User {
   manager       User?          @relation("ManagerSubordinates", fields: [managerId], references: [id])
   subordinates  User[]         @relation("ManagerSubordinates")
   managedDepts  Department[]   @relation("DepartmentManager")
-  clockRecords  ClockRecord[]
-  refreshTokens RefreshToken[]
+  clockRecords   ClockRecord[]
+  refreshTokens  RefreshToken[]
+  leaveRequests  LeaveRequest[] @relation("UserLeaves")
+  reviewedLeaves LeaveRequest[] @relation("LeaveReviewer")
+  leaveQuotas    LeaveQuota[]   @relation("UserQuotas")
 
   @@map("users")
 }
@@ -97,4 +100,67 @@ enum ClockStatus {
   EARLY_LEAVE
   ABSENT
   AMENDED
+}
+
+model LeaveRequest {
+  id            String       @id @default(uuid())
+  userId        String       @map("user_id")
+  leaveType     LeaveType    @map("leave_type")
+  startDate     DateTime     @map("start_date") @db.Date
+  endDate       DateTime     @map("end_date") @db.Date
+  startHalf     HalfDay      @default(FULL) @map("start_half")
+  endHalf       HalfDay      @default(FULL) @map("end_half")
+  hours         Decimal      @db.Decimal(5, 1)
+  reason        String       @db.Text
+  status        LeaveStatus  @default(PENDING)
+  reviewerId    String?      @map("reviewer_id")
+  reviewedAt    DateTime?    @map("reviewed_at")
+  reviewComment String?      @map("review_comment") @db.Text
+  createdAt     DateTime     @default(now()) @map("created_at")
+  updatedAt     DateTime     @updatedAt @map("updated_at")
+
+  user     User  @relation("UserLeaves", fields: [userId], references: [id])
+  reviewer User? @relation("LeaveReviewer", fields: [reviewerId], references: [id])
+
+  @@map("leave_requests")
+}
+
+model LeaveQuota {
+  id         String    @id @default(uuid())
+  userId     String    @map("user_id")
+  leaveType  LeaveType @map("leave_type")
+  year       Int
+  totalHours Decimal   @map("total_hours") @db.Decimal(5, 1)
+  usedHours  Decimal   @default(0) @map("used_hours") @db.Decimal(5, 1)
+  createdAt  DateTime  @default(now()) @map("created_at")
+  updatedAt  DateTime  @updatedAt @map("updated_at")
+
+  user User @relation("UserQuotas", fields: [userId], references: [id])
+
+  @@unique([userId, leaveType, year])
+  @@map("leave_quotas")
+}
+
+enum LeaveType {
+  PERSONAL
+  SICK
+  ANNUAL
+  MARRIAGE
+  BEREAVEMENT
+  MATERNITY
+  PATERNITY
+  OFFICIAL
+}
+
+enum LeaveStatus {
+  PENDING
+  APPROVED
+  REJECTED
+  CANCELLED
+}
+
+enum HalfDay {
+  FULL
+  MORNING
+  AFTERNOON
 }

--- a/dev/prisma/seed.ts
+++ b/dev/prisma/seed.ts
@@ -1,5 +1,7 @@
-import { PrismaClient, Role, UserStatus } from '@prisma/client';
+import { PrismaClient, Prisma, Role, UserStatus, LeaveType } from '@prisma/client';
 import * as bcrypt from 'bcrypt';
+
+const Decimal = Prisma.Decimal;
 
 const prisma = new PrismaClient();
 
@@ -100,6 +102,69 @@ async function main() {
     where: { id: engDept.id },
     data: { managerId: manager.id },
   });
+
+  // 建立 2026 年度假別額度
+  const QUOTA_YEAR = 2026;
+  const DEFAULT_HOURS: Record<string, number> = {
+    PERSONAL: 56,
+    SICK: 240,
+    MARRIAGE: 64,
+    BEREAVEMENT: 24,
+    MATERNITY: 448,
+    PATERNITY: 56,
+    OFFICIAL: 9999,
+  };
+
+  function calculateAnnualHours(hireDate: Date, year: number): number {
+    const yearStart = new Date(year, 0, 1);
+    const diffMs = yearStart.getTime() - hireDate.getTime();
+    const diffYears = diffMs / (1000 * 60 * 60 * 24 * 365.25);
+    if (diffYears < 0.5) return 0;
+    if (diffYears < 1) return 24;
+    if (diffYears < 2) return 56;
+    if (diffYears < 3) return 80;
+    if (diffYears < 5) return 112;
+    if (diffYears < 10) return 120;
+    const extraYears = Math.floor(diffYears) - 10;
+    return Math.min(128 + extraYears * 8, 240);
+  }
+
+  const allUsers = [
+    { user: admin, hireDate: new Date('2024-01-01') },
+    { user: manager, hireDate: new Date('2024-01-15') },
+    { user: employee, hireDate: new Date('2024-03-01') },
+  ];
+
+  const leaveTypes = Object.values(LeaveType);
+
+  for (const { user: u, hireDate } of allUsers) {
+    for (const lt of leaveTypes) {
+      let totalHours = DEFAULT_HOURS[lt] ?? 0;
+      if (lt === 'ANNUAL') {
+        totalHours = calculateAnnualHours(hireDate, QUOTA_YEAR);
+      }
+
+      await prisma.leaveQuota.upsert({
+        where: {
+          userId_leaveType_year: {
+            userId: u.id,
+            leaveType: lt,
+            year: QUOTA_YEAR,
+          },
+        },
+        update: {},
+        create: {
+          userId: u.id,
+          leaveType: lt,
+          year: QUOTA_YEAR,
+          totalHours: new Decimal(totalHours),
+          usedHours: new Decimal(0),
+        },
+      });
+    }
+  }
+
+  console.log('Leave quotas created for year', QUOTA_YEAR);
 
   console.log('Seed completed successfully.');
 }

--- a/dev/src/app.module.ts
+++ b/dev/src/app.module.ts
@@ -5,6 +5,7 @@ import { AuthModule } from './auth/auth.module';
 import { DepartmentsModule } from './departments/departments.module';
 import { EmployeesModule } from './employees/employees.module';
 import { ClockModule } from './clock/clock.module';
+import { LeaveQuotasModule } from './leave-quotas/leave-quotas.module';
 
 @Module({
   imports: [
@@ -17,6 +18,7 @@ import { ClockModule } from './clock/clock.module';
     DepartmentsModule,
     EmployeesModule,
     ClockModule,
+    LeaveQuotasModule,
   ],
 })
 export class AppModule {}

--- a/dev/src/leave-quotas/dto/batch-quota.dto.ts
+++ b/dev/src/leave-quotas/dto/batch-quota.dto.ts
@@ -1,0 +1,55 @@
+import {
+  IsInt,
+  IsArray,
+  ValidateNested,
+  IsOptional,
+  IsString,
+  IsUUID,
+  ArrayMinSize,
+  IsEnum,
+  IsNumber,
+  Min,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+
+enum LeaveTypeEnum {
+  PERSONAL = 'PERSONAL',
+  SICK = 'SICK',
+  ANNUAL = 'ANNUAL',
+  MARRIAGE = 'MARRIAGE',
+  BEREAVEMENT = 'BEREAVEMENT',
+  MATERNITY = 'MATERNITY',
+  PATERNITY = 'PATERNITY',
+  OFFICIAL = 'OFFICIAL',
+}
+
+export class BatchQuotaItemDto {
+  @IsEnum(LeaveTypeEnum, { message: 'leave_type 必須是有效的假別' })
+  leave_type: string;
+
+  @IsNumber({}, { message: 'total_hours 必須是數字' })
+  @Min(0, { message: 'total_hours 不得為負數' })
+  total_hours: number;
+}
+
+export class BatchQuotaDto {
+  @IsInt({ message: 'year 必須是整數' })
+  @Min(2000, { message: 'year 必須大於 2000' })
+  year: number;
+
+  @IsOptional()
+  @IsString()
+  @IsUUID()
+  department_id?: string;
+
+  @IsOptional()
+  @IsArray()
+  @IsUUID('all', { each: true })
+  user_ids?: string[];
+
+  @IsArray()
+  @ArrayMinSize(1, { message: '至少需要一筆額度設定' })
+  @ValidateNested({ each: true })
+  @Type(() => BatchQuotaItemDto)
+  quotas: BatchQuotaItemDto[];
+}

--- a/dev/src/leave-quotas/dto/query-quota.dto.ts
+++ b/dev/src/leave-quotas/dto/query-quota.dto.ts
@@ -1,0 +1,8 @@
+import { IsOptional, IsInt, Min } from 'class-validator';
+
+export class QueryQuotaDto {
+  @IsOptional()
+  @IsInt()
+  @Min(2000)
+  year?: number;
+}

--- a/dev/src/leave-quotas/dto/update-quota.dto.ts
+++ b/dev/src/leave-quotas/dto/update-quota.dto.ts
@@ -1,0 +1,42 @@
+import {
+  IsInt,
+  IsArray,
+  ValidateNested,
+  IsEnum,
+  IsNumber,
+  Min,
+  ArrayMinSize,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+
+enum LeaveTypeEnum {
+  PERSONAL = 'PERSONAL',
+  SICK = 'SICK',
+  ANNUAL = 'ANNUAL',
+  MARRIAGE = 'MARRIAGE',
+  BEREAVEMENT = 'BEREAVEMENT',
+  MATERNITY = 'MATERNITY',
+  PATERNITY = 'PATERNITY',
+  OFFICIAL = 'OFFICIAL',
+}
+
+export class QuotaItemDto {
+  @IsEnum(LeaveTypeEnum, { message: 'leave_type 必須是有效的假別' })
+  leave_type: string;
+
+  @IsNumber({}, { message: 'total_hours 必須是數字' })
+  @Min(0, { message: 'total_hours 不得為負數' })
+  total_hours: number;
+}
+
+export class UpdateQuotaDto {
+  @IsInt({ message: 'year 必須是整數' })
+  @Min(2000, { message: 'year 必須大於 2000' })
+  year: number;
+
+  @IsArray()
+  @ArrayMinSize(1, { message: '至少需要一筆額度設定' })
+  @ValidateNested({ each: true })
+  @Type(() => QuotaItemDto)
+  quotas: QuotaItemDto[];
+}

--- a/dev/src/leave-quotas/leave-quotas.controller.ts
+++ b/dev/src/leave-quotas/leave-quotas.controller.ts
@@ -1,0 +1,73 @@
+import {
+  Controller,
+  Get,
+  Put,
+  Post,
+  Body,
+  Param,
+  Query,
+  UseGuards,
+  ParseUUIDPipe,
+} from '@nestjs/common';
+import { LeaveQuotasService } from './leave-quotas.service';
+import { QueryQuotaDto } from './dto/query-quota.dto';
+import { UpdateQuotaDto } from './dto/update-quota.dto';
+import { BatchQuotaDto } from './dto/batch-quota.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { CurrentUser, CurrentUserData } from '../auth/decorators/current-user.decorator';
+
+@Controller('leave-quotas')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class LeaveQuotasController {
+  constructor(private readonly leaveQuotasService: LeaveQuotasService) {}
+
+  /**
+   * 員工查看自己的額度
+   * GET /api/v1/leave-quotas/me
+   */
+  @Get('me')
+  async getMyQuotas(
+    @CurrentUser() user: CurrentUserData,
+    @Query() query: QueryQuotaDto,
+  ) {
+    return this.leaveQuotasService.getQuotas(user.userId, query.year);
+  }
+
+  /**
+   * Admin 查看員工額度
+   * GET /api/v1/leave-quotas/employees/:userId
+   */
+  @Get('employees/:userId')
+  @Roles('ADMIN')
+  async getEmployeeQuotas(
+    @Param('userId', ParseUUIDPipe) userId: string,
+    @Query() query: QueryQuotaDto,
+  ) {
+    return this.leaveQuotasService.getQuotas(userId, query.year);
+  }
+
+  /**
+   * Admin 設定員工額度
+   * PUT /api/v1/leave-quotas/employees/:userId
+   */
+  @Put('employees/:userId')
+  @Roles('ADMIN')
+  async updateEmployeeQuotas(
+    @Param('userId', ParseUUIDPipe) userId: string,
+    @Body() dto: UpdateQuotaDto,
+  ) {
+    return this.leaveQuotasService.updateQuotas(userId, dto);
+  }
+
+  /**
+   * Admin 批次設定額度
+   * POST /api/v1/leave-quotas/batch
+   */
+  @Post('batch')
+  @Roles('ADMIN')
+  async batchUpdateQuotas(@Body() dto: BatchQuotaDto) {
+    return this.leaveQuotasService.batchUpdateQuotas(dto);
+  }
+}

--- a/dev/src/leave-quotas/leave-quotas.module.ts
+++ b/dev/src/leave-quotas/leave-quotas.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { LeaveQuotasController } from './leave-quotas.controller';
+import { LeaveQuotasService } from './leave-quotas.service';
+
+@Module({
+  controllers: [LeaveQuotasController],
+  providers: [LeaveQuotasService],
+  exports: [LeaveQuotasService],
+})
+export class LeaveQuotasModule {}

--- a/dev/src/leave-quotas/leave-quotas.service.ts
+++ b/dev/src/leave-quotas/leave-quotas.service.ts
@@ -1,0 +1,313 @@
+import {
+  Injectable,
+  HttpException,
+  HttpStatus,
+  NotFoundException,
+} from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+
+type Decimal = Prisma.Decimal;
+const Decimal = Prisma.Decimal;
+import { UpdateQuotaDto } from './dto/update-quota.dto';
+import { BatchQuotaDto } from './dto/batch-quota.dto';
+
+/** 假別中文名稱對照表 */
+const LEAVE_TYPE_LABELS: Record<string, string> = {
+  PERSONAL: '事假',
+  SICK: '病假',
+  ANNUAL: '特休',
+  MARRIAGE: '婚假',
+  BEREAVEMENT: '喪假',
+  MATERNITY: '產假',
+  PATERNITY: '陪產假',
+  OFFICIAL: '公假',
+};
+
+/** 各假別預設年度時數 */
+const DEFAULT_QUOTA_HOURS: Record<string, number> = {
+  PERSONAL: 56,
+  SICK: 240,
+  ANNUAL: 0, // 依年資計算
+  MARRIAGE: 64,
+  BEREAVEMENT: 24,
+  MATERNITY: 448,
+  PATERNITY: 56,
+  OFFICIAL: 9999,
+};
+
+/** 所有假別列表 */
+const ALL_LEAVE_TYPES = [
+  'PERSONAL',
+  'SICK',
+  'ANNUAL',
+  'MARRIAGE',
+  'BEREAVEMENT',
+  'MATERNITY',
+  'PATERNITY',
+  'OFFICIAL',
+];
+
+@Injectable()
+export class LeaveQuotasService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * 查看某位使用者的年度額度
+   */
+  async getQuotas(userId: string, year?: number) {
+    const currentYear = year || new Date().getFullYear();
+
+    // 確認使用者存在
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+    });
+    if (!user) {
+      throw new NotFoundException({
+        code: 'NOT_FOUND',
+        message: '員工不存在',
+      });
+    }
+
+    const quotas = await this.prisma.leaveQuota.findMany({
+      where: {
+        userId,
+        year: currentYear,
+      },
+      orderBy: { leaveType: 'asc' },
+    });
+
+    return {
+      user_id: userId,
+      year: currentYear,
+      quotas: quotas.map((q) => this.formatQuota(q)),
+    };
+  }
+
+  /**
+   * Admin 設定單一員工額度
+   */
+  async updateQuotas(userId: string, dto: UpdateQuotaDto) {
+    // 確認使用者存在
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+    });
+    if (!user) {
+      throw new NotFoundException({
+        code: 'NOT_FOUND',
+        message: '員工不存在',
+      });
+    }
+
+    // 檢查每筆額度是否低於已使用時數
+    for (const item of dto.quotas) {
+      const existing = await this.prisma.leaveQuota.findUnique({
+        where: {
+          userId_leaveType_year: {
+            userId,
+            leaveType: item.leave_type as never,
+            year: dto.year,
+          },
+        },
+      });
+
+      if (existing) {
+        const usedHours = Number(existing.usedHours);
+        if (item.total_hours < usedHours) {
+          throw new HttpException(
+            {
+              code: 'QUOTA_BELOW_USED',
+              message: `${LEAVE_TYPE_LABELS[item.leave_type] || item.leave_type} 的額度 (${item.total_hours}h) 不可低於已使用時數 (${usedHours}h)`,
+            },
+            HttpStatus.UNPROCESSABLE_ENTITY,
+          );
+        }
+      }
+    }
+
+    // 使用 transaction 批次 upsert
+    const results = await this.prisma.$transaction(
+      dto.quotas.map((item) =>
+        this.prisma.leaveQuota.upsert({
+          where: {
+            userId_leaveType_year: {
+              userId,
+              leaveType: item.leave_type as never,
+              year: dto.year,
+            },
+          },
+          update: {
+            totalHours: new Decimal(item.total_hours),
+          },
+          create: {
+            userId,
+            leaveType: item.leave_type as never,
+            year: dto.year,
+            totalHours: new Decimal(item.total_hours),
+            usedHours: new Decimal(0),
+          },
+        }),
+      ),
+    );
+
+    // 取得完整的額度列表
+    const allQuotas = await this.prisma.leaveQuota.findMany({
+      where: { userId, year: dto.year },
+      orderBy: { leaveType: 'asc' },
+    });
+
+    return {
+      user_id: userId,
+      year: dto.year,
+      quotas: allQuotas.map((q) => this.formatQuota(q)),
+      updated_at: results.length > 0 ? results[results.length - 1].updatedAt.toISOString() : new Date().toISOString(),
+    };
+  }
+
+  /**
+   * Admin 批次設定額度
+   */
+  async batchUpdateQuotas(dto: BatchQuotaDto) {
+    // 至少需要指定 department_id 或 user_ids
+    if (!dto.department_id && (!dto.user_ids || dto.user_ids.length === 0)) {
+      throw new HttpException(
+        {
+          code: 'INVALID_INPUT',
+          message: '必須指定 department_id 或 user_ids 之一',
+        },
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    // 取得目標使用者列表
+    let userIds: string[];
+
+    if (dto.user_ids && dto.user_ids.length > 0) {
+      userIds = dto.user_ids;
+    } else {
+      const users = await this.prisma.user.findMany({
+        where: {
+          departmentId: dto.department_id,
+          status: 'ACTIVE',
+        },
+        select: { id: true },
+      });
+      userIds = users.map((u) => u.id);
+    }
+
+    if (userIds.length === 0) {
+      return { updated_count: 0, year: dto.year };
+    }
+
+    // 批次 upsert（使用 transaction）
+    const operations = userIds.flatMap((userId) =>
+      dto.quotas.map((item) =>
+        this.prisma.leaveQuota.upsert({
+          where: {
+            userId_leaveType_year: {
+              userId,
+              leaveType: item.leave_type as never,
+              year: dto.year,
+            },
+          },
+          update: {
+            totalHours: new Decimal(item.total_hours),
+          },
+          create: {
+            userId,
+            leaveType: item.leave_type as never,
+            year: dto.year,
+            totalHours: new Decimal(item.total_hours),
+            usedHours: new Decimal(0),
+          },
+        }),
+      ),
+    );
+
+    await this.prisma.$transaction(operations);
+
+    return {
+      updated_count: userIds.length,
+      year: dto.year,
+    };
+  }
+
+  /**
+   * 為員工建立當年度所有假別的預設額度
+   * 供 EmployeesService 在建立員工時呼叫
+   */
+  async createDefaultQuotas(userId: string, hireDate: Date, year?: number) {
+    const targetYear = year || new Date().getFullYear();
+
+    const operations = ALL_LEAVE_TYPES.map((leaveType) => {
+      let totalHours = DEFAULT_QUOTA_HOURS[leaveType];
+
+      // 特休依年資計算
+      if (leaveType === 'ANNUAL') {
+        totalHours = this.calculateAnnualHours(hireDate, targetYear);
+      }
+
+      return this.prisma.leaveQuota.upsert({
+        where: {
+          userId_leaveType_year: {
+            userId,
+            leaveType: leaveType as never,
+            year: targetYear,
+          },
+        },
+        update: {},
+        create: {
+          userId,
+          leaveType: leaveType as never,
+          year: targetYear,
+          totalHours: new Decimal(totalHours),
+          usedHours: new Decimal(0),
+        },
+      });
+    });
+
+    await this.prisma.$transaction(operations);
+  }
+
+  /**
+   * 依年資計算特休時數
+   * 0.5-1年: 24h, 1-2年: 56h, 2-3年: 80h, 3-5年: 112h, 5-10年: 120h, 10+年: 128h+
+   */
+  calculateAnnualHours(hireDate: Date, year: number): number {
+    const yearStart = new Date(year, 0, 1);
+    const diffMs = yearStart.getTime() - hireDate.getTime();
+    const diffYears = diffMs / (1000 * 60 * 60 * 24 * 365.25);
+
+    if (diffYears < 0.5) return 0;
+    if (diffYears < 1) return 24;
+    if (diffYears < 2) return 56;
+    if (diffYears < 3) return 80;
+    if (diffYears < 5) return 112;
+    if (diffYears < 10) return 120;
+
+    // 10 年以上：128h 基礎，每多一年加 8h（上限 240h）
+    const extraYears = Math.floor(diffYears) - 10;
+    return Math.min(128 + extraYears * 8, 240);
+  }
+
+  // ── Private Methods ──
+
+  private formatQuota(quota: {
+    id: string;
+    leaveType: string;
+    totalHours: Decimal | number;
+    usedHours: Decimal | number;
+  }) {
+    const totalHours = Number(quota.totalHours);
+    const usedHours = Number(quota.usedHours);
+
+    return {
+      id: quota.id,
+      leave_type: quota.leaveType.toLowerCase(),
+      leave_type_label: LEAVE_TYPE_LABELS[quota.leaveType] || quota.leaveType,
+      total_hours: totalHours,
+      used_hours: usedHours,
+      remaining_hours: Math.round((totalHours - usedHours) * 10) / 10,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- Prisma schema 新增 LeaveQuota, LeaveRequest models + LeaveType, LeaveStatus, HalfDay enums
- 假別額度 CRUD：員工查看自己額度、Admin 查看/設定員工額度、批次設定
- 特休依年資自動計算、預設額度初始化
- 額度不可低於已使用時數（422 QUOTA_BELOW_USED）
- Seed data 含 2026 年度測試額度

## 驗收標準檢查
- [x] GET /api/v1/leave-quotas/me
- [x] GET /api/v1/leave-quotas/employees/:userId
- [x] PUT /api/v1/leave-quotas/employees/:userId
- [x] POST /api/v1/leave-quotas/batch
- [x] 特休依年資計算
- [x] 額度不可低於已使用

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)