### PR TITLE
[QA] Sprint 3 - 可視化 E2E tests (API + Playwright)

### DIFF
--- a/test/browser/calendar.spec.ts
+++ b/test/browser/calendar.spec.ts
@@ -1,0 +1,220 @@
+import { test, expect } from '@playwright/test';
+import {
+  loginViaUI,
+  loginAsEmployee,
+  loginAsManager,
+  loginAsAdmin,
+  takeScreenshot,
+  LOGIN_CREDENTIALS,
+} from './helpers';
+
+const FEATURE = 'F-004';
+
+/**
+ * 行事曆頁面 Browser 測試
+ *
+ * 驗證個人行事曆和團隊行事曆的 UI 互動流程
+ */
+
+test.describe(`[${FEATURE}] 行事曆頁面 - Browser Test`, () => {
+  // =============================================
+  // 個人行事曆
+  // =============================================
+  test.describe('個人行事曆', () => {
+    test('Scenario: 查看個人月行事曆 - 顯示月曆視圖', async ({ page }) => {
+      // GIVEN - 以員工身份登入
+      await loginAsEmployee(page);
+
+      // WHEN - 導航到個人行事曆頁面
+      const calendarPaths = ['/calendar', '/calendar/personal', '/attendance/calendar', '/dashboard'];
+      let found = false;
+      for (const path of calendarPaths) {
+        await page.goto(path);
+        await page.waitForLoadState('networkidle');
+        // 檢查是否有月曆相關元素
+        const hasCalendar = await page
+          .locator('[class*="calendar"], [role="grid"], table, [class*="month"]')
+          .first()
+          .isVisible()
+          .catch(() => false);
+        if (hasCalendar) {
+          found = true;
+          break;
+        }
+      }
+
+      // THEN - 應顯示行事曆視圖
+      if (found) {
+        // 驗證包含日期格子
+        const dayCells = page.locator('[class*="day"], [role="gridcell"], td').first();
+        await expect(dayCells).toBeVisible({ timeout: 10000 });
+      }
+      await takeScreenshot(page, FEATURE, 'personal-calendar-view');
+    });
+
+    test('Scenario: 月份切換功能', async ({ page }) => {
+      // GIVEN
+      await loginAsEmployee(page);
+
+      // WHEN - 導航到行事曆
+      const calendarPaths = ['/calendar', '/calendar/personal', '/attendance/calendar'];
+      for (const path of calendarPaths) {
+        await page.goto(path);
+        await page.waitForLoadState('networkidle');
+        const hasCalendar = await page
+          .locator('[class*="calendar"], [role="grid"], table')
+          .first()
+          .isVisible()
+          .catch(() => false);
+        if (hasCalendar) break;
+      }
+
+      // 嘗試切換月份（找下一月/上一月按鈕）
+      const nextBtn = page
+        .getByRole('button', { name: /next|下一月|>|後/i })
+        .or(page.locator('[aria-label*="next"], [class*="next"]'))
+        .first();
+
+      const prevBtn = page
+        .getByRole('button', { name: /prev|上一月|<|前/i })
+        .or(page.locator('[aria-label*="prev"], [class*="prev"]'))
+        .first();
+
+      const hasNav = await nextBtn.isVisible().catch(() => false)
+        || await prevBtn.isVisible().catch(() => false);
+
+      if (hasNav) {
+        await takeScreenshot(page, FEATURE, 'calendar-before-month-switch');
+        if (await nextBtn.isVisible().catch(() => false)) {
+          await nextBtn.click();
+          await page.waitForLoadState('networkidle');
+        }
+        await takeScreenshot(page, FEATURE, 'calendar-after-month-switch');
+      }
+
+      // THEN - 頁面不應出錯
+      await expect(page.locator('body')).toBeVisible();
+    });
+
+    test('Scenario: 點擊日期查看詳情', async ({ page }) => {
+      // GIVEN
+      await loginAsEmployee(page);
+
+      const calendarPaths = ['/calendar', '/calendar/personal', '/attendance/calendar'];
+      for (const path of calendarPaths) {
+        await page.goto(path);
+        await page.waitForLoadState('networkidle');
+        const hasCalendar = await page
+          .locator('[class*="calendar"], [role="grid"], table')
+          .first()
+          .isVisible()
+          .catch(() => false);
+        if (hasCalendar) break;
+      }
+
+      // WHEN - 點擊一個日期格子
+      const dayCell = page
+        .locator('[class*="day"], [role="gridcell"], td')
+        .filter({ hasText: /\d+/ })
+        .first();
+
+      if (await dayCell.isVisible().catch(() => false)) {
+        await dayCell.click();
+        await page.waitForTimeout(500);
+        await takeScreenshot(page, FEATURE, 'calendar-day-detail');
+      }
+
+      // THEN - 頁面不應出錯
+      await expect(page.locator('body')).toBeVisible();
+    });
+  });
+
+  // =============================================
+  // 團隊行事曆
+  // =============================================
+  test.describe('團隊行事曆', () => {
+    test('Scenario: 主管查看團隊行事曆 - 顯示成員列表', async ({ page }) => {
+      // GIVEN - 以主管身份登入
+      await loginAsManager(page);
+
+      // WHEN - 導航到團隊行事曆
+      const teamPaths = ['/calendar/team', '/team/calendar', '/calendar?view=team', '/attendance/team'];
+      let found = false;
+      for (const path of teamPaths) {
+        await page.goto(path);
+        await page.waitForLoadState('networkidle');
+        // 檢查是否有表格或成員列表
+        const hasTeamView = await page
+          .locator('table, [role="table"], [class*="team"], [class*="member"]')
+          .first()
+          .isVisible()
+          .catch(() => false);
+        if (hasTeamView) {
+          found = true;
+          break;
+        }
+      }
+
+      // THEN - 應顯示團隊成員的出勤狀態
+      if (found) {
+        // 應有多列資料（成員）
+        const rows = page.locator('table tr, [role="row"]');
+        const count = await rows.count().catch(() => 0);
+        expect(count).toBeGreaterThan(0);
+      }
+      await takeScreenshot(page, FEATURE, 'team-calendar-view');
+    });
+
+    test('Scenario: 員工無法存取團隊行事曆 - 403 或重導向', async ({ page }) => {
+      // GIVEN - 以員工身份登入
+      await loginAsEmployee(page);
+
+      // WHEN - 嘗試存取團隊行事曆
+      const teamPaths = ['/calendar/team', '/team/calendar'];
+      for (const path of teamPaths) {
+        await page.goto(path);
+        await page.waitForLoadState('networkidle');
+      }
+
+      // THEN - 應顯示錯誤訊息或被重導向
+      const hasError = await page
+        .getByText(/forbidden|無權限|403|不允許|permission/i)
+        .first()
+        .isVisible()
+        .catch(() => false);
+
+      const redirected = !page.url().includes('/calendar/team')
+        && !page.url().includes('/team/calendar');
+
+      // 員工應該被拒絕或被重導向
+      expect(hasError || redirected).toBe(true);
+      await takeScreenshot(page, FEATURE, 'employee-team-calendar-forbidden');
+    });
+  });
+
+  // =============================================
+  // 出勤狀態顏色標示
+  // =============================================
+  test.describe('UI 呈現', () => {
+    test('Scenario: 行事曆顯示出勤狀態標示', async ({ page }) => {
+      // GIVEN
+      await loginAsEmployee(page);
+
+      const calendarPaths = ['/calendar', '/calendar/personal', '/attendance/calendar'];
+      for (const path of calendarPaths) {
+        await page.goto(path);
+        await page.waitForLoadState('networkidle');
+        const hasCalendar = await page
+          .locator('[class*="calendar"], [role="grid"], table')
+          .first()
+          .isVisible()
+          .catch(() => false);
+        if (hasCalendar) break;
+      }
+
+      // THEN - 截圖記錄 UI 狀態（顏色標示由視覺驗證）
+      await takeScreenshot(page, FEATURE, 'calendar-attendance-status-colors');
+      await expect(page.locator('body')).toBeVisible();
+    });
+  });
+});

--- a/test/browser/reports.spec.ts
+++ b/test/browser/reports.spec.ts
@@ -1,0 +1,286 @@
+import { test, expect } from '@playwright/test';
+import {
+  loginViaUI,
+  loginAsEmployee,
+  loginAsManager,
+  loginAsAdmin,
+  takeScreenshot,
+  LOGIN_CREDENTIALS,
+} from './helpers';
+
+const FEATURE = 'F-005';
+
+/**
+ * 出席報表頁面 Browser 測試
+ *
+ * 驗證個人報表、團隊報表、全公司報表和匯出功能的 UI 流程
+ */
+
+test.describe(`[${FEATURE}] 出席報表頁面 - Browser Test`, () => {
+  // =============================================
+  // 個人出勤摘要
+  // =============================================
+  test.describe('個人出勤摘要', () => {
+    test('Scenario: 查看個人月報 - 顯示出勤統計', async ({ page }) => {
+      // GIVEN - 以員工身份登入
+      await loginAsEmployee(page);
+
+      // WHEN - 導航到個人報表頁面
+      const reportPaths = ['/reports', '/reports/personal', '/attendance/report', '/dashboard'];
+      let found = false;
+      for (const path of reportPaths) {
+        await page.goto(path);
+        await page.waitForLoadState('networkidle');
+        const hasReport = await page
+          .locator('[class*="report"], [class*="summary"], [class*="stat"], [class*="card"]')
+          .first()
+          .isVisible()
+          .catch(() => false);
+        if (hasReport) {
+          found = true;
+          break;
+        }
+      }
+
+      // THEN - 應顯示出勤統計資訊
+      if (found) {
+        // 檢查常見的報表欄位文字
+        const hasAttendanceInfo = await page
+          .getByText(/出勤|attendance|present|工作日|workday/i)
+          .first()
+          .isVisible()
+          .catch(() => false);
+        // 至少頁面有內容
+        expect(await page.locator('body').textContent()).toBeTruthy();
+      }
+      await takeScreenshot(page, FEATURE, 'personal-report-view');
+    });
+
+    test('Scenario: 個人報表月份選擇', async ({ page }) => {
+      // GIVEN
+      await loginAsEmployee(page);
+
+      const reportPaths = ['/reports', '/reports/personal', '/attendance/report'];
+      for (const path of reportPaths) {
+        await page.goto(path);
+        await page.waitForLoadState('networkidle');
+        const hasReport = await page
+          .locator('[class*="report"], [class*="summary"]')
+          .first()
+          .isVisible()
+          .catch(() => false);
+        if (hasReport) break;
+      }
+
+      // WHEN - 嘗試切換月份
+      const monthSelector = page
+        .locator('select, [role="combobox"], [class*="month-select"], [class*="date-picker"]')
+        .first();
+
+      if (await monthSelector.isVisible().catch(() => false)) {
+        await takeScreenshot(page, FEATURE, 'report-month-selector');
+      }
+
+      // THEN - 頁面正常載入
+      await expect(page.locator('body')).toBeVisible();
+    });
+  });
+
+  // =============================================
+  // 團隊報表
+  // =============================================
+  test.describe('團隊報表', () => {
+    test('Scenario: 主管查看團隊報表 - 顯示成員列表', async ({ page }) => {
+      // GIVEN - 以主管身份登入
+      await loginAsManager(page);
+
+      // WHEN - 導航到團隊報表
+      const teamPaths = ['/reports/team', '/team/report', '/reports?scope=team', '/attendance/team-report'];
+      let found = false;
+      for (const path of teamPaths) {
+        await page.goto(path);
+        await page.waitForLoadState('networkidle');
+        const hasTeamReport = await page
+          .locator('table, [role="table"], [class*="team"], [class*="member-list"]')
+          .first()
+          .isVisible()
+          .catch(() => false);
+        if (hasTeamReport) {
+          found = true;
+          break;
+        }
+      }
+
+      // THEN - 應顯示團隊成員出勤資料
+      if (found) {
+        const rows = page.locator('table tbody tr, [role="row"]');
+        const count = await rows.count().catch(() => 0);
+        expect(count).toBeGreaterThan(0);
+      }
+      await takeScreenshot(page, FEATURE, 'team-report-view');
+    });
+
+    test('Scenario: 員工無法存取團隊報表 - 403 或重導向', async ({ page }) => {
+      // GIVEN - 以員工身份登入
+      await loginAsEmployee(page);
+
+      // WHEN - 嘗試存取團隊報表
+      const teamPaths = ['/reports/team', '/team/report'];
+      for (const path of teamPaths) {
+        await page.goto(path);
+        await page.waitForLoadState('networkidle');
+      }
+
+      // THEN - 應顯示錯誤或被重導向
+      const hasError = await page
+        .getByText(/forbidden|無權限|403|不允許|permission/i)
+        .first()
+        .isVisible()
+        .catch(() => false);
+
+      const redirected = !page.url().includes('/reports/team')
+        && !page.url().includes('/team/report');
+
+      expect(hasError || redirected).toBe(true);
+      await takeScreenshot(page, FEATURE, 'employee-team-report-forbidden');
+    });
+  });
+
+  // =============================================
+  // 全公司報表
+  // =============================================
+  test.describe('全公司報表', () => {
+    test('Scenario: Admin 查看全公司報表 - 顯示部門列表', async ({ page }) => {
+      // GIVEN - 以 Admin 身份登入
+      await loginAsAdmin(page);
+
+      // WHEN - 導航到全公司報表
+      const companyPaths = ['/reports/company', '/reports?scope=company', '/admin/reports'];
+      let found = false;
+      for (const path of companyPaths) {
+        await page.goto(path);
+        await page.waitForLoadState('networkidle');
+        const hasCompanyReport = await page
+          .locator('table, [role="table"], [class*="department"], [class*="company"]')
+          .first()
+          .isVisible()
+          .catch(() => false);
+        if (hasCompanyReport) {
+          found = true;
+          break;
+        }
+      }
+
+      // THEN - 應顯示部門出勤統計
+      if (found) {
+        const deptRows = page.locator('table tbody tr, [role="row"]');
+        const count = await deptRows.count().catch(() => 0);
+        expect(count).toBeGreaterThan(0);
+      }
+      await takeScreenshot(page, FEATURE, 'company-report-view');
+    });
+
+    test('Scenario: Manager 無法存取全公司報表 - 403 或重導向', async ({ page }) => {
+      // GIVEN - 以主管身份登入
+      await loginAsManager(page);
+
+      // WHEN - 嘗試存取全公司報表
+      const companyPaths = ['/reports/company', '/admin/reports'];
+      for (const path of companyPaths) {
+        await page.goto(path);
+        await page.waitForLoadState('networkidle');
+      }
+
+      // THEN - 應顯示錯誤或被重導向
+      const hasError = await page
+        .getByText(/forbidden|無權限|403|不允許|permission/i)
+        .first()
+        .isVisible()
+        .catch(() => false);
+
+      const redirected = !page.url().includes('/reports/company')
+        && !page.url().includes('/admin/reports');
+
+      expect(hasError || redirected).toBe(true);
+      await takeScreenshot(page, FEATURE, 'manager-company-report-forbidden');
+    });
+  });
+
+  // =============================================
+  // 匯出功能
+  // =============================================
+  test.describe('匯出功能', () => {
+    test('Scenario: 主管匯出團隊報表 CSV', async ({ page }) => {
+      // GIVEN - 以主管身份登入
+      await loginAsManager(page);
+
+      // 導航到團隊報表
+      const teamPaths = ['/reports/team', '/team/report', '/reports?scope=team'];
+      for (const path of teamPaths) {
+        await page.goto(path);
+        await page.waitForLoadState('networkidle');
+        const hasPage = await page
+          .locator('[class*="report"], table, [class*="team"]')
+          .first()
+          .isVisible()
+          .catch(() => false);
+        if (hasPage) break;
+      }
+
+      // WHEN - 找到匯出按鈕
+      const exportBtn = page
+        .getByRole('button', { name: /export|匯出|下載|download|csv/i })
+        .or(page.locator('[class*="export"], [class*="download"]'))
+        .first();
+
+      if (await exportBtn.isVisible().catch(() => false)) {
+        // 攔截下載事件
+        const downloadPromise = page.waitForEvent('download', { timeout: 10000 }).catch(() => null);
+        await exportBtn.click();
+        const download = await downloadPromise;
+
+        // THEN - 應觸發檔案下載
+        if (download) {
+          const filename = download.suggestedFilename();
+          expect(filename).toMatch(/\.csv$/i);
+        }
+        await takeScreenshot(page, FEATURE, 'export-csv-clicked');
+      } else {
+        // 匯出按鈕可能不在此頁面，截圖記錄
+        await takeScreenshot(page, FEATURE, 'export-button-not-found');
+      }
+    });
+
+    test('Scenario: Admin 匯出全公司報表', async ({ page }) => {
+      // GIVEN - 以 Admin 身份登入
+      await loginAsAdmin(page);
+
+      // 導航到全公司報表
+      const companyPaths = ['/reports/company', '/reports?scope=company', '/admin/reports'];
+      for (const path of companyPaths) {
+        await page.goto(path);
+        await page.waitForLoadState('networkidle');
+        const hasPage = await page
+          .locator('[class*="report"], table, [class*="company"]')
+          .first()
+          .isVisible()
+          .catch(() => false);
+        if (hasPage) break;
+      }
+
+      // WHEN - 找到匯出按鈕
+      const exportBtn = page
+        .getByRole('button', { name: /export|匯出|下載|download/i })
+        .or(page.locator('[class*="export"], [class*="download"]'))
+        .first();
+
+      if (await exportBtn.isVisible().catch(() => false)) {
+        await takeScreenshot(page, FEATURE, 'admin-export-button-visible');
+      }
+
+      // THEN - 頁面正常載入
+      await expect(page.locator('body')).toBeVisible();
+      await takeScreenshot(page, FEATURE, 'admin-company-report-export');
+    });
+  });
+});

--- a/test/e2e/calendar.spec.ts
+++ b/test/e2e/calendar.spec.ts
@@ -1,0 +1,226 @@
+import { test, expect } from '@playwright/test';
+import {
+  loginAsEmployee,
+  loginAsManager,
+  loginAsAdmin,
+  authHeaders,
+} from '../helpers/api-client';
+import { API } from '../helpers/test-data';
+
+const FEATURE = 'F-004';
+
+test.describe(`[${FEATURE}] 行事曆 - API E2E`, () => {
+  let employeeToken: string;
+  let managerToken: string;
+  let adminToken: string;
+  let managerDeptId: string;
+
+  test.beforeAll(async ({ request }) => {
+    const empLogin = await loginAsEmployee(request);
+    employeeToken = empLogin.access_token;
+
+    const mgrLogin = await loginAsManager(request);
+    managerToken = mgrLogin.access_token;
+    managerDeptId = mgrLogin.user.department.id;
+
+    const admLogin = await loginAsAdmin(request);
+    adminToken = admLogin.access_token;
+  });
+
+  // =============================================
+  // Happy Path
+  // =============================================
+  test.describe('Happy Path', () => {
+    test('Scenario: 查看個人月行事曆 - 200 + 30 天資料 + clock/leaves', async ({ request }) => {
+      // WHEN
+      const res = await request.get(
+        `${API.CALENDAR.PERSONAL}?year=2026&month=4`,
+        { headers: authHeaders(employeeToken) },
+      );
+
+      // THEN
+      expect(res.status()).toBe(200);
+      const body = await res.json();
+      expect(body.year).toBe(2026);
+      expect(body.month).toBe(4);
+      expect(body.days).toHaveLength(30); // 四月有 30 天
+      // 每天應有完整結構
+      for (const day of body.days) {
+        expect(day).toHaveProperty('date');
+        expect(day).toHaveProperty('is_workday');
+        expect(day).toHaveProperty('clock');
+        expect(day).toHaveProperty('leaves');
+        expect(Array.isArray(day.leaves)).toBe(true);
+      }
+    });
+
+    test('Scenario: 主管查看團隊行事曆 - 200 + members + days', async ({ request }) => {
+      // WHEN
+      const res = await request.get(
+        `${API.CALENDAR.TEAM}?year=2026&month=4`,
+        { headers: authHeaders(managerToken) },
+      );
+
+      // THEN
+      expect(res.status()).toBe(200);
+      const body = await res.json();
+      expect(body.year).toBe(2026);
+      expect(body.month).toBe(4);
+      expect(body).toHaveProperty('department');
+      expect(body.department).toHaveProperty('id');
+      expect(body.department).toHaveProperty('name');
+      expect(Array.isArray(body.members)).toBe(true);
+      expect(body.members.length).toBeGreaterThan(0);
+      // 每個成員應有 user + days
+      for (const member of body.members) {
+        expect(member).toHaveProperty('user');
+        expect(member.user).toHaveProperty('id');
+        expect(member.user).toHaveProperty('name');
+        expect(Array.isArray(member.days)).toBe(true);
+        expect(member.days).toHaveLength(30);
+        for (const day of member.days) {
+          expect(day).toHaveProperty('date');
+          expect(day).toHaveProperty('status');
+          expect([
+            'present', 'late', 'early_leave', 'leave', 'absent', 'holiday', 'overtime',
+          ]).toContain(day.status);
+        }
+      }
+    });
+
+    test('Scenario: Admin 查看指定部門行事曆 - 200', async ({ request }) => {
+      test.skip(!managerDeptId, '無可用部門 ID');
+
+      // WHEN
+      const res = await request.get(
+        `${API.CALENDAR.TEAM}?year=2026&month=4&department_id=${managerDeptId}`,
+        { headers: authHeaders(adminToken) },
+      );
+
+      // THEN
+      expect(res.status()).toBe(200);
+      const body = await res.json();
+      expect(body.department.id).toBe(managerDeptId);
+      expect(Array.isArray(body.members)).toBe(true);
+    });
+  });
+
+  // =============================================
+  // Error Handling
+  // =============================================
+  test.describe('Error Handling', () => {
+    test('Scenario: 員工嘗試看團隊行事曆 - 403 FORBIDDEN', async ({ request }) => {
+      // WHEN
+      const res = await request.get(
+        `${API.CALENDAR.TEAM}?year=2026&month=4`,
+        { headers: authHeaders(employeeToken) },
+      );
+
+      // THEN
+      expect(res.status()).toBe(403);
+      const body = await res.json();
+      expect(body.code).toBe('FORBIDDEN');
+    });
+
+    test('Scenario: 無效月份 - 400 INVALID_INPUT', async ({ request }) => {
+      // WHEN
+      const res = await request.get(
+        `${API.CALENDAR.PERSONAL}?year=2026&month=13`,
+        { headers: authHeaders(employeeToken) },
+      );
+
+      // THEN
+      expect(res.status()).toBe(400);
+      const body = await res.json();
+      expect(body.code).toBe('INVALID_INPUT');
+    });
+
+    test('Scenario: 未認證存取 - 401 UNAUTHORIZED', async ({ request }) => {
+      // WHEN - 不帶 token
+      const res = await request.get(
+        `${API.CALENDAR.PERSONAL}?year=2026&month=4`,
+      );
+
+      // THEN
+      expect(res.status()).toBe(401);
+      const body = await res.json();
+      expect(body.code).toBe('UNAUTHORIZED');
+    });
+  });
+
+  // =============================================
+  // Edge Cases
+  // =============================================
+  test.describe('Edge Cases', () => {
+    test('Scenario: 查看未來月份（無資料）- 200 + 全 null', async ({ request }) => {
+      // WHEN
+      const res = await request.get(
+        `${API.CALENDAR.PERSONAL}?year=2026&month=12`,
+        { headers: authHeaders(employeeToken) },
+      );
+
+      // THEN
+      expect(res.status()).toBe(200);
+      const body = await res.json();
+      expect(body.year).toBe(2026);
+      expect(body.month).toBe(12);
+      expect(body.days).toHaveLength(31); // 十二月有 31 天
+      for (const day of body.days) {
+        expect(day.clock).toBeNull();
+        expect(day.leaves).toEqual([]);
+        expect(day.overtime).toBeNull();
+      }
+    });
+
+    test('Scenario: 同一天既有半天假又有打卡 - leaves + clock 都有值', async ({ request }) => {
+      // WHEN - 查詢 2026 年 4 月（假設測試資料中 4/10 有半天假+打卡）
+      const res = await request.get(
+        `${API.CALENDAR.PERSONAL}?year=2026&month=4`,
+        { headers: authHeaders(employeeToken) },
+      );
+
+      // THEN
+      expect(res.status()).toBe(200);
+      const body = await res.json();
+      // 找到同時有 clock 和 leaves 的日期
+      const daysWithBoth = body.days.filter(
+        (d: any) => d.clock !== null && d.leaves.length > 0,
+      );
+      // 如果有這樣的資料，驗證結構
+      if (daysWithBoth.length > 0) {
+        const day = daysWithBoth[0];
+        expect(day.clock).toHaveProperty('clock_in');
+        expect(day.leaves[0]).toHaveProperty('leave_type');
+        expect(day.leaves[0]).toHaveProperty('start_half');
+      }
+      // 即使目前沒有資料，API 應該正常回傳（不 crash）
+      expect(body.days.length).toBe(30);
+    });
+
+    test('Scenario: 無效年份 - 400', async ({ request }) => {
+      // WHEN
+      const res = await request.get(
+        `${API.CALENDAR.PERSONAL}?year=1999&month=4`,
+        { headers: authHeaders(employeeToken) },
+      );
+
+      // THEN
+      expect(res.status()).toBe(400);
+      const body = await res.json();
+      expect(body.code).toBe('INVALID_INPUT');
+    });
+
+    test('Scenario: month=0 - 400', async ({ request }) => {
+      // WHEN
+      const res = await request.get(
+        `${API.CALENDAR.PERSONAL}?year=2026&month=0`,
+        { headers: authHeaders(employeeToken) },
+      );
+
+      // THEN
+      expect(res.status()).toBe(400);
+      const body = await res.json();
+      expect(body.code).toBe('INVALID_INPUT');
+    });
+  });
+});

--- a/test/e2e/reports.spec.ts
+++ b/test/e2e/reports.spec.ts
@@ -1,0 +1,289 @@
+import { test, expect } from '@playwright/test';
+import {
+  loginAsEmployee,
+  loginAsManager,
+  loginAsAdmin,
+  authHeaders,
+} from '../helpers/api-client';
+import { API } from '../helpers/test-data';
+
+const FEATURE = 'F-005';
+
+test.describe(`[${FEATURE}] 出席報表 - API E2E`, () => {
+  let employeeToken: string;
+  let managerToken: string;
+  let adminToken: string;
+
+  test.beforeAll(async ({ request }) => {
+    const empLogin = await loginAsEmployee(request);
+    employeeToken = empLogin.access_token;
+
+    const mgrLogin = await loginAsManager(request);
+    managerToken = mgrLogin.access_token;
+
+    const admLogin = await loginAsAdmin(request);
+    adminToken = admLogin.access_token;
+  });
+
+  // =============================================
+  // Happy Path
+  // =============================================
+  test.describe('Happy Path', () => {
+    test('Scenario: 查看個人月報 - 200 + summary + leave_summary', async ({ request }) => {
+      // WHEN
+      const res = await request.get(
+        `${API.REPORTS.PERSONAL}?year=2026&month=4`,
+        { headers: authHeaders(employeeToken) },
+      );
+
+      // THEN
+      expect(res.status()).toBe(200);
+      const body = await res.json();
+      expect(body).toHaveProperty('user');
+      expect(body.user).toHaveProperty('id');
+      expect(body.user).toHaveProperty('name');
+      expect(body.year).toBe(2026);
+      expect(body.month).toBe(4);
+
+      // summary 結構驗證
+      expect(body).toHaveProperty('summary');
+      const s = body.summary;
+      expect(s).toHaveProperty('workdays');
+      expect(s).toHaveProperty('present_days');
+      expect(s).toHaveProperty('absent_days');
+      expect(s).toHaveProperty('late_days');
+      expect(s).toHaveProperty('early_leave_days');
+      expect(s).toHaveProperty('leave_days');
+      expect(s).toHaveProperty('overtime_hours');
+      expect(s).toHaveProperty('attendance_rate');
+      expect(typeof s.attendance_rate).toBe('number');
+
+      // leave_summary 結構驗證
+      expect(Array.isArray(body.leave_summary)).toBe(true);
+      for (const item of body.leave_summary) {
+        expect(item).toHaveProperty('leave_type');
+        expect(item).toHaveProperty('hours');
+        expect(typeof item.hours).toBe('number');
+      }
+    });
+
+    test('Scenario: 主管查看團隊報表 - 200 + members + team_summary', async ({ request }) => {
+      // WHEN
+      const res = await request.get(
+        `${API.REPORTS.TEAM}?year=2026&month=4`,
+        { headers: authHeaders(managerToken) },
+      );
+
+      // THEN
+      expect(res.status()).toBe(200);
+      const body = await res.json();
+      expect(body).toHaveProperty('department');
+      expect(body.department).toHaveProperty('id');
+      expect(body.department).toHaveProperty('name');
+      expect(body.year).toBe(2026);
+      expect(body.month).toBe(4);
+
+      // team_summary
+      expect(body).toHaveProperty('team_summary');
+      const ts = body.team_summary;
+      expect(ts).toHaveProperty('total_members');
+      expect(ts).toHaveProperty('avg_attendance_rate');
+      expect(ts).toHaveProperty('total_late_count');
+      expect(ts).toHaveProperty('total_leave_days');
+
+      // members
+      expect(Array.isArray(body.members)).toBe(true);
+      expect(body.members.length).toBeGreaterThan(0);
+      for (const m of body.members) {
+        expect(m).toHaveProperty('user');
+        expect(m).toHaveProperty('present_days');
+        expect(m).toHaveProperty('absent_days');
+        expect(m).toHaveProperty('late_days');
+        expect(m).toHaveProperty('attendance_rate');
+      }
+    });
+
+    test('Scenario: Admin 查看全公司報表 - 200 + departments + company_summary', async ({ request }) => {
+      // WHEN
+      const res = await request.get(
+        `${API.REPORTS.COMPANY}?year=2026&month=4`,
+        { headers: authHeaders(adminToken) },
+      );
+
+      // THEN
+      expect(res.status()).toBe(200);
+      const body = await res.json();
+      expect(body.year).toBe(2026);
+      expect(body.month).toBe(4);
+
+      // company_summary
+      expect(body).toHaveProperty('company_summary');
+      const cs = body.company_summary;
+      expect(cs).toHaveProperty('total_employees');
+      expect(cs).toHaveProperty('avg_attendance_rate');
+      expect(cs).toHaveProperty('total_late_count');
+      expect(cs).toHaveProperty('total_leave_days');
+      expect(cs).toHaveProperty('total_overtime_hours');
+
+      // departments
+      expect(Array.isArray(body.departments)).toBe(true);
+      expect(body.departments.length).toBeGreaterThan(0);
+      for (const dept of body.departments) {
+        expect(dept).toHaveProperty('department');
+        expect(dept.department).toHaveProperty('id');
+        expect(dept.department).toHaveProperty('name');
+        expect(dept).toHaveProperty('total_members');
+        expect(dept).toHaveProperty('avg_attendance_rate');
+      }
+    });
+
+    test('Scenario: 匯出團隊報表 CSV - 200 + text/csv', async ({ request }) => {
+      // WHEN
+      const res = await request.get(
+        `${API.REPORTS.EXPORT}?year=2026&month=4&scope=team&format=csv`,
+        { headers: authHeaders(managerToken) },
+      );
+
+      // THEN
+      expect(res.status()).toBe(200);
+      const contentType = res.headers()['content-type'] || '';
+      expect(contentType).toContain('text/csv');
+      const text = await res.text();
+      expect(text.length).toBeGreaterThan(0);
+      // CSV 應包含標題列
+      expect(text).toContain(',');
+    });
+
+    test('Scenario: Admin 匯出全公司報表 CSV', async ({ request }) => {
+      // WHEN
+      const res = await request.get(
+        `${API.REPORTS.EXPORT}?year=2026&month=4&scope=company&format=csv`,
+        { headers: authHeaders(adminToken) },
+      );
+
+      // THEN
+      expect(res.status()).toBe(200);
+      const contentType = res.headers()['content-type'] || '';
+      expect(contentType).toContain('text/csv');
+    });
+  });
+
+  // =============================================
+  // Error Handling
+  // =============================================
+  test.describe('Error Handling', () => {
+    test('Scenario: 員工嘗試看團隊報表 - 403 FORBIDDEN', async ({ request }) => {
+      // WHEN
+      const res = await request.get(
+        `${API.REPORTS.TEAM}?year=2026&month=4`,
+        { headers: authHeaders(employeeToken) },
+      );
+
+      // THEN
+      expect(res.status()).toBe(403);
+      const body = await res.json();
+      expect(body.code).toBe('FORBIDDEN');
+    });
+
+    test('Scenario: Manager 嘗試看全公司報表 - 403 FORBIDDEN', async ({ request }) => {
+      // WHEN
+      const res = await request.get(
+        `${API.REPORTS.COMPANY}?year=2026&month=4`,
+        { headers: authHeaders(managerToken) },
+      );
+
+      // THEN
+      expect(res.status()).toBe(403);
+      const body = await res.json();
+      expect(body.code).toBe('FORBIDDEN');
+    });
+
+    test('Scenario: 員工嘗試匯出報表 - 403', async ({ request }) => {
+      // WHEN
+      const res = await request.get(
+        `${API.REPORTS.EXPORT}?year=2026&month=4&scope=team&format=csv`,
+        { headers: authHeaders(employeeToken) },
+      );
+
+      // THEN
+      expect(res.status()).toBe(403);
+      const body = await res.json();
+      expect(body.code).toBe('FORBIDDEN');
+    });
+
+    test('Scenario: 未認證存取個人報表 - 401', async ({ request }) => {
+      // WHEN
+      const res = await request.get(
+        `${API.REPORTS.PERSONAL}?year=2026&month=4`,
+      );
+
+      // THEN
+      expect(res.status()).toBe(401);
+      const body = await res.json();
+      expect(body.code).toBe('UNAUTHORIZED');
+    });
+  });
+
+  // =============================================
+  // Edge Cases
+  // =============================================
+  test.describe('Edge Cases', () => {
+    test('Scenario: 查看未來月份 - 200 + 數值 0', async ({ request }) => {
+      // WHEN
+      const res = await request.get(
+        `${API.REPORTS.PERSONAL}?year=2026&month=12`,
+        { headers: authHeaders(employeeToken) },
+      );
+
+      // THEN
+      expect(res.status()).toBe(200);
+      const body = await res.json();
+      expect(body.year).toBe(2026);
+      expect(body.month).toBe(12);
+      const s = body.summary;
+      expect(s.present_days).toBe(0);
+      expect(s.absent_days).toBe(0);
+      expect(s.late_days).toBe(0);
+      expect(s.early_leave_days).toBe(0);
+      expect(s.leave_days).toBe(0);
+      expect(s.overtime_hours).toBe(0);
+    });
+
+    test('Scenario: 團隊報表未來月份 - 200 + 數值 0', async ({ request }) => {
+      // WHEN
+      const res = await request.get(
+        `${API.REPORTS.TEAM}?year=2026&month=12`,
+        { headers: authHeaders(managerToken) },
+      );
+
+      // THEN
+      expect(res.status()).toBe(200);
+      const body = await res.json();
+      const ts = body.team_summary;
+      expect(ts.total_late_count).toBe(0);
+      expect(ts.total_leave_days).toBe(0);
+    });
+
+    test('Scenario: 缺少必要參數 year - 400', async ({ request }) => {
+      // WHEN
+      const res = await request.get(
+        `${API.REPORTS.PERSONAL}?month=4`,
+        { headers: authHeaders(employeeToken) },
+      );
+
+      // THEN
+      expect(res.status()).toBe(400);
+    });
+
+    test('Scenario: 缺少必要參數 month - 400', async ({ request }) => {
+      // WHEN
+      const res = await request.get(
+        `${API.REPORTS.PERSONAL}?year=2026`,
+        { headers: authHeaders(employeeToken) },
+      );
+
+      // THEN
+      expect(res.status()).toBe(400);
+    });
+  });
+});

--- a/test/helpers/test-data.ts
+++ b/test/helpers/test-data.ts
@@ -108,6 +108,16 @@ export const API = {
     PENDING: '/api/v1/leaves/pending',
     // + /:id, /:id/cancel, /:id/approve, /:id/reject
   },
+  CALENDAR: {
+    PERSONAL: '/api/v1/calendar/personal',
+    TEAM: '/api/v1/calendar/team',
+  },
+  REPORTS: {
+    PERSONAL: '/api/v1/reports/personal',
+    TEAM: '/api/v1/reports/team',
+    COMPANY: '/api/v1/reports/company',
+    EXPORT: '/api/v1/reports/export',
+  },
 } as const;
 
 // ===== 密碼測試 =====


### PR DESCRIPTION
## Summary
Sprint 3 雙層 e2e tests：API-level + Browser-level（Playwright）。

## 測試覆蓋

| Feature | Scenarios | API Tests | Browser Tests |
|---------|-----------|-----------|---------------|
| F-004 行事曆 | 7 | 9 | 6 |
| F-005 出席報表 | 7 | 11 | 7 |

### F-004 行事曆 API Tests
- 查看個人月行事曆 (200 + 30 天 + clock/leaves 結構)
- 主管查看團隊行事曆 (200 + members + days + status enum)
- Admin 查看指定部門行事曆 (200 + department_id match)
- 員工看團隊行事曆 (403 FORBIDDEN)
- 無效月份 month=13 (400 INVALID_INPUT)
- 未認證存取 (401 UNAUTHORIZED)
- 未來月份無資料 (200 + 全 null)
- 同天半天假+打卡 (leaves + clock 並存)
- 無效年份/month=0 (400 INVALID_INPUT)

### F-005 出席報表 API Tests
- 個人月報 (200 + summary + leave_summary)
- 團隊報表 (200 + members + team_summary)
- 全公司報表 (200 + departments + company_summary)
- 匯出 CSV (200 + text/csv Content-Type)
- Admin 匯出全公司 CSV
- 員工看團隊報表 (403)
- Manager 看全公司報表 (403)
- 員工匯出報表 (403)
- 未認證存取 (401)
- 未來月份數值 0
- 缺少 year/month 參數 (400)

### Browser Tests
- 個人行事曆月曆視圖載入 + 月份切換 + 日期點擊詳情
- 團隊行事曆成員列表 + 員工權限拒絕
- 個人報表統計頁面 + 月份選擇
- 團隊報表成員列表 + 員工權限拒絕
- 全公司報表部門列表 + Manager 權限拒絕
- 匯出 CSV 下載流程

## Test Files
- `test/e2e/calendar.spec.ts` — F-004 API tests (9 cases)
- `test/e2e/reports.spec.ts` — F-005 API tests (11 cases)
- `test/browser/calendar.spec.ts` — F-004 browser tests (6 cases)
- `test/browser/reports.spec.ts` — F-005 browser tests (7 cases)
- `test/helpers/test-data.ts` — 新增 CALENDAR + REPORTS API 路徑

待 engineer PR 合併後執行完整測試。

Closes #28