### PR TITLE
[Feature] F-002: 請假申請

### DIFF
--- a/dev/__tests__/leaves/leaves.controller.spec.ts
+++ b/dev/__tests__/leaves/leaves.controller.spec.ts
@@ -1,0 +1,123 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LeavesController } from '../../src/leaves/leaves.controller';
+import { LeavesService } from '../../src/leaves/leaves.service';
+import { CurrentUserData } from '../../src/auth/decorators/current-user.decorator';
+
+describe('LeavesController', () => {
+  let controller: LeavesController;
+  let leavesService: {
+    createLeave: jest.Mock;
+    getLeaves: jest.Mock;
+    getLeaveById: jest.Mock;
+    cancelLeave: jest.Mock;
+  };
+
+  const mockUser: CurrentUserData = {
+    userId: 'user-uuid-1',
+    role: 'EMPLOYEE',
+    departmentId: 'dept-uuid-1',
+  };
+
+  const mockLeaveResponse = {
+    id: 'leave-uuid-1',
+    user_id: 'user-uuid-1',
+    leave_type: 'annual',
+    start_date: '2026-04-10',
+    end_date: '2026-04-10',
+    start_half: 'full',
+    end_half: 'full',
+    hours: 8,
+    reason: '個人事務',
+    status: 'pending',
+    reviewer_id: null,
+    reviewed_at: null,
+    review_comment: null,
+    created_at: '2026-04-07T10:00:00.000Z',
+  };
+
+  beforeEach(async () => {
+    leavesService = {
+      createLeave: jest.fn(),
+      getLeaves: jest.fn(),
+      getLeaveById: jest.fn(),
+      cancelLeave: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [LeavesController],
+      providers: [{ provide: LeavesService, useValue: leavesService }],
+    }).compile();
+
+    controller = module.get<LeavesController>(LeavesController);
+  });
+
+  describe('POST /leaves', () => {
+    it('should call createLeave with user ID and DTO', async () => {
+      leavesService.createLeave.mockResolvedValue(mockLeaveResponse);
+
+      const dto = {
+        leave_type: 'annual' as const,
+        start_date: '2026-04-10',
+        end_date: '2026-04-10',
+        reason: '個人事務',
+      };
+
+      const result = await controller.createLeave(mockUser, dto as any);
+
+      expect(leavesService.createLeave).toHaveBeenCalledWith('user-uuid-1', dto);
+      expect(result.id).toBe('leave-uuid-1');
+      expect(result.status).toBe('pending');
+    });
+  });
+
+  describe('GET /leaves', () => {
+    it('should call getLeaves with user ID and query', async () => {
+      const mockResult = {
+        data: [mockLeaveResponse],
+        meta: { total: 1, page: 1, limit: 20, totalPages: 1 },
+      };
+      leavesService.getLeaves.mockResolvedValue(mockResult);
+
+      const query = { page: 1, limit: 20 };
+      const result = await controller.getLeaves(mockUser, query as any);
+
+      expect(leavesService.getLeaves).toHaveBeenCalledWith('user-uuid-1', query);
+      expect(result.data).toHaveLength(1);
+    });
+  });
+
+  describe('GET /leaves/:id', () => {
+    it('should call getLeaveById with correct params', async () => {
+      leavesService.getLeaveById.mockResolvedValue(mockLeaveResponse);
+
+      const result = await controller.getLeaveById(mockUser, 'leave-uuid-1');
+
+      expect(leavesService.getLeaveById).toHaveBeenCalledWith(
+        'leave-uuid-1',
+        'user-uuid-1',
+        'EMPLOYEE',
+        'dept-uuid-1',
+      );
+      expect(result.id).toBe('leave-uuid-1');
+    });
+  });
+
+  describe('PUT /leaves/:id/cancel', () => {
+    it('should call cancelLeave with correct params', async () => {
+      const cancelResponse = {
+        id: 'leave-uuid-1',
+        status: 'cancelled',
+        updated_at: '2026-04-07T11:00:00.000Z',
+      };
+      leavesService.cancelLeave.mockResolvedValue(cancelResponse);
+
+      const result = await controller.cancelLeave(mockUser, 'leave-uuid-1');
+
+      expect(leavesService.cancelLeave).toHaveBeenCalledWith(
+        'leave-uuid-1',
+        'user-uuid-1',
+      );
+      expect(result.status).toBe('cancelled');
+    });
+  });
+});

--- a/dev/__tests__/leaves/leaves.service.spec.ts
+++ b/dev/__tests__/leaves/leaves.service.spec.ts
@@ -1,0 +1,693 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  HttpException,
+  HttpStatus,
+  NotFoundException,
+  ForbiddenException,
+} from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { LeavesService } from '../../src/leaves/leaves.service';
+import { LeaveQuotasService } from '../../src/leave-quotas/leave-quotas.service';
+import { PrismaService } from '../../src/prisma/prisma.service';
+import { HalfDayEnum } from '../../src/leaves/dto/create-leave.dto';
+
+const Decimal = Prisma.Decimal;
+
+describe('LeavesService', () => {
+  let service: LeavesService;
+  let prisma: {
+    leaveRequest: {
+      create: jest.Mock;
+      findFirst: jest.Mock;
+      findUnique: jest.Mock;
+      findMany: jest.Mock;
+      count: jest.Mock;
+      update: jest.Mock;
+    };
+    leaveQuota: {
+      findUnique: jest.Mock;
+      updateMany: jest.Mock;
+    };
+    $transaction: jest.Mock;
+  };
+  let leaveQuotasService: { getQuotas: jest.Mock };
+
+  // 固定 "today" 為 2026-04-07
+  const MOCK_TODAY = new Date('2026-04-07T00:00:00.000Z');
+
+  const mockLeave = {
+    id: 'leave-uuid-1',
+    userId: 'user-uuid-1',
+    leaveType: 'ANNUAL',
+    startDate: new Date('2026-04-10T00:00:00.000Z'),
+    endDate: new Date('2026-04-10T00:00:00.000Z'),
+    startHalf: 'FULL',
+    endHalf: 'FULL',
+    hours: new Decimal(8),
+    reason: '個人事務',
+    status: 'PENDING',
+    reviewerId: null,
+    reviewedAt: null,
+    reviewComment: null,
+    createdAt: new Date('2026-04-07T10:00:00.000Z'),
+    updatedAt: new Date('2026-04-07T10:00:00.000Z'),
+  };
+
+  const mockQuota = {
+    id: 'quota-uuid-1',
+    userId: 'user-uuid-1',
+    leaveType: 'ANNUAL',
+    year: 2026,
+    totalHours: new Decimal(56),
+    usedHours: new Decimal(0),
+  };
+
+  beforeEach(async () => {
+    // Mock Date 讓 today 固定
+    jest.useFakeTimers();
+    jest.setSystemTime(MOCK_TODAY);
+
+    prisma = {
+      leaveRequest: {
+        create: jest.fn(),
+        findFirst: jest.fn(),
+        findUnique: jest.fn(),
+        findMany: jest.fn(),
+        count: jest.fn(),
+        update: jest.fn(),
+      },
+      leaveQuota: {
+        findUnique: jest.fn(),
+        updateMany: jest.fn(),
+      },
+      $transaction: jest.fn(),
+    };
+
+    leaveQuotasService = {
+      getQuotas: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LeavesService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: LeaveQuotasService, useValue: leaveQuotasService },
+      ],
+    }).compile();
+
+    service = module.get<LeavesService>(LeavesService);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  // ── calculateLeaveHours ──
+
+  describe('calculateLeaveHours', () => {
+    it('should return 8 for a full day', () => {
+      const start = new Date('2026-04-10');
+      const end = new Date('2026-04-10');
+      expect(
+        service.calculateLeaveHours(start, end, HalfDayEnum.FULL, HalfDayEnum.FULL),
+      ).toBe(8);
+    });
+
+    it('should return 4 for a half day (morning)', () => {
+      const start = new Date('2026-04-10');
+      const end = new Date('2026-04-10');
+      expect(
+        service.calculateLeaveHours(start, end, HalfDayEnum.MORNING, HalfDayEnum.MORNING),
+      ).toBe(4);
+    });
+
+    it('should return 4 for a half day (afternoon)', () => {
+      const start = new Date('2026-04-10');
+      const end = new Date('2026-04-10');
+      expect(
+        service.calculateLeaveHours(start, end, HalfDayEnum.AFTERNOON, HalfDayEnum.AFTERNOON),
+      ).toBe(4);
+    });
+
+    it('should return 16 for 2 full days', () => {
+      const start = new Date('2026-04-10');
+      const end = new Date('2026-04-11');
+      expect(
+        service.calculateLeaveHours(start, end, HalfDayEnum.FULL, HalfDayEnum.FULL),
+      ).toBe(16);
+    });
+
+    it('should return 36 for 5 days with start_half=afternoon, end_half=full', () => {
+      // 4 + 8 + 8 + 8 + 8 = 36
+      const start = new Date('2026-04-10');
+      const end = new Date('2026-04-14');
+      expect(
+        service.calculateLeaveHours(
+          start,
+          end,
+          HalfDayEnum.AFTERNOON,
+          HalfDayEnum.FULL,
+        ),
+      ).toBe(36);
+    });
+
+    it('should return 12 for 2 days with start_half=afternoon, end_half=full', () => {
+      // 4 + 8 = 12
+      const start = new Date('2026-04-10');
+      const end = new Date('2026-04-11');
+      expect(
+        service.calculateLeaveHours(
+          start,
+          end,
+          HalfDayEnum.AFTERNOON,
+          HalfDayEnum.FULL,
+        ),
+      ).toBe(12);
+    });
+
+    it('should return 8 for 2 days with start_half=morning, end_half=morning', () => {
+      // 4 + 4 = 8
+      const start = new Date('2026-04-10');
+      const end = new Date('2026-04-11');
+      expect(
+        service.calculateLeaveHours(
+          start,
+          end,
+          HalfDayEnum.MORNING,
+          HalfDayEnum.MORNING,
+        ),
+      ).toBe(8);
+    });
+  });
+
+  // ── createLeave ──
+
+  describe('createLeave', () => {
+    const createDto = {
+      leave_type: 'annual' as const,
+      start_date: '2026-04-10',
+      end_date: '2026-04-10',
+      reason: '個人事務',
+    };
+
+    it('should create a leave request successfully (Scenario: 申請特休一天)', async () => {
+      prisma.leaveRequest.findFirst.mockResolvedValue(null); // no conflict
+      prisma.leaveQuota.findUnique.mockResolvedValue(mockQuota); // quota available
+      prisma.leaveRequest.create.mockResolvedValue(mockLeave);
+
+      const result = await service.createLeave('user-uuid-1', createDto as any);
+
+      expect(result.id).toBe('leave-uuid-1');
+      expect(result.status).toBe('pending');
+      expect(result.hours).toBe(8);
+      expect(result.leave_type).toBe('annual');
+      expect(prisma.leaveRequest.create).toHaveBeenCalledTimes(1);
+    });
+
+    it('should create a half-day leave (Scenario: 申請半天假)', async () => {
+      const halfDayLeave = {
+        ...mockLeave,
+        startHalf: 'MORNING',
+        endHalf: 'MORNING',
+        hours: new Decimal(4),
+      };
+
+      prisma.leaveRequest.findFirst.mockResolvedValue(null);
+      prisma.leaveQuota.findUnique.mockResolvedValue(mockQuota);
+      prisma.leaveRequest.create.mockResolvedValue(halfDayLeave);
+
+      const dto = {
+        leave_type: 'personal' as const,
+        start_date: '2026-04-10',
+        end_date: '2026-04-10',
+        start_half: 'morning' as const,
+        end_half: 'morning' as const,
+        reason: '看診',
+      };
+
+      const result = await service.createLeave('user-uuid-1', dto as any);
+
+      expect(result.hours).toBe(4);
+      expect(result.start_half).toBe('morning');
+    });
+
+    it('should create multi-day leave (Scenario: 申請跨多天假)', async () => {
+      const multiDayLeave = {
+        ...mockLeave,
+        startDate: new Date('2026-04-10T00:00:00.000Z'),
+        endDate: new Date('2026-04-14T00:00:00.000Z'),
+        startHalf: 'AFTERNOON',
+        endHalf: 'FULL',
+        hours: new Decimal(36),
+      };
+
+      prisma.leaveRequest.findFirst.mockResolvedValue(null);
+      prisma.leaveQuota.findUnique.mockResolvedValue({
+        ...mockQuota,
+        totalHours: new Decimal(120),
+      });
+      prisma.leaveRequest.create.mockResolvedValue(multiDayLeave);
+
+      const dto = {
+        leave_type: 'annual' as const,
+        start_date: '2026-04-10',
+        end_date: '2026-04-14',
+        start_half: 'afternoon' as const,
+        end_half: 'full' as const,
+        reason: '出國旅遊',
+      };
+
+      const result = await service.createLeave('user-uuid-1', dto as any);
+
+      expect(result.hours).toBe(36);
+    });
+
+    it('should throw PAST_DATE when start_date is in the past', async () => {
+      const dto = {
+        leave_type: 'annual' as const,
+        start_date: '2026-04-01',
+        end_date: '2026-04-01',
+        reason: '過去的日期',
+      };
+
+      try {
+        await service.createLeave('user-uuid-1', dto as any);
+        fail('Expected exception');
+      } catch (e) {
+        const ex = e as HttpException;
+        expect(ex.getStatus()).toBe(HttpStatus.UNPROCESSABLE_ENTITY);
+        const resp = ex.getResponse() as Record<string, string>;
+        expect(resp.code).toBe('PAST_DATE');
+      }
+    });
+
+    it('should allow sick leave 3 days ago (Scenario: 病假可追溯 3 天)', async () => {
+      // today = 2026-04-07, start_date = 2026-04-04 => ok
+      prisma.leaveRequest.findFirst.mockResolvedValue(null);
+      prisma.leaveQuota.findUnique.mockResolvedValue({
+        ...mockQuota,
+        leaveType: 'SICK',
+        totalHours: new Decimal(240),
+      });
+      prisma.leaveRequest.create.mockResolvedValue({
+        ...mockLeave,
+        leaveType: 'SICK',
+        startDate: new Date('2026-04-04T00:00:00.000Z'),
+      });
+
+      const dto = {
+        leave_type: 'sick' as const,
+        start_date: '2026-04-04',
+        end_date: '2026-04-04',
+        reason: '身體不適',
+      };
+
+      const result = await service.createLeave('user-uuid-1', dto as any);
+      expect(result.leave_type).toBe('sick');
+    });
+
+    it('should reject sick leave more than 3 days ago (Scenario: 病假追溯超過 3 天)', async () => {
+      // today = 2026-04-07, start_date = 2026-04-03 => reject
+      const dto = {
+        leave_type: 'sick' as const,
+        start_date: '2026-04-03',
+        end_date: '2026-04-03',
+        reason: '身體不適',
+      };
+
+      try {
+        await service.createLeave('user-uuid-1', dto as any);
+        fail('Expected exception');
+      } catch (e) {
+        const ex = e as HttpException;
+        expect(ex.getStatus()).toBe(HttpStatus.UNPROCESSABLE_ENTITY);
+        const resp = ex.getResponse() as Record<string, string>;
+        expect(resp.code).toBe('PAST_DATE');
+      }
+    });
+
+    it('should throw DATE_CONFLICT when date overlaps (Scenario: 日期衝突)', async () => {
+      prisma.leaveRequest.findFirst.mockResolvedValue(mockLeave); // conflict exists
+
+      try {
+        await service.createLeave('user-uuid-1', createDto as any);
+        fail('Expected exception');
+      } catch (e) {
+        const ex = e as HttpException;
+        expect(ex.getStatus()).toBe(HttpStatus.CONFLICT);
+        const resp = ex.getResponse() as Record<string, string>;
+        expect(resp.code).toBe('DATE_CONFLICT');
+      }
+    });
+
+    it('should throw INSUFFICIENT_QUOTA when quota is not enough (Scenario: 額度不足)', async () => {
+      prisma.leaveRequest.findFirst.mockResolvedValue(null);
+      prisma.leaveQuota.findUnique.mockResolvedValue({
+        ...mockQuota,
+        totalHours: new Decimal(4),
+        usedHours: new Decimal(0),
+      });
+
+      try {
+        await service.createLeave('user-uuid-1', createDto as any);
+        fail('Expected exception');
+      } catch (e) {
+        const ex = e as HttpException;
+        expect(ex.getStatus()).toBe(HttpStatus.UNPROCESSABLE_ENTITY);
+        const resp = ex.getResponse() as Record<string, string>;
+        expect(resp.code).toBe('INSUFFICIENT_QUOTA');
+      }
+    });
+
+    it('should throw INSUFFICIENT_QUOTA when no quota exists', async () => {
+      prisma.leaveRequest.findFirst.mockResolvedValue(null);
+      prisma.leaveQuota.findUnique.mockResolvedValue(null);
+
+      try {
+        await service.createLeave('user-uuid-1', createDto as any);
+        fail('Expected exception');
+      } catch (e) {
+        const ex = e as HttpException;
+        expect(ex.getStatus()).toBe(HttpStatus.UNPROCESSABLE_ENTITY);
+        const resp = ex.getResponse() as Record<string, string>;
+        expect(resp.code).toBe('INSUFFICIENT_QUOTA');
+      }
+    });
+
+    it('should throw INVALID_INPUT when end_date < start_date', async () => {
+      const dto = {
+        leave_type: 'annual' as const,
+        start_date: '2026-04-12',
+        end_date: '2026-04-10',
+        reason: '日期錯誤',
+      };
+
+      try {
+        await service.createLeave('user-uuid-1', dto as any);
+        fail('Expected exception');
+      } catch (e) {
+        const ex = e as HttpException;
+        expect(ex.getStatus()).toBe(HttpStatus.BAD_REQUEST);
+        const resp = ex.getResponse() as Record<string, string>;
+        expect(resp.code).toBe('INVALID_INPUT');
+      }
+    });
+
+    it('should accept reason with exactly 500 chars (Scenario: reason 恰好 500 字)', async () => {
+      prisma.leaveRequest.findFirst.mockResolvedValue(null);
+      prisma.leaveQuota.findUnique.mockResolvedValue(mockQuota);
+      prisma.leaveRequest.create.mockResolvedValue({
+        ...mockLeave,
+        reason: 'a'.repeat(500),
+      });
+
+      const dto = {
+        leave_type: 'annual' as const,
+        start_date: '2026-04-10',
+        end_date: '2026-04-10',
+        reason: 'a'.repeat(500),
+      };
+
+      const result = await service.createLeave('user-uuid-1', dto as any);
+      expect(result.reason).toHaveLength(500);
+    });
+  });
+
+  // ── getLeaves ──
+
+  describe('getLeaves', () => {
+    it('should return paginated leave list (Scenario: 查詢個人請假紀錄)', async () => {
+      const leaves = [
+        { ...mockLeave, reviewer: null },
+        { ...mockLeave, id: 'leave-uuid-2', reviewer: null },
+        { ...mockLeave, id: 'leave-uuid-3', reviewer: null },
+      ];
+      prisma.leaveRequest.findMany.mockResolvedValue(leaves);
+      prisma.leaveRequest.count.mockResolvedValue(3);
+
+      const result = await service.getLeaves('user-uuid-1', {} as any);
+
+      expect(result.data).toHaveLength(3);
+      expect(result.meta.total).toBe(3);
+      expect(result.meta.page).toBe(1);
+      expect(result.meta.limit).toBe(20);
+      expect(result.meta.totalPages).toBe(1);
+    });
+
+    it('should filter by status', async () => {
+      prisma.leaveRequest.findMany.mockResolvedValue([]);
+      prisma.leaveRequest.count.mockResolvedValue(0);
+
+      await service.getLeaves('user-uuid-1', { status: 'pending' } as any);
+
+      expect(prisma.leaveRequest.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ status: 'PENDING' }),
+        }),
+      );
+    });
+
+    it('should filter by leave_type', async () => {
+      prisma.leaveRequest.findMany.mockResolvedValue([]);
+      prisma.leaveRequest.count.mockResolvedValue(0);
+
+      await service.getLeaves('user-uuid-1', { leave_type: 'annual' } as any);
+
+      expect(prisma.leaveRequest.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ leaveType: 'ANNUAL' }),
+        }),
+      );
+    });
+
+    it('should filter by date range', async () => {
+      prisma.leaveRequest.findMany.mockResolvedValue([]);
+      prisma.leaveRequest.count.mockResolvedValue(0);
+
+      await service.getLeaves('user-uuid-1', {
+        start_date: '2026-04-01',
+        end_date: '2026-04-30',
+      } as any);
+
+      expect(prisma.leaveRequest.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            startDate: {
+              gte: new Date('2026-04-01T00:00:00.000Z'),
+              lte: new Date('2026-04-30T00:00:00.000Z'),
+            },
+          }),
+        }),
+      );
+    });
+
+    it('should support pagination', async () => {
+      prisma.leaveRequest.findMany.mockResolvedValue([]);
+      prisma.leaveRequest.count.mockResolvedValue(50);
+
+      const result = await service.getLeaves('user-uuid-1', {
+        page: 2,
+        limit: 10,
+      } as any);
+
+      expect(prisma.leaveRequest.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          skip: 10,
+          take: 10,
+        }),
+      );
+      expect(result.meta.totalPages).toBe(5);
+    });
+  });
+
+  // ── getLeaveById ──
+
+  describe('getLeaveById', () => {
+    const mockLeaveWithUser = {
+      ...mockLeave,
+      updatedAt: new Date('2026-04-07T10:00:00.000Z'),
+      user: {
+        id: 'user-uuid-1',
+        name: '王小明',
+        employeeId: 'EMP001',
+        departmentId: 'dept-uuid-1',
+        department: { id: 'dept-uuid-1', name: '工程部' },
+      },
+      reviewer: null,
+    };
+
+    it('should return leave detail for own leave', async () => {
+      prisma.leaveRequest.findUnique.mockResolvedValue(mockLeaveWithUser);
+
+      const result = await service.getLeaveById(
+        'leave-uuid-1',
+        'user-uuid-1',
+        'EMPLOYEE',
+        'dept-uuid-1',
+      );
+
+      expect(result.id).toBe('leave-uuid-1');
+      expect(result.user.name).toBe('王小明');
+      expect(result.user.department.name).toBe('工程部');
+    });
+
+    it('should throw NOT_FOUND when leave does not exist', async () => {
+      prisma.leaveRequest.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.getLeaveById('nonexistent', 'user-uuid-1', 'EMPLOYEE', 'dept-uuid-1'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw FORBIDDEN for other user leave (Scenario: employee)', async () => {
+      prisma.leaveRequest.findUnique.mockResolvedValue(mockLeaveWithUser);
+
+      await expect(
+        service.getLeaveById('leave-uuid-1', 'other-user', 'EMPLOYEE', 'dept-uuid-1'),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should allow ADMIN to view any leave', async () => {
+      prisma.leaveRequest.findUnique.mockResolvedValue(mockLeaveWithUser);
+
+      const result = await service.getLeaveById(
+        'leave-uuid-1',
+        'admin-user',
+        'ADMIN',
+        'dept-uuid-2',
+      );
+
+      expect(result.id).toBe('leave-uuid-1');
+    });
+
+    it('should allow MANAGER to view same department leave', async () => {
+      prisma.leaveRequest.findUnique.mockResolvedValue(mockLeaveWithUser);
+
+      const result = await service.getLeaveById(
+        'leave-uuid-1',
+        'manager-user',
+        'MANAGER',
+        'dept-uuid-1',
+      );
+
+      expect(result.id).toBe('leave-uuid-1');
+    });
+
+    it('should throw FORBIDDEN for MANAGER viewing other department leave', async () => {
+      prisma.leaveRequest.findUnique.mockResolvedValue(mockLeaveWithUser);
+
+      await expect(
+        service.getLeaveById('leave-uuid-1', 'manager-user', 'MANAGER', 'dept-uuid-2'),
+      ).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  // ── cancelLeave ──
+
+  describe('cancelLeave', () => {
+    it('should cancel a pending leave (Scenario: 取消 pending 的請假)', async () => {
+      const pendingLeave = { ...mockLeave, status: 'PENDING' };
+      prisma.leaveRequest.findUnique.mockResolvedValue(pendingLeave);
+      prisma.leaveRequest.update.mockResolvedValue({
+        ...pendingLeave,
+        status: 'CANCELLED',
+        updatedAt: new Date('2026-04-07T11:00:00.000Z'),
+      });
+
+      const result = await service.cancelLeave('leave-uuid-1', 'user-uuid-1');
+
+      expect(result.id).toBe('leave-uuid-1');
+      expect(result.status).toBe('cancelled');
+      expect(result.updated_at).toBeDefined();
+    });
+
+    it('should cancel approved leave with future start_date and refund quota (Scenario: 取消已核准但未開始的請假)', async () => {
+      const approvedLeave = {
+        ...mockLeave,
+        status: 'APPROVED',
+        startDate: new Date('2026-04-10T00:00:00.000Z'), // future
+        hours: new Decimal(8),
+      };
+      prisma.leaveRequest.findUnique.mockResolvedValue(approvedLeave);
+
+      const updatedLeave = {
+        ...approvedLeave,
+        status: 'CANCELLED',
+        updatedAt: new Date('2026-04-07T11:00:00.000Z'),
+      };
+      prisma.$transaction.mockResolvedValue([updatedLeave, { count: 1 }]);
+
+      const result = await service.cancelLeave('leave-uuid-1', 'user-uuid-1');
+
+      expect(result.id).toBe('leave-uuid-1');
+      expect(result.status).toBe('cancelled');
+      expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+    });
+
+    it('should throw LEAVE_STARTED for approved leave with past/today start_date (Scenario: 取消已開始的 approved 假)', async () => {
+      const startedLeave = {
+        ...mockLeave,
+        status: 'APPROVED',
+        startDate: new Date('2026-04-07T00:00:00.000Z'), // today
+      };
+      prisma.leaveRequest.findUnique.mockResolvedValue(startedLeave);
+
+      try {
+        await service.cancelLeave('leave-uuid-1', 'user-uuid-1');
+        fail('Expected exception');
+      } catch (e) {
+        const ex = e as HttpException;
+        expect(ex.getStatus()).toBe(HttpStatus.UNPROCESSABLE_ENTITY);
+        const resp = ex.getResponse() as Record<string, string>;
+        expect(resp.code).toBe('LEAVE_STARTED');
+      }
+    });
+
+    it('should throw CANNOT_CANCEL for rejected leave', async () => {
+      const rejectedLeave = { ...mockLeave, status: 'REJECTED' };
+      prisma.leaveRequest.findUnique.mockResolvedValue(rejectedLeave);
+
+      try {
+        await service.cancelLeave('leave-uuid-1', 'user-uuid-1');
+        fail('Expected exception');
+      } catch (e) {
+        const ex = e as HttpException;
+        expect(ex.getStatus()).toBe(HttpStatus.UNPROCESSABLE_ENTITY);
+        const resp = ex.getResponse() as Record<string, string>;
+        expect(resp.code).toBe('CANNOT_CANCEL');
+      }
+    });
+
+    it('should throw CANNOT_CANCEL for already cancelled leave', async () => {
+      const cancelledLeave = { ...mockLeave, status: 'CANCELLED' };
+      prisma.leaveRequest.findUnique.mockResolvedValue(cancelledLeave);
+
+      try {
+        await service.cancelLeave('leave-uuid-1', 'user-uuid-1');
+        fail('Expected exception');
+      } catch (e) {
+        const ex = e as HttpException;
+        expect(ex.getStatus()).toBe(HttpStatus.UNPROCESSABLE_ENTITY);
+        const resp = ex.getResponse() as Record<string, string>;
+        expect(resp.code).toBe('CANNOT_CANCEL');
+      }
+    });
+
+    it('should throw NOT_FOUND when leave does not exist', async () => {
+      prisma.leaveRequest.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.cancelLeave('nonexistent', 'user-uuid-1'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw FORBIDDEN when cancelling another user leave (Scenario: 取消非自己的請假單)', async () => {
+      prisma.leaveRequest.findUnique.mockResolvedValue(mockLeave);
+
+      await expect(
+        service.cancelLeave('leave-uuid-1', 'other-user'),
+      ).rejects.toThrow(ForbiddenException);
+    });
+  });
+});

--- a/dev/src/app.module.ts
+++ b/dev/src/app.module.ts
@@ -6,6 +6,7 @@ import { DepartmentsModule } from './departments/departments.module';
 import { EmployeesModule } from './employees/employees.module';
 import { ClockModule } from './clock/clock.module';
 import { LeaveQuotasModule } from './leave-quotas/leave-quotas.module';
+import { LeavesModule } from './leaves/leaves.module';
 
 @Module({
   imports: [
@@ -19,6 +20,7 @@ import { LeaveQuotasModule } from './leave-quotas/leave-quotas.module';
     EmployeesModule,
     ClockModule,
     LeaveQuotasModule,
+    LeavesModule,
   ],
 })
 export class AppModule {}

--- a/dev/src/leaves/dto/create-leave.dto.ts
+++ b/dev/src/leaves/dto/create-leave.dto.ts
@@ -1,0 +1,49 @@
+import {
+  IsString,
+  IsEnum,
+  IsDateString,
+  IsOptional,
+  MinLength,
+  MaxLength,
+} from 'class-validator';
+
+export enum LeaveTypeEnum {
+  PERSONAL = 'personal',
+  SICK = 'sick',
+  ANNUAL = 'annual',
+  MARRIAGE = 'marriage',
+  BEREAVEMENT = 'bereavement',
+  MATERNITY = 'maternity',
+  PATERNITY = 'paternity',
+  OFFICIAL = 'official',
+}
+
+export enum HalfDayEnum {
+  FULL = 'full',
+  MORNING = 'morning',
+  AFTERNOON = 'afternoon',
+}
+
+export class CreateLeaveDto {
+  @IsEnum(LeaveTypeEnum)
+  leave_type: LeaveTypeEnum;
+
+  @IsDateString()
+  start_date: string;
+
+  @IsDateString()
+  end_date: string;
+
+  @IsOptional()
+  @IsEnum(HalfDayEnum)
+  start_half?: HalfDayEnum = HalfDayEnum.FULL;
+
+  @IsOptional()
+  @IsEnum(HalfDayEnum)
+  end_half?: HalfDayEnum = HalfDayEnum.FULL;
+
+  @IsString()
+  @MinLength(1)
+  @MaxLength(500)
+  reason: string;
+}

--- a/dev/src/leaves/dto/query-leaves.dto.ts
+++ b/dev/src/leaves/dto/query-leaves.dto.ts
@@ -1,0 +1,45 @@
+import {
+  IsOptional,
+  IsEnum,
+  IsDateString,
+  IsInt,
+  Min,
+  Max,
+} from 'class-validator';
+import { LeaveTypeEnum } from './create-leave.dto';
+
+export enum LeaveStatusEnum {
+  PENDING = 'pending',
+  APPROVED = 'approved',
+  REJECTED = 'rejected',
+  CANCELLED = 'cancelled',
+}
+
+export class QueryLeavesDto {
+  @IsOptional()
+  @IsEnum(LeaveStatusEnum)
+  status?: LeaveStatusEnum;
+
+  @IsOptional()
+  @IsEnum(LeaveTypeEnum)
+  leave_type?: LeaveTypeEnum;
+
+  @IsOptional()
+  @IsDateString()
+  start_date?: string;
+
+  @IsOptional()
+  @IsDateString()
+  end_date?: string;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(50)
+  limit?: number = 20;
+}

--- a/dev/src/leaves/leaves.controller.ts
+++ b/dev/src/leaves/leaves.controller.ts
@@ -1,0 +1,78 @@
+import {
+  Controller,
+  Post,
+  Get,
+  Put,
+  Body,
+  Param,
+  Query,
+  UseGuards,
+  HttpCode,
+  HttpStatus,
+  ParseUUIDPipe,
+} from '@nestjs/common';
+import { LeavesService } from './leaves.service';
+import { CreateLeaveDto } from './dto/create-leave.dto';
+import { QueryLeavesDto } from './dto/query-leaves.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { CurrentUser, CurrentUserData } from '../auth/decorators/current-user.decorator';
+
+@Controller('leaves')
+@UseGuards(JwtAuthGuard)
+export class LeavesController {
+  constructor(private readonly leavesService: LeavesService) {}
+
+  /**
+   * 申請請假
+   * POST /api/v1/leaves
+   */
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  async createLeave(
+    @CurrentUser() user: CurrentUserData,
+    @Body() dto: CreateLeaveDto,
+  ) {
+    return this.leavesService.createLeave(user.userId, dto);
+  }
+
+  /**
+   * 查詢個人請假紀錄
+   * GET /api/v1/leaves
+   */
+  @Get()
+  async getLeaves(
+    @CurrentUser() user: CurrentUserData,
+    @Query() query: QueryLeavesDto,
+  ) {
+    return this.leavesService.getLeaves(user.userId, query);
+  }
+
+  /**
+   * 請假詳情
+   * GET /api/v1/leaves/:id
+   */
+  @Get(':id')
+  async getLeaveById(
+    @CurrentUser() user: CurrentUserData,
+    @Param('id', ParseUUIDPipe) id: string,
+  ) {
+    return this.leavesService.getLeaveById(
+      id,
+      user.userId,
+      user.role,
+      user.departmentId,
+    );
+  }
+
+  /**
+   * 取消請假
+   * PUT /api/v1/leaves/:id/cancel
+   */
+  @Put(':id/cancel')
+  async cancelLeave(
+    @CurrentUser() user: CurrentUserData,
+    @Param('id', ParseUUIDPipe) id: string,
+  ) {
+    return this.leavesService.cancelLeave(id, user.userId);
+  }
+}

--- a/dev/src/leaves/leaves.module.ts
+++ b/dev/src/leaves/leaves.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { LeavesController } from './leaves.controller';
+import { LeavesService } from './leaves.service';
+import { LeaveQuotasModule } from '../leave-quotas/leave-quotas.module';
+
+@Module({
+  imports: [LeaveQuotasModule],
+  controllers: [LeavesController],
+  providers: [LeavesService],
+  exports: [LeavesService],
+})
+export class LeavesModule {}

--- a/dev/src/leaves/leaves.service.ts
+++ b/dev/src/leaves/leaves.service.ts
@@ -1,0 +1,571 @@
+import {
+  Injectable,
+  HttpException,
+  HttpStatus,
+  NotFoundException,
+  ForbiddenException,
+} from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { LeaveQuotasService } from '../leave-quotas/leave-quotas.service';
+import { CreateLeaveDto, HalfDayEnum } from './dto/create-leave.dto';
+import { QueryLeavesDto } from './dto/query-leaves.dto';
+
+type Decimal = Prisma.Decimal;
+const Decimal = Prisma.Decimal;
+
+/** LeaveType DTO 值 -> Prisma enum 值對照 */
+const LEAVE_TYPE_MAP: Record<string, string> = {
+  personal: 'PERSONAL',
+  sick: 'SICK',
+  annual: 'ANNUAL',
+  marriage: 'MARRIAGE',
+  bereavement: 'BEREAVEMENT',
+  maternity: 'MATERNITY',
+  paternity: 'PATERNITY',
+  official: 'OFFICIAL',
+};
+
+/** LeaveStatus DTO 值 -> Prisma enum 值對照 */
+const LEAVE_STATUS_MAP: Record<string, string> = {
+  pending: 'PENDING',
+  approved: 'APPROVED',
+  rejected: 'REJECTED',
+  cancelled: 'CANCELLED',
+};
+
+/** HalfDay DTO 值 -> Prisma enum 值對照 */
+const HALF_DAY_MAP: Record<string, string> = {
+  full: 'FULL',
+  morning: 'MORNING',
+  afternoon: 'AFTERNOON',
+};
+
+@Injectable()
+export class LeavesService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly leaveQuotasService: LeaveQuotasService,
+  ) {}
+
+  /**
+   * 計算請假時數
+   * - 同一天：依 startHalf 決定（full=8, morning=4, afternoon=4）
+   * - 跨天：首日 half + (中間天數 * 8) + 末日 half
+   */
+  calculateLeaveHours(
+    startDate: Date,
+    endDate: Date,
+    startHalf: HalfDayEnum,
+    endHalf: HalfDayEnum,
+  ): number {
+    const start = new Date(startDate);
+    start.setHours(0, 0, 0, 0);
+    const end = new Date(endDate);
+    end.setHours(0, 0, 0, 0);
+
+    const diffDays = Math.round(
+      (end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24),
+    );
+
+    if (diffDays === 0) {
+      // 同一天：startHalf 和 endHalf 相同，取 startHalf
+      return startHalf === HalfDayEnum.FULL ? 8 : 4;
+    }
+
+    // 跨天
+    const startDayHours = startHalf === HalfDayEnum.FULL ? 8 : 4;
+    const endDayHours = endHalf === HalfDayEnum.FULL ? 8 : 4;
+    const middleDays = diffDays - 1;
+
+    return startDayHours + middleDays * 8 + endDayHours;
+  }
+
+  /**
+   * 申請請假
+   */
+  async createLeave(userId: string, dto: CreateLeaveDto) {
+    const leaveType = LEAVE_TYPE_MAP[dto.leave_type];
+    const startHalf = HALF_DAY_MAP[dto.start_half || 'full'];
+    const endHalf = HALF_DAY_MAP[dto.end_half || 'full'];
+
+    const startDate = new Date(dto.start_date + 'T00:00:00.000Z');
+    const endDate = new Date(dto.end_date + 'T00:00:00.000Z');
+
+    // 驗證 end_date >= start_date
+    if (endDate < startDate) {
+      throw new HttpException(
+        {
+          code: 'INVALID_INPUT',
+          message: 'end_date 不可早於 start_date',
+        },
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    // 驗證日期不在過去（病假可追溯 3 天）
+    const today = new Date();
+    today.setUTCHours(0, 0, 0, 0);
+
+    if (leaveType === 'SICK') {
+      const minDate = new Date(today);
+      minDate.setDate(minDate.getDate() - 3);
+      if (startDate < minDate) {
+        throw new HttpException(
+          {
+            code: 'PAST_DATE',
+            message: '病假最多可追溯 3 天',
+          },
+          HttpStatus.UNPROCESSABLE_ENTITY,
+        );
+      }
+    } else {
+      if (startDate < today) {
+        throw new HttpException(
+          {
+            code: 'PAST_DATE',
+            message: '不可申請過去的日期',
+          },
+          HttpStatus.UNPROCESSABLE_ENTITY,
+        );
+      }
+    }
+
+    // 計算時數
+    const hours = this.calculateLeaveHours(
+      startDate,
+      endDate,
+      (dto.start_half || 'full') as HalfDayEnum,
+      (dto.end_half || 'full') as HalfDayEnum,
+    );
+
+    // 檢查日期衝突（pending 或 approved 的假單日期重疊）
+    await this.checkDateConflict(userId, startDate, endDate);
+
+    // 檢查額度
+    await this.checkQuota(userId, leaveType, hours, startDate);
+
+    // 建立請假紀錄
+    const leave = await this.prisma.leaveRequest.create({
+      data: {
+        userId,
+        leaveType: leaveType as never,
+        startDate,
+        endDate,
+        startHalf: startHalf as never,
+        endHalf: endHalf as never,
+        hours: new Decimal(hours),
+        reason: dto.reason,
+        status: 'PENDING' as never,
+      },
+    });
+
+    return this.formatLeaveResponse(leave);
+  }
+
+  /**
+   * 查詢個人請假紀錄
+   */
+  async getLeaves(userId: string, query: QueryLeavesDto) {
+    const { page = 1, limit = 20 } = query;
+
+    const where: Record<string, unknown> = { userId };
+
+    if (query.status) {
+      where.status = LEAVE_STATUS_MAP[query.status];
+    }
+    if (query.leave_type) {
+      where.leaveType = LEAVE_TYPE_MAP[query.leave_type];
+    }
+    if (query.start_date || query.end_date) {
+      const dateFilter: Record<string, Date> = {};
+      if (query.start_date) {
+        dateFilter.gte = new Date(query.start_date + 'T00:00:00.000Z');
+      }
+      if (query.end_date) {
+        dateFilter.lte = new Date(query.end_date + 'T00:00:00.000Z');
+      }
+      where.startDate = dateFilter;
+    }
+
+    const [leaves, total] = await Promise.all([
+      this.prisma.leaveRequest.findMany({
+        where,
+        skip: (page - 1) * limit,
+        take: limit,
+        orderBy: { createdAt: 'desc' },
+        include: {
+          reviewer: {
+            select: { id: true, name: true },
+          },
+        },
+      }),
+      this.prisma.leaveRequest.count({ where }),
+    ]);
+
+    return {
+      data: leaves.map((leave) => this.formatLeaveListItem(leave)),
+      meta: {
+        total,
+        page,
+        limit,
+        totalPages: Math.ceil(total / limit),
+      },
+    };
+  }
+
+  /**
+   * 請假詳情
+   */
+  async getLeaveById(
+    leaveId: string,
+    userId: string,
+    userRole: string,
+    userDepartmentId: string,
+  ) {
+    const leave = await this.prisma.leaveRequest.findUnique({
+      where: { id: leaveId },
+      include: {
+        user: {
+          select: {
+            id: true,
+            name: true,
+            employeeId: true,
+            departmentId: true,
+            department: { select: { id: true, name: true } },
+          },
+        },
+        reviewer: {
+          select: { id: true, name: true },
+        },
+      },
+    });
+
+    if (!leave) {
+      throw new NotFoundException({
+        code: 'NOT_FOUND',
+        message: '請假紀錄不存在',
+      });
+    }
+
+    // 權限檢查：自己的、主管看部屬的、Admin 看全部
+    if (leave.userId !== userId) {
+      if (userRole === 'ADMIN') {
+        // Admin 可看全部
+      } else if (userRole === 'MANAGER') {
+        // 主管只能看同部門
+        if (leave.user.departmentId !== userDepartmentId) {
+          throw new ForbiddenException({
+            code: 'FORBIDDEN',
+            message: '無權查看此請假紀錄',
+          });
+        }
+      } else {
+        throw new ForbiddenException({
+          code: 'FORBIDDEN',
+          message: '無權查看此請假紀錄',
+        });
+      }
+    }
+
+    return this.formatLeaveDetail(leave);
+  }
+
+  /**
+   * 取消請假
+   */
+  async cancelLeave(leaveId: string, userId: string) {
+    const leave = await this.prisma.leaveRequest.findUnique({
+      where: { id: leaveId },
+    });
+
+    if (!leave) {
+      throw new NotFoundException({
+        code: 'NOT_FOUND',
+        message: '請假紀錄不存在',
+      });
+    }
+
+    // 只能取消自己的
+    if (leave.userId !== userId) {
+      throw new ForbiddenException({
+        code: 'FORBIDDEN',
+        message: '只能取消自己的請假',
+      });
+    }
+
+    const today = new Date();
+    today.setUTCHours(0, 0, 0, 0);
+
+    if (leave.status === 'PENDING') {
+      // pending -> cancelled
+      const updated = await this.prisma.leaveRequest.update({
+        where: { id: leaveId },
+        data: { status: 'CANCELLED' as never },
+      });
+
+      return {
+        id: updated.id,
+        status: 'cancelled',
+        updated_at: updated.updatedAt.toISOString(),
+      };
+    }
+
+    if (leave.status === 'APPROVED') {
+      // approved + start_date > today -> cancelled + refund
+      if (leave.startDate > today) {
+        // 使用 transaction 同時取消假單並退還額度
+        const year = leave.startDate.getFullYear();
+        const leaveHours = Number(leave.hours);
+
+        const [updated] = await this.prisma.$transaction([
+          this.prisma.leaveRequest.update({
+            where: { id: leaveId },
+            data: { status: 'CANCELLED' as never },
+          }),
+          this.prisma.leaveQuota.updateMany({
+            where: {
+              userId: leave.userId,
+              leaveType: leave.leaveType,
+              year,
+            },
+            data: {
+              usedHours: { decrement: leaveHours },
+            },
+          }),
+        ]);
+
+        return {
+          id: updated.id,
+          status: 'cancelled',
+          updated_at: updated.updatedAt.toISOString(),
+        };
+      }
+
+      // approved + start_date <= today -> 不可取消
+      throw new HttpException(
+        {
+          code: 'LEAVE_STARTED',
+          message: '已開始的假期無法取消',
+        },
+        HttpStatus.UNPROCESSABLE_ENTITY,
+      );
+    }
+
+    // rejected / cancelled -> 不可取消
+    throw new HttpException(
+      {
+        code: 'CANNOT_CANCEL',
+        message: `狀態為 ${leave.status.toLowerCase()} 的假單無法取消`,
+      },
+      HttpStatus.UNPROCESSABLE_ENTITY,
+    );
+  }
+
+  // ── Private Methods ──
+
+  /**
+   * 檢查日期衝突：是否有 pending/approved 假單在同一日期範圍
+   */
+  private async checkDateConflict(
+    userId: string,
+    startDate: Date,
+    endDate: Date,
+  ) {
+    const conflicting = await this.prisma.leaveRequest.findFirst({
+      where: {
+        userId,
+        status: { in: ['PENDING', 'APPROVED'] as never[] },
+        // 日期範圍重疊條件
+        startDate: { lte: endDate },
+        endDate: { gte: startDate },
+      },
+    });
+
+    if (conflicting) {
+      throw new HttpException(
+        {
+          code: 'DATE_CONFLICT',
+          message: '該日期範圍已有請假申請',
+        },
+        HttpStatus.CONFLICT,
+      );
+    }
+  }
+
+  /**
+   * 檢查額度是否足夠
+   */
+  private async checkQuota(
+    userId: string,
+    leaveType: string,
+    hours: number,
+    startDate: Date,
+  ) {
+    const year = startDate.getFullYear();
+
+    const quota = await this.prisma.leaveQuota.findUnique({
+      where: {
+        userId_leaveType_year: {
+          userId,
+          leaveType: leaveType as never,
+          year,
+        },
+      },
+    });
+
+    if (!quota) {
+      throw new HttpException(
+        {
+          code: 'INSUFFICIENT_QUOTA',
+          message: '尚未設定該假別額度',
+        },
+        HttpStatus.UNPROCESSABLE_ENTITY,
+      );
+    }
+
+    const remaining = Number(quota.totalHours) - Number(quota.usedHours);
+    if (remaining < hours) {
+      throw new HttpException(
+        {
+          code: 'INSUFFICIENT_QUOTA',
+          message: `額度不足，剩餘 ${remaining} 小時，需要 ${hours} 小時`,
+        },
+        HttpStatus.UNPROCESSABLE_ENTITY,
+      );
+    }
+  }
+
+  /**
+   * 格式化單筆請假回應（POST 回傳）
+   */
+  private formatLeaveResponse(leave: {
+    id: string;
+    userId: string;
+    leaveType: string;
+    startDate: Date;
+    endDate: Date;
+    startHalf: string;
+    endHalf: string;
+    hours: Decimal | number;
+    reason: string;
+    status: string;
+    reviewerId: string | null;
+    reviewedAt: Date | null;
+    reviewComment: string | null;
+    createdAt: Date;
+  }) {
+    return {
+      id: leave.id,
+      user_id: leave.userId,
+      leave_type: leave.leaveType.toLowerCase(),
+      start_date: leave.startDate.toISOString().split('T')[0],
+      end_date: leave.endDate.toISOString().split('T')[0],
+      start_half: leave.startHalf.toLowerCase(),
+      end_half: leave.endHalf.toLowerCase(),
+      hours: Number(leave.hours),
+      reason: leave.reason,
+      status: leave.status.toLowerCase(),
+      reviewer_id: leave.reviewerId,
+      reviewed_at: leave.reviewedAt
+        ? leave.reviewedAt.toISOString()
+        : null,
+      review_comment: leave.reviewComment,
+      created_at: leave.createdAt.toISOString(),
+    };
+  }
+
+  /**
+   * 格式化列表項目（GET 列表回傳）
+   */
+  private formatLeaveListItem(leave: {
+    id: string;
+    leaveType: string;
+    startDate: Date;
+    endDate: Date;
+    startHalf: string;
+    endHalf: string;
+    hours: Decimal | number;
+    reason: string;
+    status: string;
+    reviewer: { id: string; name: string } | null;
+    createdAt: Date;
+  }) {
+    return {
+      id: leave.id,
+      leave_type: leave.leaveType.toLowerCase(),
+      start_date: leave.startDate.toISOString().split('T')[0],
+      end_date: leave.endDate.toISOString().split('T')[0],
+      start_half: leave.startHalf.toLowerCase(),
+      end_half: leave.endHalf.toLowerCase(),
+      hours: Number(leave.hours),
+      reason: leave.reason,
+      status: leave.status.toLowerCase(),
+      reviewer: leave.reviewer
+        ? { id: leave.reviewer.id, name: leave.reviewer.name }
+        : null,
+      created_at: leave.createdAt.toISOString(),
+    };
+  }
+
+  /**
+   * 格式化詳情（GET :id 回傳）
+   */
+  private formatLeaveDetail(leave: {
+    id: string;
+    userId: string;
+    leaveType: string;
+    startDate: Date;
+    endDate: Date;
+    startHalf: string;
+    endHalf: string;
+    hours: Decimal | number;
+    reason: string;
+    status: string;
+    reviewerId: string | null;
+    reviewedAt: Date | null;
+    reviewComment: string | null;
+    createdAt: Date;
+    updatedAt: Date;
+    user: {
+      id: string;
+      name: string;
+      employeeId: string;
+      departmentId: string;
+      department: { id: string; name: string };
+    };
+    reviewer: { id: string; name: string } | null;
+  }) {
+    return {
+      id: leave.id,
+      user_id: leave.userId,
+      leave_type: leave.leaveType.toLowerCase(),
+      start_date: leave.startDate.toISOString().split('T')[0],
+      end_date: leave.endDate.toISOString().split('T')[0],
+      start_half: leave.startHalf.toLowerCase(),
+      end_half: leave.endHalf.toLowerCase(),
+      hours: Number(leave.hours),
+      reason: leave.reason,
+      status: leave.status.toLowerCase(),
+      reviewer_id: leave.reviewerId,
+      reviewed_at: leave.reviewedAt
+        ? leave.reviewedAt.toISOString()
+        : null,
+      review_comment: leave.reviewComment,
+      created_at: leave.createdAt.toISOString(),
+      updated_at: leave.updatedAt.toISOString(),
+      user: {
+        id: leave.user.id,
+        name: leave.user.name,
+        employee_id: leave.user.employeeId,
+        department: {
+          id: leave.user.department.id,
+          name: leave.user.department.name,
+        },
+      },
+      reviewer: leave.reviewer
+        ? { id: leave.reviewer.id, name: leave.reviewer.name }
+        : null,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- 請假模組：建立申請、查詢紀錄、查看詳情、取消請假
- 時數計算：full=8h, morning/afternoon=4h, 跨多天自動計算
- 日期衝突偵測、額度檢查、病假追溯 3 天
- 取消邏輯：pending 可取消、approved 未開始可取消（退還額度）

## 驗收標準
- [x] POST /api/v1/leaves — 申請請假
- [x] GET /api/v1/leaves — 個人紀錄
- [x] GET /api/v1/leaves/:id — 詳情
- [x] PUT /api/v1/leaves/:id/cancel — 取消

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)