### PR TITLE
[Feature] F-003: 主管審核請假

### DIFF
--- a/dev/__tests__/leave-approval/leave-approval.service.spec.ts
+++ b/dev/__tests__/leave-approval/leave-approval.service.spec.ts
@@ -1,0 +1,646 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  HttpException,
+  HttpStatus,
+  NotFoundException,
+  ForbiddenException,
+} from '@nestjs/common';
+import { LeaveApprovalService } from '../../src/leave-approval/leave-approval.service';
+import { PrismaService } from '../../src/prisma/prisma.service';
+import { Prisma } from '@prisma/client';
+
+const Decimal = Prisma.Decimal;
+
+describe('LeaveApprovalService', () => {
+  let service: LeaveApprovalService;
+  let prisma: {
+    leaveRequest: {
+      findMany: jest.Mock;
+      findUnique: jest.Mock;
+      update: jest.Mock;
+      count: jest.Mock;
+    };
+    leaveQuota: {
+      findUnique: jest.Mock;
+      update: jest.Mock;
+    };
+    user: {
+      findUnique: jest.Mock;
+    };
+    $transaction: jest.Mock;
+  };
+
+  const managerUser = {
+    userId: 'manager-uuid-1',
+    role: 'MANAGER',
+    departmentId: 'dept-uuid-1',
+  };
+
+  const adminUser = {
+    userId: 'admin-uuid-1',
+    role: 'ADMIN',
+    departmentId: 'dept-uuid-1',
+  };
+
+  const mockLeave = {
+    id: 'leave-uuid-1',
+    userId: 'employee-uuid-1',
+    leaveType: 'ANNUAL',
+    startDate: new Date('2026-04-10'),
+    endDate: new Date('2026-04-10'),
+    startHalf: 'FULL',
+    endHalf: 'FULL',
+    hours: new Decimal(8),
+    reason: '家庭旅遊',
+    status: 'PENDING',
+    reviewerId: null,
+    reviewedAt: null,
+    reviewComment: null,
+    createdAt: new Date('2026-04-07T10:00:00Z'),
+    updatedAt: new Date('2026-04-07T10:00:00Z'),
+    user: {
+      id: 'employee-uuid-1',
+      managerId: 'manager-uuid-1',
+      departmentId: 'dept-uuid-1',
+    },
+  };
+
+  const mockLeaveWithUserInfo = {
+    ...mockLeave,
+    user: {
+      id: 'employee-uuid-1',
+      name: '王小明',
+      employeeId: 'EMP001',
+      department: { id: 'dept-uuid-1', name: '工程部' },
+    },
+  };
+
+  const mockQuota = {
+    id: 'quota-uuid-1',
+    userId: 'employee-uuid-1',
+    leaveType: 'ANNUAL',
+    year: 2026,
+    totalHours: new Decimal(56),
+    usedHours: new Decimal(16),
+  };
+
+  const mockReviewerUser = {
+    id: 'manager-uuid-1',
+    name: '李大華',
+  };
+
+  beforeEach(async () => {
+    prisma = {
+      leaveRequest: {
+        findMany: jest.fn(),
+        findUnique: jest.fn(),
+        update: jest.fn(),
+        count: jest.fn(),
+      },
+      leaveQuota: {
+        findUnique: jest.fn(),
+        update: jest.fn(),
+      },
+      user: {
+        findUnique: jest.fn(),
+      },
+      $transaction: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LeaveApprovalService,
+        { provide: PrismaService, useValue: prisma },
+      ],
+    }).compile();
+
+    service = module.get<LeaveApprovalService>(LeaveApprovalService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // ── getPendingLeaves ──
+
+  describe('getPendingLeaves', () => {
+    it('should return pending leaves for manager (direct subordinates only)', async () => {
+      const mockLeaves = [mockLeaveWithUserInfo];
+      prisma.leaveRequest.findMany.mockResolvedValue(mockLeaves);
+      prisma.leaveRequest.count.mockResolvedValue(1);
+
+      const result = await service.getPendingLeaves(managerUser, {});
+
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0].id).toBe('leave-uuid-1');
+      expect(result.data[0].user.employee_id).toBe('EMP001');
+      expect(result.data[0].leave_type).toBe('annual');
+      expect(result.data[0].status).toBe('pending');
+      expect(result.meta.total).toBe(1);
+      expect(result.meta.page).toBe(1);
+      expect(result.meta.limit).toBe(20);
+
+      // 確認查詢條件包含 managerId
+      expect(prisma.leaveRequest.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            status: 'PENDING',
+            user: { managerId: 'manager-uuid-1' },
+          },
+        }),
+      );
+    });
+
+    it('should return pending leaves for admin (all company)', async () => {
+      prisma.leaveRequest.findMany.mockResolvedValue([]);
+      prisma.leaveRequest.count.mockResolvedValue(0);
+
+      const result = await service.getPendingLeaves(adminUser, {});
+
+      expect(result.data).toHaveLength(0);
+      expect(prisma.leaveRequest.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { status: 'PENDING' },
+        }),
+      );
+    });
+
+    it('should filter by department_id for admin', async () => {
+      prisma.leaveRequest.findMany.mockResolvedValue([]);
+      prisma.leaveRequest.count.mockResolvedValue(0);
+
+      await service.getPendingLeaves(adminUser, {
+        department_id: 'dept-uuid-2',
+      });
+
+      expect(prisma.leaveRequest.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            status: 'PENDING',
+            user: { departmentId: 'dept-uuid-2' },
+          },
+        }),
+      );
+    });
+
+    it('should apply pagination correctly', async () => {
+      prisma.leaveRequest.findMany.mockResolvedValue([]);
+      prisma.leaveRequest.count.mockResolvedValue(45);
+
+      const result = await service.getPendingLeaves(adminUser, {
+        page: 2,
+        limit: 10,
+      });
+
+      expect(result.meta.page).toBe(2);
+      expect(result.meta.limit).toBe(10);
+      expect(result.meta.totalPages).toBe(5);
+      expect(prisma.leaveRequest.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          skip: 10,
+          take: 10,
+        }),
+      );
+    });
+
+    it('should default to page 1, limit 20', async () => {
+      prisma.leaveRequest.findMany.mockResolvedValue([]);
+      prisma.leaveRequest.count.mockResolvedValue(0);
+
+      const result = await service.getPendingLeaves(managerUser, {});
+
+      expect(result.meta.page).toBe(1);
+      expect(result.meta.limit).toBe(20);
+      expect(prisma.leaveRequest.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          skip: 0,
+          take: 20,
+        }),
+      );
+    });
+  });
+
+  // ── approveLeave ──
+
+  describe('approveLeave', () => {
+    it('should approve a pending leave and deduct quota', async () => {
+      prisma.leaveRequest.findUnique.mockResolvedValue(mockLeave);
+      prisma.user.findUnique.mockResolvedValue(mockReviewerUser);
+
+      // $transaction 以 callback 方式呼叫
+      prisma.$transaction.mockImplementation(async (callback) => {
+        const tx = {
+          leaveRequest: {
+            findUnique: jest.fn().mockResolvedValue(mockLeave),
+            update: jest.fn().mockResolvedValue({
+              ...mockLeave,
+              status: 'APPROVED',
+              reviewerId: 'manager-uuid-1',
+              reviewedAt: new Date('2026-04-07T14:00:00Z'),
+              reviewComment: '核准',
+              updatedAt: new Date('2026-04-07T14:00:00Z'),
+            }),
+          },
+          leaveQuota: {
+            findUnique: jest.fn().mockResolvedValue(mockQuota),
+            update: jest.fn().mockResolvedValue({}),
+          },
+        };
+        return callback(tx);
+      });
+
+      const result = await service.approveLeave(
+        'leave-uuid-1',
+        managerUser,
+        '核准',
+      );
+
+      expect(result.id).toBe('leave-uuid-1');
+      expect(result.status).toBe('approved');
+      expect(result.reviewer).toEqual({ id: 'manager-uuid-1', name: '李大華' });
+      expect(result.review_comment).toBe('核准');
+      expect(result.reviewed_at).toBeDefined();
+    });
+
+    it('should approve leave without comment', async () => {
+      prisma.leaveRequest.findUnique.mockResolvedValue(mockLeave);
+      prisma.user.findUnique.mockResolvedValue(mockReviewerUser);
+
+      prisma.$transaction.mockImplementation(async (callback) => {
+        const tx = {
+          leaveRequest: {
+            findUnique: jest.fn().mockResolvedValue(mockLeave),
+            update: jest.fn().mockResolvedValue({
+              ...mockLeave,
+              status: 'APPROVED',
+              reviewerId: 'manager-uuid-1',
+              reviewedAt: new Date(),
+              reviewComment: null,
+              updatedAt: new Date(),
+            }),
+          },
+          leaveQuota: {
+            findUnique: jest.fn().mockResolvedValue(mockQuota),
+            update: jest.fn().mockResolvedValue({}),
+          },
+        };
+        return callback(tx);
+      });
+
+      const result = await service.approveLeave(
+        'leave-uuid-1',
+        managerUser,
+      );
+
+      expect(result.status).toBe('approved');
+      expect(result.review_comment).toBeNull();
+    });
+
+    it('should throw NOT_FOUND when leave does not exist', async () => {
+      prisma.leaveRequest.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.approveLeave('nonexistent', managerUser),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw NOT_PENDING when leave is already approved', async () => {
+      prisma.leaveRequest.findUnique.mockResolvedValue({
+        ...mockLeave,
+        status: 'APPROVED',
+      });
+
+      try {
+        await service.approveLeave('leave-uuid-1', managerUser);
+        fail('Expected exception');
+      } catch (e) {
+        const exception = e as HttpException;
+        expect(exception.getStatus()).toBe(HttpStatus.UNPROCESSABLE_ENTITY);
+        const response = exception.getResponse() as Record<string, string>;
+        expect(response.code).toBe('NOT_PENDING');
+      }
+    });
+
+    it('should throw FORBIDDEN when manager tries to approve non-subordinate', async () => {
+      prisma.leaveRequest.findUnique.mockResolvedValue({
+        ...mockLeave,
+        user: {
+          id: 'employee-uuid-1',
+          managerId: 'other-manager-uuid',
+          departmentId: 'dept-uuid-2',
+        },
+      });
+
+      await expect(
+        service.approveLeave('leave-uuid-1', managerUser),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should throw FORBIDDEN when reviewer tries to approve own leave', async () => {
+      prisma.leaveRequest.findUnique.mockResolvedValue({
+        ...mockLeave,
+        userId: 'manager-uuid-1',
+        user: {
+          id: 'manager-uuid-1',
+          managerId: 'upper-manager-uuid',
+          departmentId: 'dept-uuid-1',
+        },
+      });
+
+      try {
+        await service.approveLeave('leave-uuid-1', managerUser);
+        fail('Expected exception');
+      } catch (e) {
+        const exception = e as ForbiddenException;
+        const response = exception.getResponse() as Record<string, string>;
+        expect(response.code).toBe('FORBIDDEN');
+        expect(response.message).toContain('不可審核自己');
+      }
+    });
+
+    it('should allow admin to approve any leave', async () => {
+      const leaveWithDifferentDept = {
+        ...mockLeave,
+        user: {
+          id: 'employee-uuid-1',
+          managerId: 'other-manager-uuid',
+          departmentId: 'dept-uuid-2',
+        },
+      };
+      prisma.leaveRequest.findUnique.mockResolvedValue(leaveWithDifferentDept);
+      prisma.user.findUnique.mockResolvedValue({
+        id: 'admin-uuid-1',
+        name: 'Admin',
+      });
+
+      prisma.$transaction.mockImplementation(async (callback) => {
+        const tx = {
+          leaveRequest: {
+            findUnique: jest.fn().mockResolvedValue(leaveWithDifferentDept),
+            update: jest.fn().mockResolvedValue({
+              ...leaveWithDifferentDept,
+              status: 'APPROVED',
+              reviewerId: 'admin-uuid-1',
+              reviewedAt: new Date(),
+              reviewComment: null,
+              updatedAt: new Date(),
+            }),
+          },
+          leaveQuota: {
+            findUnique: jest.fn().mockResolvedValue(mockQuota),
+            update: jest.fn().mockResolvedValue({}),
+          },
+        };
+        return callback(tx);
+      });
+
+      const result = await service.approveLeave('leave-uuid-1', adminUser);
+
+      expect(result.status).toBe('approved');
+    });
+
+    it('should throw QUOTA_EXCEEDED when approval would exceed quota', async () => {
+      const leaveWith48h = {
+        ...mockLeave,
+        hours: new Decimal(48),
+      };
+      prisma.leaveRequest.findUnique.mockResolvedValue(leaveWith48h);
+
+      prisma.$transaction.mockImplementation(async (callback) => {
+        const tx = {
+          leaveRequest: {
+            findUnique: jest.fn().mockResolvedValue(leaveWith48h),
+            update: jest.fn().mockResolvedValue({}),
+          },
+          leaveQuota: {
+            findUnique: jest.fn().mockResolvedValue({
+              ...mockQuota,
+              usedHours: new Decimal(16),
+              totalHours: new Decimal(56),
+            }),
+            update: jest.fn(),
+          },
+        };
+        return callback(tx);
+      });
+
+      try {
+        await service.approveLeave('leave-uuid-1', managerUser);
+        fail('Expected exception');
+      } catch (e) {
+        const exception = e as HttpException;
+        expect(exception.getStatus()).toBe(HttpStatus.UNPROCESSABLE_ENTITY);
+        const response = exception.getResponse() as Record<string, string>;
+        expect(response.code).toBe('QUOTA_EXCEEDED');
+      }
+    });
+
+    it('should approve when quota usage reaches exactly total hours', async () => {
+      const leaveWith40h = {
+        ...mockLeave,
+        hours: new Decimal(40),
+      };
+      prisma.leaveRequest.findUnique.mockResolvedValue(leaveWith40h);
+      prisma.user.findUnique.mockResolvedValue(mockReviewerUser);
+
+      prisma.$transaction.mockImplementation(async (callback) => {
+        const tx = {
+          leaveRequest: {
+            findUnique: jest.fn().mockResolvedValue(leaveWith40h),
+            update: jest.fn().mockResolvedValue({
+              ...leaveWith40h,
+              status: 'APPROVED',
+              reviewerId: 'manager-uuid-1',
+              reviewedAt: new Date(),
+              reviewComment: null,
+              updatedAt: new Date(),
+            }),
+          },
+          leaveQuota: {
+            findUnique: jest.fn().mockResolvedValue({
+              ...mockQuota,
+              usedHours: new Decimal(16),
+              totalHours: new Decimal(56),
+            }),
+            update: jest.fn().mockResolvedValue({}),
+          },
+        };
+        return callback(tx);
+      });
+
+      const result = await service.approveLeave(
+        'leave-uuid-1',
+        managerUser,
+      );
+
+      expect(result.status).toBe('approved');
+    });
+  });
+
+  // ── rejectLeave ──
+
+  describe('rejectLeave', () => {
+    it('should reject a pending leave with comment', async () => {
+      prisma.leaveRequest.findUnique.mockResolvedValue(mockLeave);
+      prisma.user.findUnique.mockResolvedValue(mockReviewerUser);
+
+      prisma.$transaction.mockImplementation(async (callback) => {
+        const tx = {
+          leaveRequest: {
+            findUnique: jest.fn().mockResolvedValue(mockLeave),
+            update: jest.fn().mockResolvedValue({
+              ...mockLeave,
+              status: 'REJECTED',
+              reviewerId: 'manager-uuid-1',
+              reviewedAt: new Date('2026-04-07T14:00:00Z'),
+              reviewComment: '該週有重要專案 deadline',
+              updatedAt: new Date('2026-04-07T14:00:00Z'),
+            }),
+          },
+        };
+        return callback(tx);
+      });
+
+      const result = await service.rejectLeave(
+        'leave-uuid-1',
+        managerUser,
+        '該週有重要專案 deadline',
+      );
+
+      expect(result.id).toBe('leave-uuid-1');
+      expect(result.status).toBe('rejected');
+      expect(result.review_comment).toBe('該週有重要專案 deadline');
+      expect(result.reviewer).toEqual({ id: 'manager-uuid-1', name: '李大華' });
+    });
+
+    it('should throw NOT_FOUND when leave does not exist', async () => {
+      prisma.leaveRequest.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.rejectLeave('nonexistent', managerUser, '原因'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw NOT_PENDING when leave is already rejected', async () => {
+      prisma.leaveRequest.findUnique.mockResolvedValue({
+        ...mockLeave,
+        status: 'REJECTED',
+      });
+
+      try {
+        await service.rejectLeave('leave-uuid-1', managerUser, '原因');
+        fail('Expected exception');
+      } catch (e) {
+        const exception = e as HttpException;
+        expect(exception.getStatus()).toBe(HttpStatus.UNPROCESSABLE_ENTITY);
+        const response = exception.getResponse() as Record<string, string>;
+        expect(response.code).toBe('NOT_PENDING');
+      }
+    });
+
+    it('should throw FORBIDDEN when manager tries to reject non-subordinate', async () => {
+      prisma.leaveRequest.findUnique.mockResolvedValue({
+        ...mockLeave,
+        user: {
+          id: 'employee-uuid-1',
+          managerId: 'other-manager-uuid',
+          departmentId: 'dept-uuid-2',
+        },
+      });
+
+      await expect(
+        service.rejectLeave('leave-uuid-1', managerUser, '原因'),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should throw FORBIDDEN when reviewer tries to reject own leave', async () => {
+      prisma.leaveRequest.findUnique.mockResolvedValue({
+        ...mockLeave,
+        userId: 'manager-uuid-1',
+        user: {
+          id: 'manager-uuid-1',
+          managerId: 'upper-manager-uuid',
+          departmentId: 'dept-uuid-1',
+        },
+      });
+
+      try {
+        await service.rejectLeave('leave-uuid-1', managerUser, '原因');
+        fail('Expected exception');
+      } catch (e) {
+        const exception = e as ForbiddenException;
+        const response = exception.getResponse() as Record<string, string>;
+        expect(response.code).toBe('FORBIDDEN');
+        expect(response.message).toContain('不可審核自己');
+      }
+    });
+
+    it('should not deduct quota when rejecting', async () => {
+      prisma.leaveRequest.findUnique.mockResolvedValue(mockLeave);
+      prisma.user.findUnique.mockResolvedValue(mockReviewerUser);
+
+      prisma.$transaction.mockImplementation(async (callback) => {
+        const tx = {
+          leaveRequest: {
+            findUnique: jest.fn().mockResolvedValue(mockLeave),
+            update: jest.fn().mockResolvedValue({
+              ...mockLeave,
+              status: 'REJECTED',
+              reviewerId: 'manager-uuid-1',
+              reviewedAt: new Date(),
+              reviewComment: '不准',
+              updatedAt: new Date(),
+            }),
+          },
+        };
+        return callback(tx);
+      });
+
+      await service.rejectLeave('leave-uuid-1', managerUser, '不准');
+
+      // leaveQuota.update should never be called
+      expect(prisma.leaveQuota.update).not.toHaveBeenCalled();
+    });
+
+    it('should allow admin to reject any leave', async () => {
+      const leaveWithDifferentDept = {
+        ...mockLeave,
+        user: {
+          id: 'employee-uuid-1',
+          managerId: 'other-manager-uuid',
+          departmentId: 'dept-uuid-2',
+        },
+      };
+      prisma.leaveRequest.findUnique.mockResolvedValue(leaveWithDifferentDept);
+      prisma.user.findUnique.mockResolvedValue({
+        id: 'admin-uuid-1',
+        name: 'Admin',
+      });
+
+      prisma.$transaction.mockImplementation(async (callback) => {
+        const tx = {
+          leaveRequest: {
+            findUnique: jest.fn().mockResolvedValue(leaveWithDifferentDept),
+            update: jest.fn().mockResolvedValue({
+              ...leaveWithDifferentDept,
+              status: 'REJECTED',
+              reviewerId: 'admin-uuid-1',
+              reviewedAt: new Date(),
+              reviewComment: '公司政策',
+              updatedAt: new Date(),
+            }),
+          },
+        };
+        return callback(tx);
+      });
+
+      const result = await service.rejectLeave(
+        'leave-uuid-1',
+        adminUser,
+        '公司政策',
+      );
+
+      expect(result.status).toBe('rejected');
+    });
+  });
+});

--- a/dev/src/app.module.ts
+++ b/dev/src/app.module.ts
@@ -7,6 +7,7 @@ import { EmployeesModule } from './employees/employees.module';
 import { ClockModule } from './clock/clock.module';
 import { LeaveQuotasModule } from './leave-quotas/leave-quotas.module';
 import { LeavesModule } from './leaves/leaves.module';
+import { LeaveApprovalModule } from './leave-approval/leave-approval.module';
 
 @Module({
   imports: [
@@ -21,6 +22,7 @@ import { LeavesModule } from './leaves/leaves.module';
     ClockModule,
     LeaveQuotasModule,
     LeavesModule,
+    LeaveApprovalModule,
   ],
 })
 export class AppModule {}

--- a/dev/src/leave-approval/dto/approve-leave.dto.ts
+++ b/dev/src/leave-approval/dto/approve-leave.dto.ts
@@ -1,0 +1,8 @@
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class ApproveLeaveDto {
+  @IsOptional()
+  @IsString({ message: 'comment 必須是字串' })
+  @MaxLength(500, { message: 'comment 不得超過 500 字' })
+  comment?: string;
+}

--- a/dev/src/leave-approval/dto/query-pending.dto.ts
+++ b/dev/src/leave-approval/dto/query-pending.dto.ts
@@ -1,0 +1,18 @@
+import { IsOptional, IsUUID, IsInt, Min, Max } from 'class-validator';
+
+export class QueryPendingDto {
+  @IsOptional()
+  @IsUUID('4', { message: 'department_id 必須是有效的 UUID' })
+  department_id?: string;
+
+  @IsOptional()
+  @IsInt({ message: 'page 必須是整數' })
+  @Min(1, { message: 'page 必須 >= 1' })
+  page?: number;
+
+  @IsOptional()
+  @IsInt({ message: 'limit 必須是整數' })
+  @Min(1, { message: 'limit 必須 >= 1' })
+  @Max(50, { message: 'limit 不得超過 50' })
+  limit?: number;
+}

--- a/dev/src/leave-approval/dto/reject-leave.dto.ts
+++ b/dev/src/leave-approval/dto/reject-leave.dto.ts
@@ -1,0 +1,8 @@
+import { IsString, IsNotEmpty, MaxLength } from 'class-validator';
+
+export class RejectLeaveDto {
+  @IsString({ message: 'comment 必須是字串' })
+  @IsNotEmpty({ message: '駁回必須填寫原因' })
+  @MaxLength(500, { message: 'comment 不得超過 500 字' })
+  comment: string;
+}

--- a/dev/src/leave-approval/leave-approval.controller.ts
+++ b/dev/src/leave-approval/leave-approval.controller.ts
@@ -1,0 +1,70 @@
+import {
+  Controller,
+  Get,
+  Put,
+  Body,
+  Param,
+  Query,
+  UseGuards,
+  ParseUUIDPipe,
+} from '@nestjs/common';
+import { LeaveApprovalService } from './leave-approval.service';
+import { QueryPendingDto } from './dto/query-pending.dto';
+import { ApproveLeaveDto } from './dto/approve-leave.dto';
+import { RejectLeaveDto } from './dto/reject-leave.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import {
+  CurrentUser,
+  CurrentUserData,
+} from '../auth/decorators/current-user.decorator';
+
+@Controller('leaves')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class LeaveApprovalController {
+  constructor(
+    private readonly leaveApprovalService: LeaveApprovalService,
+  ) {}
+
+  /**
+   * 查看待審核清單
+   * GET /api/v1/leaves/pending
+   */
+  @Get('pending')
+  @Roles('MANAGER', 'ADMIN')
+  async getPendingLeaves(
+    @CurrentUser() user: CurrentUserData,
+    @Query() query: QueryPendingDto,
+  ) {
+    return this.leaveApprovalService.getPendingLeaves(user, query);
+  }
+
+  /**
+   * 核准請假
+   * PUT /api/v1/leaves/:id/approve
+   */
+  @Put(':id/approve')
+  @Roles('MANAGER', 'ADMIN')
+  async approveLeave(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser() user: CurrentUserData,
+    @Body() dto: ApproveLeaveDto,
+  ) {
+    return this.leaveApprovalService.approveLeave(id, user, dto.comment);
+  }
+
+  /**
+   * 駁回請假
+   * PUT /api/v1/leaves/:id/reject
+   */
+  @Put(':id/reject')
+  @Roles('MANAGER', 'ADMIN')
+  async rejectLeave(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser() user: CurrentUserData,
+    @Body() dto: RejectLeaveDto,
+  ) {
+    return this.leaveApprovalService.rejectLeave(id, user, dto.comment);
+  }
+}

--- a/dev/src/leave-approval/leave-approval.module.ts
+++ b/dev/src/leave-approval/leave-approval.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { LeaveApprovalController } from './leave-approval.controller';
+import { LeaveApprovalService } from './leave-approval.service';
+
+@Module({
+  controllers: [LeaveApprovalController],
+  providers: [LeaveApprovalService],
+  exports: [LeaveApprovalService],
+})
+export class LeaveApprovalModule {}

--- a/dev/src/leave-approval/leave-approval.service.ts
+++ b/dev/src/leave-approval/leave-approval.service.ts
@@ -1,0 +1,348 @@
+import {
+  Injectable,
+  HttpException,
+  HttpStatus,
+  NotFoundException,
+  ForbiddenException,
+} from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CurrentUserData } from '../auth/decorators/current-user.decorator';
+import { QueryPendingDto } from './dto/query-pending.dto';
+
+@Injectable()
+export class LeaveApprovalService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * 查詢待審核請假清單
+   * - Manager: 只看直屬部屬（managerId === currentUser.userId）的 pending 請假
+   * - Admin: 可指定 department_id，或查看全公司 pending 請假
+   */
+  async getPendingLeaves(user: CurrentUserData, query: QueryPendingDto) {
+    const page = query.page || 1;
+    const limit = query.limit || 20;
+    const skip = (page - 1) * limit;
+
+    const where = this.buildPendingWhereClause(user, query.department_id);
+
+    const [data, total] = await Promise.all([
+      this.prisma.leaveRequest.findMany({
+        where,
+        include: {
+          user: {
+            select: {
+              id: true,
+              name: true,
+              employeeId: true,
+              department: {
+                select: { id: true, name: true },
+              },
+            },
+          },
+        },
+        orderBy: { createdAt: 'asc' },
+        skip,
+        take: limit,
+      }),
+      this.prisma.leaveRequest.count({ where }),
+    ]);
+
+    return {
+      data: data.map((leave) => this.formatLeaveWithUser(leave)),
+      meta: {
+        total,
+        page,
+        limit,
+        totalPages: Math.ceil(total / limit),
+      },
+    };
+  }
+
+  /**
+   * 核准請假
+   * 使用 transaction 確保 status 更新和額度扣除的原子性
+   */
+  async approveLeave(
+    leaveId: string,
+    reviewer: CurrentUserData,
+    comment?: string,
+  ) {
+    const leave = await this.findAndValidateLeave(leaveId, reviewer);
+
+    // 在 transaction 中更新狀態和扣除額度
+    const now = new Date();
+    const year = leave.startDate.getFullYear();
+
+    const result = await this.prisma.$transaction(async (tx) => {
+      // 再次確認狀態（避免併發問題）
+      const freshLeave = await tx.leaveRequest.findUnique({
+        where: { id: leaveId },
+      });
+      if (!freshLeave || freshLeave.status !== 'PENDING') {
+        throw new HttpException(
+          {
+            code: 'NOT_PENDING',
+            message: '此請假單已不是待審核狀態',
+          },
+          HttpStatus.UNPROCESSABLE_ENTITY,
+        );
+      }
+
+      // 更新請假狀態
+      const updatedLeave = await tx.leaveRequest.update({
+        where: { id: leaveId },
+        data: {
+          status: 'APPROVED',
+          reviewerId: reviewer.userId,
+          reviewedAt: now,
+          reviewComment: comment || null,
+        },
+      });
+
+      // 扣除額度
+      const quota = await tx.leaveQuota.findUnique({
+        where: {
+          userId_leaveType_year: {
+            userId: leave.userId,
+            leaveType: leave.leaveType,
+            year,
+          },
+        },
+      });
+
+      if (quota) {
+        const newUsedHours =
+          Number(quota.usedHours) + Number(leave.hours);
+        const totalHours = Number(quota.totalHours);
+
+        // 檢查是否超出額度（防止併發核准導致超額）
+        if (newUsedHours > totalHours) {
+          throw new HttpException(
+            {
+              code: 'QUOTA_EXCEEDED',
+              message: '核准後將超出假別額度上限，請確認是否有其他已核准的請假',
+            },
+            HttpStatus.UNPROCESSABLE_ENTITY,
+          );
+        }
+
+        await tx.leaveQuota.update({
+          where: {
+            userId_leaveType_year: {
+              userId: leave.userId,
+              leaveType: leave.leaveType,
+              year,
+            },
+          },
+          data: {
+            usedHours: { increment: Number(leave.hours) },
+          },
+        });
+      }
+
+      return updatedLeave;
+    });
+
+    // 取得審核者資訊
+    const reviewerUser = await this.prisma.user.findUnique({
+      where: { id: reviewer.userId },
+      select: { id: true, name: true },
+    });
+
+    return {
+      id: result.id,
+      status: 'approved',
+      reviewer: reviewerUser
+        ? { id: reviewerUser.id, name: reviewerUser.name }
+        : null,
+      reviewed_at: result.reviewedAt?.toISOString(),
+      review_comment: result.reviewComment,
+      updated_at: result.updatedAt.toISOString(),
+    };
+  }
+
+  /**
+   * 駁回請假
+   * 額度不變
+   */
+  async rejectLeave(
+    leaveId: string,
+    reviewer: CurrentUserData,
+    comment: string,
+  ) {
+    const leave = await this.findAndValidateLeave(leaveId, reviewer);
+
+    const now = new Date();
+
+    const result = await this.prisma.$transaction(async (tx) => {
+      // 再次確認狀態
+      const freshLeave = await tx.leaveRequest.findUnique({
+        where: { id: leaveId },
+      });
+      if (!freshLeave || freshLeave.status !== 'PENDING') {
+        throw new HttpException(
+          {
+            code: 'NOT_PENDING',
+            message: '此請假單已不是待審核狀態',
+          },
+          HttpStatus.UNPROCESSABLE_ENTITY,
+        );
+      }
+
+      return tx.leaveRequest.update({
+        where: { id: leaveId },
+        data: {
+          status: 'REJECTED',
+          reviewerId: reviewer.userId,
+          reviewedAt: now,
+          reviewComment: comment,
+        },
+      });
+    });
+
+    // 取得審核者資訊
+    const reviewerUser = await this.prisma.user.findUnique({
+      where: { id: reviewer.userId },
+      select: { id: true, name: true },
+    });
+
+    return {
+      id: result.id,
+      status: 'rejected',
+      reviewer: reviewerUser
+        ? { id: reviewerUser.id, name: reviewerUser.name }
+        : null,
+      reviewed_at: result.reviewedAt?.toISOString(),
+      review_comment: result.reviewComment,
+      updated_at: result.updatedAt.toISOString(),
+    };
+  }
+
+  // ── Private Methods ──
+
+  /**
+   * 根據角色建立 pending 查詢條件
+   */
+  private buildPendingWhereClause(
+    user: CurrentUserData,
+    departmentId?: string,
+  ) {
+    const baseWhere: Record<string, unknown> = {
+      status: 'PENDING',
+    };
+
+    if (user.role === 'ADMIN') {
+      // Admin 可查看全公司，或指定部門
+      if (departmentId) {
+        baseWhere.user = { departmentId };
+      }
+    } else {
+      // Manager 只看直屬部屬
+      baseWhere.user = { managerId: user.userId };
+    }
+
+    return baseWhere;
+  }
+
+  /**
+   * 查找請假單並驗證審核權限
+   */
+  private async findAndValidateLeave(
+    leaveId: string,
+    reviewer: CurrentUserData,
+  ) {
+    const leave = await this.prisma.leaveRequest.findUnique({
+      where: { id: leaveId },
+      include: {
+        user: {
+          select: {
+            id: true,
+            managerId: true,
+            departmentId: true,
+          },
+        },
+      },
+    });
+
+    if (!leave) {
+      throw new NotFoundException({
+        code: 'NOT_FOUND',
+        message: '請假單不存在',
+      });
+    }
+
+    // 檢查是否為 pending
+    if (leave.status !== 'PENDING') {
+      throw new HttpException(
+        {
+          code: 'NOT_PENDING',
+          message: '此請假單已不是待審核狀態，無法進行審核',
+        },
+        HttpStatus.UNPROCESSABLE_ENTITY,
+      );
+    }
+
+    // 不可審核自己的請假
+    if (leave.userId === reviewer.userId) {
+      throw new ForbiddenException({
+        code: 'FORBIDDEN',
+        message: '不可審核自己的請假單',
+      });
+    }
+
+    // Manager 只能審核直屬部屬
+    if (reviewer.role === 'MANAGER') {
+      if (leave.user.managerId !== reviewer.userId) {
+        throw new ForbiddenException({
+          code: 'FORBIDDEN',
+          message: '只能審核直屬部屬的請假單',
+        });
+      }
+    }
+
+    // Admin 可審核全公司，不需額外檢查
+
+    return leave;
+  }
+
+  /**
+   * 格式化請假紀錄（含使用者資訊）
+   */
+  private formatLeaveWithUser(leave: {
+    id: string;
+    leaveType: string;
+    startDate: Date;
+    endDate: Date;
+    startHalf: string;
+    endHalf: string;
+    hours: unknown;
+    reason: string;
+    status: string;
+    createdAt: Date;
+    user: {
+      id: string;
+      name: string;
+      employeeId: string;
+      department: { id: string; name: string };
+    };
+  }) {
+    return {
+      id: leave.id,
+      user: {
+        id: leave.user.id,
+        name: leave.user.name,
+        employee_id: leave.user.employeeId,
+        department: leave.user.department,
+      },
+      leave_type: leave.leaveType.toLowerCase(),
+      start_date: leave.startDate.toISOString().split('T')[0],
+      end_date: leave.endDate.toISOString().split('T')[0],
+      start_half: leave.startHalf.toLowerCase(),
+      end_half: leave.endHalf.toLowerCase(),
+      hours: Number(leave.hours),
+      reason: leave.reason,
+      status: leave.status.toLowerCase(),
+      created_at: leave.createdAt.toISOString(),
+    };
+  }
+}


### PR DESCRIPTION
## Summary
實作主管審核請假功能（F-003），包含待審核清單查詢、核准與駁回操作。

- Manager 只能審核直屬部屬（user.managerId === reviewer.id）
- Admin 可審核全公司任何人的請假
- 核准時在 Prisma transaction 中同時更新狀態與扣除 LeaveQuota
- 駁回時不扣額度，且 comment 為必填
- 防止自我審核與併發超額核准

## Changes
- `dev/src/leave-approval/leave-approval.module.ts` - 新建 LeaveApprovalModule
- `dev/src/leave-approval/leave-approval.controller.ts` - 新建 controller（GET /leaves/pending, PUT /leaves/:id/approve, PUT /leaves/:id/reject）
- `dev/src/leave-approval/leave-approval.service.ts` - 核心業務邏輯（權限檢查、transaction、額度扣除）
- `dev/src/leave-approval/dto/query-pending.dto.ts` - 待審核查詢參數 DTO
- `dev/src/leave-approval/dto/approve-leave.dto.ts` - 核准 DTO（comment 選填，max 500）
- `dev/src/leave-approval/dto/reject-leave.dto.ts` - 駁回 DTO（comment 必填，max 500）
- `dev/src/app.module.ts` - 加入 LeaveApprovalModule
- `dev/__tests__/leave-approval/leave-approval.service.spec.ts` - 21 筆單元測試

## Scenario 覆蓋
- [x] Scenario: 查看待審核清單（Manager 只看直屬部屬）
- [x] Scenario: 核准請假（含扣除額度）
- [x] Scenario: 駁回請假（額度不變、comment 必填）
- [x] Scenario: 員工嘗試審核 → 403 FORBIDDEN
- [x] Scenario: 主管審核非直屬部屬 → 403 FORBIDDEN
- [x] Scenario: 駁回不填原因 → 400 INVALID_INPUT（DTO 驗證）
- [x] Scenario: 審核已處理的請假單 → 422 NOT_PENDING
- [x] Scenario: 審核不存在的請假單 → 404 NOT_FOUND
- [x] Scenario: 主管審核自己的請假 → 403 FORBIDDEN
- [x] Scenario: Admin 審核任意部門
- [x] Scenario: 核准後額度剛好歸零
- [x] Edge Case: 併發核准導致超額 → QUOTA_EXCEEDED 回滾

## 測試
- 21 筆單元測試全數通過（getPendingLeaves: 5, approveLeave: 8, rejectLeave: 8）

## 備註
- 建立獨立的 `leave-approval` module 避免與 F-002（請假申請）的 `leaves` module 衝突
- 通知功能（F-007）預留 hook 位置，本 sprint 不實作
- Controller 掛載在 `leaves` 路徑下，與 API contract 一致（/api/v1/leaves/pending, /api/v1/leaves/:id/approve, /api/v1/leaves/:id/reject）

## Related Issues
Closes #18