### PR TITLE
[Feature] F-005: 出席報表/統計

### DIFF
--- a/dev/__tests__/reports/reports.service.spec.ts
+++ b/dev/__tests__/reports/reports.service.spec.ts
@@ -1,0 +1,587 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ForbiddenException } from '@nestjs/common';
+import { ReportsService } from '../../src/reports/reports.service';
+import { PrismaService } from '../../src/prisma/prisma.service';
+
+describe('ReportsService', () => {
+  let service: ReportsService;
+  let prisma: {
+    user: {
+      findUnique: jest.Mock;
+      findMany: jest.Mock;
+    };
+    clockRecord: {
+      findMany: jest.Mock;
+    };
+    leaveRequest: {
+      findMany: jest.Mock;
+    };
+    department: {
+      findUnique: jest.Mock;
+      findMany: jest.Mock;
+    };
+  };
+
+  const mockUserId = 'user-uuid-1';
+  const mockDeptId = 'dept-uuid-1';
+
+  function makeDateOnly(year: number, month: number, day: number): Date {
+    return new Date(Date.UTC(year, month - 1, day, 0, 0, 0, 0));
+  }
+
+  function makeUTC8Date(
+    year: number,
+    month: number,
+    day: number,
+    hour: number,
+    minute: number,
+  ): Date {
+    const utcHour = hour - 8;
+    return new Date(Date.UTC(year, month - 1, day, utcHour, minute, 0, 0));
+  }
+
+  beforeEach(async () => {
+    prisma = {
+      user: {
+        findUnique: jest.fn(),
+        findMany: jest.fn(),
+      },
+      clockRecord: {
+        findMany: jest.fn(),
+      },
+      leaveRequest: {
+        findMany: jest.fn(),
+      },
+      department: {
+        findUnique: jest.fn(),
+        findMany: jest.fn(),
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ReportsService,
+        { provide: PrismaService, useValue: prisma },
+      ],
+    }).compile();
+
+    service = module.get<ReportsService>(ReportsService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getMonthRange', () => {
+    it('should return correct start and end dates for a month', () => {
+      const { startDate, endDate } = service.getMonthRange(2026, 4);
+      expect(startDate).toEqual(new Date(Date.UTC(2026, 3, 1)));
+      expect(endDate).toEqual(new Date(Date.UTC(2026, 3, 30)));
+    });
+
+    it('should handle February correctly', () => {
+      const { startDate, endDate } = service.getMonthRange(2026, 2);
+      expect(startDate).toEqual(new Date(Date.UTC(2026, 1, 1)));
+      expect(endDate).toEqual(new Date(Date.UTC(2026, 1, 28)));
+    });
+  });
+
+  describe('calculateWorkdays', () => {
+    it('should exclude weekends', () => {
+      // April 2026: starts on Wednesday
+      // Weekdays: 1,2,3 (Wed-Fri), 6-10, 13-17, 20-24, 27-30 = 22 days
+      const start = makeDateOnly(2026, 4, 1);
+      const end = makeDateOnly(2026, 4, 30);
+      expect(service.calculateWorkdays(start, end)).toBe(22);
+    });
+
+    it('should count from hire_date when hire_date is mid-month', () => {
+      // April 15, 2026 is Wednesday
+      // 15,16,17 (Wed-Fri), 20-24, 27-30 = 12 days
+      const start = makeDateOnly(2026, 4, 1);
+      const end = makeDateOnly(2026, 4, 30);
+      const hireDate = makeDateOnly(2026, 4, 15);
+      expect(service.calculateWorkdays(start, end, hireDate)).toBe(12);
+    });
+
+    it('should ignore hire_date when it is before the month', () => {
+      const start = makeDateOnly(2026, 4, 1);
+      const end = makeDateOnly(2026, 4, 30);
+      const hireDate = makeDateOnly(2026, 1, 10);
+      expect(service.calculateWorkdays(start, end, hireDate)).toBe(22);
+    });
+  });
+
+  describe('calculateLateDays', () => {
+    it('should count records with clock_in after 09:00 UTC+8', () => {
+      const records = [
+        { clockIn: makeUTC8Date(2026, 4, 1, 8, 55) },  // on time
+        { clockIn: makeUTC8Date(2026, 4, 2, 9, 5) },   // late
+        { clockIn: makeUTC8Date(2026, 4, 3, 9, 0) },   // on time (exactly 09:00)
+        { clockIn: makeUTC8Date(2026, 4, 6, 10, 0) },  // late
+      ];
+      expect(service.calculateLateDays(records)).toBe(2);
+    });
+
+    it('should return 0 when no records are late', () => {
+      const records = [
+        { clockIn: makeUTC8Date(2026, 4, 1, 8, 30) },
+        { clockIn: makeUTC8Date(2026, 4, 2, 9, 0) },
+      ];
+      expect(service.calculateLateDays(records)).toBe(0);
+    });
+  });
+
+  describe('calculateEarlyLeaveDays', () => {
+    it('should count records with clock_out before 18:00 UTC+8', () => {
+      const records = [
+        { clockOut: makeUTC8Date(2026, 4, 1, 18, 30) }, // normal
+        { clockOut: makeUTC8Date(2026, 4, 2, 17, 0) },  // early
+        { clockOut: makeUTC8Date(2026, 4, 3, 18, 0) },  // exactly 18:00 = normal
+        { clockOut: null },                               // no clock out
+      ];
+      expect(service.calculateEarlyLeaveDays(records)).toBe(1);
+    });
+  });
+
+  describe('calculateLeaveDays', () => {
+    it('should count full day leaves', () => {
+      const leaves = [
+        {
+          startDate: makeDateOnly(2026, 4, 6), // Monday
+          endDate: makeDateOnly(2026, 4, 8),   // Wednesday
+          startHalf: 'FULL',
+          endHalf: 'FULL',
+        },
+      ];
+      const monthStart = makeDateOnly(2026, 4, 1);
+      const monthEnd = makeDateOnly(2026, 4, 30);
+      expect(service.calculateLeaveDays(leaves, monthStart, monthEnd)).toBe(3);
+    });
+
+    it('should count half day leaves as 0.5', () => {
+      const leaves = [
+        {
+          startDate: makeDateOnly(2026, 4, 6), // Monday
+          endDate: makeDateOnly(2026, 4, 6),
+          startHalf: 'MORNING',
+          endHalf: 'MORNING',
+        },
+      ];
+      const monthStart = makeDateOnly(2026, 4, 1);
+      const monthEnd = makeDateOnly(2026, 4, 30);
+      expect(service.calculateLeaveDays(leaves, monthStart, monthEnd)).toBe(0.5);
+    });
+
+    it('should skip weekends in leave calculation', () => {
+      // Friday to Monday = 2 workdays (Fri + Mon), skip Sat/Sun
+      const leaves = [
+        {
+          startDate: makeDateOnly(2026, 4, 3),  // Friday
+          endDate: makeDateOnly(2026, 4, 6),    // Monday
+          startHalf: 'FULL',
+          endHalf: 'FULL',
+        },
+      ];
+      const monthStart = makeDateOnly(2026, 4, 1);
+      const monthEnd = makeDateOnly(2026, 4, 30);
+      expect(service.calculateLeaveDays(leaves, monthStart, monthEnd)).toBe(2);
+    });
+
+    it('should handle multi-day leave with half day on start/end', () => {
+      const leaves = [
+        {
+          startDate: makeDateOnly(2026, 4, 6),  // Monday
+          endDate: makeDateOnly(2026, 4, 8),    // Wednesday
+          startHalf: 'AFTERNOON',               // half day start
+          endHalf: 'MORNING',                   // half day end
+        },
+      ];
+      const monthStart = makeDateOnly(2026, 4, 1);
+      const monthEnd = makeDateOnly(2026, 4, 30);
+      // Mon 0.5 + Tue 1 + Wed 0.5 = 2
+      expect(service.calculateLeaveDays(leaves, monthStart, monthEnd)).toBe(2);
+    });
+  });
+
+  describe('calculatePresentDays', () => {
+    it('should count clock records that are not full day leave', () => {
+      const clockRecords = [
+        { date: makeDateOnly(2026, 4, 1), clockIn: makeUTC8Date(2026, 4, 1, 9, 0), clockOut: makeUTC8Date(2026, 4, 1, 18, 0) },
+        { date: makeDateOnly(2026, 4, 2), clockIn: makeUTC8Date(2026, 4, 2, 9, 0), clockOut: makeUTC8Date(2026, 4, 2, 18, 0) },
+        { date: makeDateOnly(2026, 4, 3), clockIn: makeUTC8Date(2026, 4, 3, 9, 0), clockOut: makeUTC8Date(2026, 4, 3, 18, 0) },
+      ];
+      const leaveRequests = [
+        {
+          startDate: makeDateOnly(2026, 4, 2),
+          endDate: makeDateOnly(2026, 4, 2),
+          startHalf: 'FULL',
+          endHalf: 'FULL',
+          hours: 8,
+        },
+      ];
+      const monthStart = makeDateOnly(2026, 4, 1);
+      const monthEnd = makeDateOnly(2026, 4, 30);
+      // 3 clock records, but Apr 2 is full day leave => 2 present
+      expect(service.calculatePresentDays(clockRecords, leaveRequests, monthStart, monthEnd)).toBe(2);
+    });
+
+    it('should count half day leave as present', () => {
+      const clockRecords = [
+        { date: makeDateOnly(2026, 4, 1), clockIn: makeUTC8Date(2026, 4, 1, 9, 0), clockOut: makeUTC8Date(2026, 4, 1, 12, 0) },
+      ];
+      const leaveRequests = [
+        {
+          startDate: makeDateOnly(2026, 4, 1),
+          endDate: makeDateOnly(2026, 4, 1),
+          startHalf: 'AFTERNOON',
+          endHalf: 'AFTERNOON',
+          hours: 4,
+        },
+      ];
+      const monthStart = makeDateOnly(2026, 4, 1);
+      const monthEnd = makeDateOnly(2026, 4, 30);
+      // Half day leave, so still counted as present
+      expect(service.calculatePresentDays(clockRecords, leaveRequests, monthStart, monthEnd)).toBe(1);
+    });
+  });
+
+  describe('getPersonalReport', () => {
+    it('should return correct personal report with attendance stats', async () => {
+      const mockUser = {
+        id: mockUserId,
+        name: '王小明',
+        employeeId: 'EMP001',
+        hireDate: makeDateOnly(2026, 1, 1),
+      };
+
+      prisma.user.findUnique.mockResolvedValue(mockUser);
+
+      // 20 clock records in April 2026 (all on time, no early leave)
+      const clockRecords = Array.from({ length: 20 }, (_, i) => {
+        const day = [1, 2, 3, 6, 7, 8, 9, 10, 13, 14, 15, 16, 17, 20, 21, 22, 23, 24, 27, 28][i];
+        return {
+          date: makeDateOnly(2026, 4, day),
+          clockIn: makeUTC8Date(2026, 4, day, 8, 55),
+          clockOut: makeUTC8Date(2026, 4, day, 18, 30),
+        };
+      });
+
+      prisma.clockRecord.findMany.mockResolvedValue(clockRecords);
+
+      // 2 days annual leave
+      const leaveRequests = [
+        {
+          id: 'leave-1',
+          leaveType: 'ANNUAL',
+          startDate: makeDateOnly(2026, 4, 29),
+          endDate: makeDateOnly(2026, 4, 30),
+          startHalf: 'FULL',
+          endHalf: 'FULL',
+          hours: { toNumber: () => 16 },
+          status: 'APPROVED',
+        },
+      ];
+      prisma.leaveRequest.findMany.mockResolvedValue(leaveRequests);
+
+      const result = await service.getPersonalReport(mockUserId, 2026, 4);
+
+      expect(result.user.id).toBe(mockUserId);
+      expect(result.user.name).toBe('王小明');
+      expect(result.user.employee_id).toBe('EMP001');
+      expect(result.year).toBe(2026);
+      expect(result.month).toBe(4);
+      expect(result.summary.workdays).toBe(22);
+      expect(result.summary.present_days).toBe(20);
+      expect(result.summary.leave_days).toBe(2);
+      expect(result.summary.absent_days).toBe(0);
+      expect(result.summary.late_days).toBe(0);
+      expect(result.summary.early_leave_days).toBe(0);
+      expect(result.summary.overtime_hours).toBe(0);
+      // attendance_rate = (20 / 22) * 100 = 90.9
+      expect(result.summary.attendance_rate).toBe(90.9);
+      // leave summary should include annual
+      const annualLeave = result.leave_summary.find(
+        (l: { leave_type: string }) => l.leave_type === 'annual',
+      );
+      expect(annualLeave).toBeDefined();
+      expect(annualLeave!.hours).toBe(16);
+    });
+
+    it('should handle new employee with mid-month hire date', async () => {
+      const mockUser = {
+        id: mockUserId,
+        name: '新員工',
+        employeeId: 'EMP010',
+        hireDate: makeDateOnly(2026, 4, 15), // mid-month
+      };
+
+      prisma.user.findUnique.mockResolvedValue(mockUser);
+
+      // 12 workdays after April 15
+      const workdayDates = [15, 16, 17, 20, 21, 22, 23, 24, 27, 28, 29, 30];
+      const clockRecords = workdayDates.map((day) => ({
+        date: makeDateOnly(2026, 4, day),
+        clockIn: makeUTC8Date(2026, 4, day, 8, 55),
+        clockOut: makeUTC8Date(2026, 4, day, 18, 30),
+      }));
+
+      prisma.clockRecord.findMany.mockResolvedValue(clockRecords);
+      prisma.leaveRequest.findMany.mockResolvedValue([]);
+
+      const result = await service.getPersonalReport(mockUserId, 2026, 4);
+
+      expect(result.summary.workdays).toBe(12);
+      expect(result.summary.present_days).toBe(12);
+      expect(result.summary.attendance_rate).toBe(100);
+    });
+
+    it('should return all zeros for future month', async () => {
+      const mockUser = {
+        id: mockUserId,
+        name: '王小明',
+        employeeId: 'EMP001',
+        hireDate: makeDateOnly(2026, 1, 1),
+      };
+
+      prisma.user.findUnique.mockResolvedValue(mockUser);
+      prisma.clockRecord.findMany.mockResolvedValue([]);
+      prisma.leaveRequest.findMany.mockResolvedValue([]);
+
+      const result = await service.getPersonalReport(mockUserId, 2026, 12);
+
+      expect(result.summary.present_days).toBe(0);
+      expect(result.summary.late_days).toBe(0);
+      expect(result.summary.early_leave_days).toBe(0);
+      expect(result.summary.leave_days).toBe(0);
+    });
+
+    it('should return empty report when user not found', async () => {
+      prisma.user.findUnique.mockResolvedValue(null);
+
+      const result = await service.getPersonalReport('nonexistent', 2026, 4);
+
+      expect(result.user.id).toBe('');
+      expect(result.summary.workdays).toBe(0);
+    });
+  });
+
+  describe('getTeamReport', () => {
+    const managerUser = {
+      userId: 'manager-uuid',
+      role: 'MANAGER',
+      departmentId: mockDeptId,
+    };
+
+    it('should return team report with correct summary', async () => {
+      prisma.department.findUnique.mockResolvedValue({
+        id: mockDeptId,
+        name: '工程部',
+      });
+
+      const members = [
+        { id: 'user-1', name: '員工A', employeeId: 'EMP001', hireDate: makeDateOnly(2026, 1, 1) },
+        { id: 'user-2', name: '員工B', employeeId: 'EMP002', hireDate: makeDateOnly(2026, 1, 1) },
+      ];
+      prisma.user.findMany.mockResolvedValue(members);
+
+      // Mock getPersonalReport for each member
+      prisma.user.findUnique
+        .mockResolvedValueOnce({ id: 'user-1', name: '員工A', employeeId: 'EMP001', hireDate: makeDateOnly(2026, 1, 1) })
+        .mockResolvedValueOnce({ id: 'user-2', name: '員工B', employeeId: 'EMP002', hireDate: makeDateOnly(2026, 1, 1) });
+
+      // user-1: 20 present, 1 late, 2 leave
+      prisma.clockRecord.findMany
+        .mockResolvedValueOnce(
+          Array.from({ length: 20 }, (_, i) => ({
+            date: makeDateOnly(2026, 4, i + 1),
+            clockIn: i === 0
+              ? makeUTC8Date(2026, 4, 1, 9, 30)  // late
+              : makeUTC8Date(2026, 4, i + 1, 8, 55),
+            clockOut: makeUTC8Date(2026, 4, i + 1, 18, 30),
+          })),
+        )
+        .mockResolvedValueOnce(
+          Array.from({ length: 22 }, (_, i) => ({
+            date: makeDateOnly(2026, 4, i + 1),
+            clockIn: makeUTC8Date(2026, 4, i + 1, 8, 50),
+            clockOut: makeUTC8Date(2026, 4, i + 1, 18, 30),
+          })),
+        );
+
+      prisma.leaveRequest.findMany
+        .mockResolvedValueOnce([
+          {
+            leaveType: 'ANNUAL',
+            startDate: makeDateOnly(2026, 4, 29),
+            endDate: makeDateOnly(2026, 4, 30),
+            startHalf: 'FULL',
+            endHalf: 'FULL',
+            hours: { toNumber: () => 16 },
+            status: 'APPROVED',
+          },
+        ])
+        .mockResolvedValueOnce([]);
+
+      const result = await service.getTeamReport(managerUser, 2026, 4);
+
+      expect(result.department).toEqual({ id: mockDeptId, name: '工程部' });
+      expect(result.team_summary.total_members).toBe(2);
+      expect(result.members).toHaveLength(2);
+    });
+
+    it('should use manager department_id regardless of query param', async () => {
+      prisma.department.findUnique.mockResolvedValue({
+        id: mockDeptId,
+        name: '工程部',
+      });
+      prisma.user.findMany.mockResolvedValue([]);
+
+      await service.getTeamReport(managerUser, 2026, 4, 'other-dept-id');
+
+      // Should query with manager's own department, not the passed one
+      expect(prisma.department.findUnique).toHaveBeenCalledWith({
+        where: { id: mockDeptId },
+        select: { id: true, name: true },
+      });
+    });
+
+    it('should allow admin to specify department_id', async () => {
+      const adminUser = {
+        userId: 'admin-uuid',
+        role: 'ADMIN',
+        departmentId: 'admin-dept',
+      };
+      const targetDept = 'target-dept-uuid';
+
+      prisma.department.findUnique.mockResolvedValue({
+        id: targetDept,
+        name: '行銷部',
+      });
+      prisma.user.findMany.mockResolvedValue([]);
+
+      await service.getTeamReport(adminUser, 2026, 4, targetDept);
+
+      expect(prisma.department.findUnique).toHaveBeenCalledWith({
+        where: { id: targetDept },
+        select: { id: true, name: true },
+      });
+    });
+  });
+
+  describe('getCompanyReport', () => {
+    it('should aggregate all departments', async () => {
+      prisma.department.findMany.mockResolvedValue([
+        { id: 'dept-1', name: '工程部' },
+        { id: 'dept-2', name: '行銷部' },
+      ]);
+
+      // Dept 1: 2 members
+      prisma.user.findMany
+        .mockResolvedValueOnce([
+          { id: 'u1', name: 'A', employeeId: 'E1', hireDate: makeDateOnly(2026, 1, 1) },
+          { id: 'u2', name: 'B', employeeId: 'E2', hireDate: makeDateOnly(2026, 1, 1) },
+        ])
+        .mockResolvedValueOnce([
+          { id: 'u3', name: 'C', employeeId: 'E3', hireDate: makeDateOnly(2026, 1, 1) },
+        ]);
+
+      // Mock personal reports for all 3 users
+      prisma.user.findUnique
+        .mockResolvedValueOnce({ id: 'u1', name: 'A', employeeId: 'E1', hireDate: makeDateOnly(2026, 1, 1) })
+        .mockResolvedValueOnce({ id: 'u2', name: 'B', employeeId: 'E2', hireDate: makeDateOnly(2026, 1, 1) })
+        .mockResolvedValueOnce({ id: 'u3', name: 'C', employeeId: 'E3', hireDate: makeDateOnly(2026, 1, 1) });
+
+      prisma.clockRecord.findMany.mockResolvedValue([]);
+      prisma.leaveRequest.findMany.mockResolvedValue([]);
+
+      const result = await service.getCompanyReport(2026, 4);
+
+      expect(result.company_summary.total_employees).toBe(3);
+      expect(result.departments).toHaveLength(2);
+      expect(result.company_summary.total_overtime_hours).toBe(0);
+    });
+
+    it('should skip departments with no active members', async () => {
+      prisma.department.findMany.mockResolvedValue([
+        { id: 'dept-1', name: '工程部' },
+        { id: 'dept-2', name: '已裁撤部門' },
+      ]);
+
+      prisma.user.findMany
+        .mockResolvedValueOnce([
+          { id: 'u1', name: 'A', employeeId: 'E1', hireDate: makeDateOnly(2026, 1, 1) },
+        ])
+        .mockResolvedValueOnce([]); // empty department
+
+      prisma.user.findUnique.mockResolvedValueOnce({
+        id: 'u1', name: 'A', employeeId: 'E1', hireDate: makeDateOnly(2026, 1, 1),
+      });
+      prisma.clockRecord.findMany.mockResolvedValue([]);
+      prisma.leaveRequest.findMany.mockResolvedValue([]);
+
+      const result = await service.getCompanyReport(2026, 4);
+
+      expect(result.departments).toHaveLength(1);
+      expect(result.company_summary.total_employees).toBe(1);
+    });
+  });
+
+  describe('exportReport', () => {
+    const managerUser = {
+      userId: 'manager-uuid',
+      role: 'MANAGER',
+      departmentId: mockDeptId,
+    };
+
+    const adminUser = {
+      userId: 'admin-uuid',
+      role: 'ADMIN',
+      departmentId: mockDeptId,
+    };
+
+    it('should throw FORBIDDEN when manager tries to export company scope', async () => {
+      await expect(
+        service.exportReport(managerUser, 2026, 4, 'company'),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should generate CSV for team scope', async () => {
+      prisma.department.findUnique.mockResolvedValue({ id: mockDeptId, name: '工程部' });
+      prisma.user.findMany.mockResolvedValue([
+        { id: 'u1', name: '員工A', employeeId: 'EMP001', hireDate: makeDateOnly(2026, 1, 1) },
+      ]);
+      prisma.user.findUnique.mockResolvedValue({
+        id: 'u1', name: '員工A', employeeId: 'EMP001', hireDate: makeDateOnly(2026, 1, 1),
+      });
+      prisma.clockRecord.findMany.mockResolvedValue([]);
+      prisma.leaveRequest.findMany.mockResolvedValue([]);
+
+      const csv = await service.exportReport(managerUser, 2026, 4, 'team');
+
+      expect(csv).toContain('員工編號');
+      expect(csv).toContain('姓名');
+      expect(csv).toContain('EMP001');
+      expect(csv).toContain('員工A');
+    });
+
+    it('should generate CSV for company scope (admin)', async () => {
+      prisma.department.findMany.mockResolvedValue([
+        { id: 'dept-1', name: '工程部' },
+      ]);
+      prisma.user.findMany.mockResolvedValue([
+        { id: 'u1', name: 'A', employeeId: 'E1', hireDate: makeDateOnly(2026, 1, 1) },
+      ]);
+      prisma.user.findUnique.mockResolvedValue({
+        id: 'u1', name: 'A', employeeId: 'E1', hireDate: makeDateOnly(2026, 1, 1),
+      });
+      prisma.clockRecord.findMany.mockResolvedValue([]);
+      prisma.leaveRequest.findMany.mockResolvedValue([]);
+
+      const csv = await service.exportReport(adminUser, 2026, 4, 'company');
+
+      expect(csv).toContain('部門');
+      expect(csv).toContain('工程部');
+    });
+  });
+});

--- a/dev/src/app.module.ts
+++ b/dev/src/app.module.ts
@@ -8,6 +8,7 @@ import { ClockModule } from './clock/clock.module';
 import { LeaveQuotasModule } from './leave-quotas/leave-quotas.module';
 import { LeavesModule } from './leaves/leaves.module';
 import { LeaveApprovalModule } from './leave-approval/leave-approval.module';
+import { ReportsModule } from './reports/reports.module';
 
 @Module({
   imports: [
@@ -23,6 +24,7 @@ import { LeaveApprovalModule } from './leave-approval/leave-approval.module';
     LeaveQuotasModule,
     LeavesModule,
     LeaveApprovalModule,
+    ReportsModule,
   ],
 })
 export class AppModule {}

--- a/dev/src/reports/dto/export-report.dto.ts
+++ b/dev/src/reports/dto/export-report.dto.ts
@@ -1,0 +1,15 @@
+import { IsEnum, IsOptional, IsUUID } from 'class-validator';
+import { QueryReportDto } from './query-report.dto';
+
+export class ExportReportDto extends QueryReportDto {
+  @IsEnum(['team', 'company'])
+  scope!: 'team' | 'company';
+
+  @IsOptional()
+  @IsUUID()
+  department_id?: string;
+
+  @IsOptional()
+  @IsEnum(['csv', 'xlsx'])
+  format?: 'csv' | 'xlsx' = 'csv';
+}

--- a/dev/src/reports/dto/query-report.dto.ts
+++ b/dev/src/reports/dto/query-report.dto.ts
@@ -1,0 +1,16 @@
+import { IsInt, Min, Max } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class QueryReportDto {
+  @Type(() => Number)
+  @IsInt()
+  @Min(2020)
+  @Max(2099)
+  year!: number;
+
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(12)
+  month!: number;
+}

--- a/dev/src/reports/dto/query-team-report.dto.ts
+++ b/dev/src/reports/dto/query-team-report.dto.ts
@@ -1,0 +1,8 @@
+import { IsOptional, IsUUID } from 'class-validator';
+import { QueryReportDto } from './query-report.dto';
+
+export class QueryTeamReportDto extends QueryReportDto {
+  @IsOptional()
+  @IsUUID()
+  department_id?: string;
+}

--- a/dev/src/reports/reports.controller.ts
+++ b/dev/src/reports/reports.controller.ts
@@ -1,0 +1,92 @@
+import {
+  Controller,
+  Get,
+  Query,
+  UseGuards,
+  Res,
+  ForbiddenException,
+} from '@nestjs/common';
+import { Response } from 'express';
+import { ReportsService } from './reports.service';
+import { QueryReportDto } from './dto/query-report.dto';
+import { QueryTeamReportDto } from './dto/query-team-report.dto';
+import { ExportReportDto } from './dto/export-report.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import {
+  CurrentUser,
+  CurrentUserData,
+} from '../auth/decorators/current-user.decorator';
+
+@Controller('reports')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class ReportsController {
+  constructor(private readonly reportsService: ReportsService) {}
+
+  @Get('personal')
+  async getPersonalReport(
+    @CurrentUser() user: CurrentUserData,
+    @Query() query: QueryReportDto,
+  ) {
+    return this.reportsService.getPersonalReport(
+      user.userId,
+      query.year,
+      query.month,
+    );
+  }
+
+  @Get('team')
+  @Roles('MANAGER', 'ADMIN')
+  async getTeamReport(
+    @CurrentUser() user: CurrentUserData,
+    @Query() query: QueryTeamReportDto,
+  ) {
+    return this.reportsService.getTeamReport(
+      user,
+      query.year,
+      query.month,
+      query.department_id,
+    );
+  }
+
+  @Get('company')
+  @Roles('ADMIN')
+  async getCompanyReport(@Query() query: QueryReportDto) {
+    return this.reportsService.getCompanyReport(query.year, query.month);
+  }
+
+  @Get('export')
+  @Roles('MANAGER', 'ADMIN')
+  async exportReport(
+    @CurrentUser() user: CurrentUserData,
+    @Query() query: ExportReportDto,
+    @Res() res: Response,
+  ) {
+    // Admin 才能匯出 company scope
+    if (query.scope === 'company' && user.role !== 'ADMIN') {
+      throw new ForbiddenException({
+        code: 'FORBIDDEN',
+        message: '權限不足',
+      });
+    }
+
+    const csv = await this.reportsService.exportReport(
+      user,
+      query.year,
+      query.month,
+      query.scope,
+      query.department_id,
+    );
+
+    const filename = `report_${query.scope}_${query.year}_${query.month}.csv`;
+
+    res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+    res.setHeader(
+      'Content-Disposition',
+      `attachment; filename="${filename}"`,
+    );
+    // 加入 BOM 讓 Excel 正確顯示中文
+    res.send('\uFEFF' + csv);
+  }
+}

--- a/dev/src/reports/reports.module.ts
+++ b/dev/src/reports/reports.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ReportsController } from './reports.controller';
+import { ReportsService } from './reports.service';
+
+@Module({
+  controllers: [ReportsController],
+  providers: [ReportsService],
+  exports: [ReportsService],
+})
+export class ReportsModule {}

--- a/dev/src/reports/reports.service.ts
+++ b/dev/src/reports/reports.service.ts
@@ -1,0 +1,557 @@
+import { Injectable, ForbiddenException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CurrentUserData } from '../auth/decorators/current-user.decorator';
+
+interface UserSummary {
+  id: string;
+  name: string;
+  employee_id: string;
+}
+
+interface AttendanceSummary {
+  workdays: number;
+  present_days: number;
+  absent_days: number;
+  late_days: number;
+  early_leave_days: number;
+  leave_days: number;
+  overtime_hours: number;
+  attendance_rate: number;
+}
+
+interface MemberReport extends Omit<AttendanceSummary, 'workdays' | 'absent_days'> {
+  user: UserSummary;
+  absent_days: number;
+}
+
+@Injectable()
+export class ReportsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * 個人月報
+   */
+  async getPersonalReport(userId: string, year: number, month: number) {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { id: true, name: true, employeeId: true, hireDate: true },
+    });
+
+    if (!user) {
+      return this.buildEmptyPersonalReport(year, month);
+    }
+
+    const { startDate, endDate } = this.getMonthRange(year, month);
+    const hireDate = new Date(user.hireDate);
+    const workdays = this.calculateWorkdays(startDate, endDate, hireDate);
+
+    const clockRecords = await this.prisma.clockRecord.findMany({
+      where: {
+        userId,
+        date: { gte: startDate, lte: endDate },
+      },
+    });
+
+    const leaveRequests = await this.prisma.leaveRequest.findMany({
+      where: {
+        userId,
+        status: 'APPROVED',
+        startDate: { lte: endDate },
+        endDate: { gte: startDate },
+      },
+    });
+
+    const leaveDays = this.calculateLeaveDays(leaveRequests, startDate, endDate);
+    const presentDays = this.calculatePresentDays(clockRecords, leaveRequests, startDate, endDate);
+    const lateDays = this.calculateLateDays(clockRecords);
+    const earlyLeaveDays = this.calculateEarlyLeaveDays(clockRecords);
+    const absentDays = Math.max(0, workdays - presentDays - leaveDays);
+    const attendanceRate = workdays > 0
+      ? Math.round((presentDays / workdays) * 1000) / 10
+      : 0;
+
+    const leaveSummary = this.buildLeaveSummary(leaveRequests, startDate, endDate);
+
+    return {
+      user: {
+        id: user.id,
+        name: user.name,
+        employee_id: user.employeeId,
+      },
+      year,
+      month,
+      summary: {
+        workdays,
+        present_days: presentDays,
+        absent_days: absentDays,
+        late_days: lateDays,
+        early_leave_days: earlyLeaveDays,
+        leave_days: leaveDays,
+        overtime_hours: 0,
+        attendance_rate: attendanceRate,
+      },
+      leave_summary: leaveSummary,
+    };
+  }
+
+  /**
+   * 團隊報表
+   */
+  async getTeamReport(user: CurrentUserData, year: number, month: number, departmentId?: string) {
+    const deptId = this.resolveTeamDepartmentId(user, departmentId);
+
+    const department = await this.prisma.department.findUnique({
+      where: { id: deptId },
+      select: { id: true, name: true },
+    });
+
+    const members = await this.prisma.user.findMany({
+      where: { departmentId: deptId, status: 'ACTIVE' },
+      select: { id: true, name: true, employeeId: true, hireDate: true },
+    });
+
+    const memberReports: MemberReport[] = [];
+    for (const member of members) {
+      const report = await this.getPersonalReport(member.id, year, month);
+      memberReports.push({
+        user: report.user,
+        present_days: report.summary.present_days,
+        absent_days: report.summary.absent_days,
+        late_days: report.summary.late_days,
+        early_leave_days: report.summary.early_leave_days,
+        leave_days: report.summary.leave_days,
+        overtime_hours: report.summary.overtime_hours,
+        attendance_rate: report.summary.attendance_rate,
+      });
+    }
+
+    const totalMembers = memberReports.length;
+    const avgAttendanceRate = totalMembers > 0
+      ? Math.round(
+          (memberReports.reduce((sum, m) => sum + m.attendance_rate, 0) / totalMembers) * 10,
+        ) / 10
+      : 0;
+    const totalLateCount = memberReports.reduce((sum, m) => sum + m.late_days, 0);
+    const totalLeaveDays = memberReports.reduce((sum, m) => sum + m.leave_days, 0);
+
+    return {
+      department: department ? { id: department.id, name: department.name } : null,
+      year,
+      month,
+      team_summary: {
+        total_members: totalMembers,
+        avg_attendance_rate: avgAttendanceRate,
+        total_late_count: totalLateCount,
+        total_leave_days: totalLeaveDays,
+      },
+      members: memberReports,
+    };
+  }
+
+  /**
+   * 全公司報表
+   */
+  async getCompanyReport(year: number, month: number) {
+    const departments = await this.prisma.department.findMany({
+      select: { id: true, name: true },
+    });
+
+    const departmentReports = [];
+    let totalEmployees = 0;
+    let totalAttendanceRateSum = 0;
+    let totalLateCount = 0;
+    let totalLeaveDays = 0;
+
+    for (const dept of departments) {
+      const members = await this.prisma.user.findMany({
+        where: { departmentId: dept.id, status: 'ACTIVE' },
+        select: { id: true, name: true, employeeId: true, hireDate: true },
+      });
+
+      if (members.length === 0) continue;
+
+      let deptAttendanceSum = 0;
+      let deptLateCount = 0;
+      let deptLeaveDays = 0;
+
+      for (const member of members) {
+        const report = await this.getPersonalReport(member.id, year, month);
+        deptAttendanceSum += report.summary.attendance_rate;
+        deptLateCount += report.summary.late_days;
+        deptLeaveDays += report.summary.leave_days;
+      }
+
+      const deptAvgRate = Math.round((deptAttendanceSum / members.length) * 10) / 10;
+
+      departmentReports.push({
+        department: { id: dept.id, name: dept.name },
+        total_members: members.length,
+        avg_attendance_rate: deptAvgRate,
+        total_late_count: deptLateCount,
+        total_leave_days: deptLeaveDays,
+      });
+
+      totalEmployees += members.length;
+      totalAttendanceRateSum += deptAttendanceSum;
+      totalLateCount += deptLateCount;
+      totalLeaveDays += deptLeaveDays;
+    }
+
+    const avgAttendanceRate = totalEmployees > 0
+      ? Math.round((totalAttendanceRateSum / totalEmployees) * 10) / 10
+      : 0;
+
+    return {
+      year,
+      month,
+      company_summary: {
+        total_employees: totalEmployees,
+        avg_attendance_rate: avgAttendanceRate,
+        total_late_count: totalLateCount,
+        total_leave_days: totalLeaveDays,
+        total_overtime_hours: 0,
+      },
+      departments: departmentReports,
+    };
+  }
+
+  /**
+   * 匯出 CSV
+   */
+  async exportReport(
+    user: CurrentUserData,
+    year: number,
+    month: number,
+    scope: 'team' | 'company',
+    departmentId?: string,
+  ): Promise<string> {
+    if (scope === 'company') {
+      if (user.role !== 'ADMIN') {
+        throw new ForbiddenException({ code: 'FORBIDDEN', message: '權限不足' });
+      }
+      return this.generateCompanyCsv(year, month);
+    }
+
+    // scope === 'team'
+    const deptId = this.resolveTeamDepartmentId(user, departmentId);
+    return this.generateTeamCsv(user, year, month, deptId);
+  }
+
+  // === Private helpers ===
+
+  /**
+   * 決定團隊報表要查看的部門 ID
+   * Manager 只能看自己部門；Admin 可指定部門，預設看全公司第一個部門
+   */
+  private resolveTeamDepartmentId(user: CurrentUserData, departmentId?: string): string {
+    if (user.role === 'MANAGER') {
+      // Manager 忽略 department_id 參數，只能看自己部門
+      return user.departmentId;
+    }
+    // Admin
+    return departmentId || user.departmentId;
+  }
+
+  /**
+   * 取得月份的起訖日期（UTC Date）
+   */
+  getMonthRange(year: number, month: number): { startDate: Date; endDate: Date } {
+    const startDate = new Date(Date.UTC(year, month - 1, 1));
+    const endDate = new Date(Date.UTC(year, month, 0)); // 最後一天
+    return { startDate, endDate };
+  }
+
+  /**
+   * 計算工作日數（排除週六日）
+   * 新進員工只算到職日之後
+   */
+  calculateWorkdays(startDate: Date, endDate: Date, hireDate?: Date): number {
+    let count = 0;
+    const current = new Date(startDate);
+
+    // 如果到職日在月份範圍內，從到職日開始算
+    if (hireDate && hireDate > startDate) {
+      current.setTime(hireDate.getTime());
+      // 對齊到 UTC 日期
+      current.setUTCHours(0, 0, 0, 0);
+    }
+
+    while (current <= endDate) {
+      const dayOfWeek = current.getUTCDay();
+      if (dayOfWeek !== 0 && dayOfWeek !== 6) {
+        count++;
+      }
+      current.setUTCDate(current.getUTCDate() + 1);
+    }
+
+    return count;
+  }
+
+  /**
+   * 計算出席天數
+   * 有打卡且非全天請假
+   */
+  calculatePresentDays(
+    clockRecords: Array<{ date: Date; clockIn: Date; clockOut: Date | null }>,
+    leaveRequests: Array<{
+      startDate: Date;
+      endDate: Date;
+      startHalf: string;
+      endHalf: string;
+      hours: { toNumber?: () => number } | number;
+    }>,
+    monthStart: Date,
+    monthEnd: Date,
+  ): number {
+    let count = 0;
+
+    for (const record of clockRecords) {
+      const recordDate = new Date(record.date);
+      recordDate.setUTCHours(0, 0, 0, 0);
+
+      // 檢查該天是否為全天請假
+      const isFullDayLeave = this.isFullDayLeave(recordDate, leaveRequests);
+      if (!isFullDayLeave) {
+        count++;
+      }
+    }
+
+    return count;
+  }
+
+  /**
+   * 判斷某天是否為全天請假
+   */
+  private isFullDayLeave(
+    date: Date,
+    leaveRequests: Array<{
+      startDate: Date;
+      endDate: Date;
+      startHalf: string;
+      endHalf: string;
+    }>,
+  ): boolean {
+    for (const leave of leaveRequests) {
+      const leaveStart = new Date(leave.startDate);
+      leaveStart.setUTCHours(0, 0, 0, 0);
+      const leaveEnd = new Date(leave.endDate);
+      leaveEnd.setUTCHours(0, 0, 0, 0);
+
+      if (date >= leaveStart && date <= leaveEnd) {
+        // 如果是單天請假
+        if (leaveStart.getTime() === leaveEnd.getTime()) {
+          return leave.startHalf === 'FULL';
+        }
+        // 如果是多天請假的第一天
+        if (date.getTime() === leaveStart.getTime()) {
+          return leave.startHalf === 'FULL';
+        }
+        // 最後一天
+        if (date.getTime() === leaveEnd.getTime()) {
+          return leave.endHalf === 'FULL';
+        }
+        // 中間天數都是全天
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * 計算遲到天數（clock_in > 09:00 UTC+8）
+   */
+  calculateLateDays(clockRecords: Array<{ clockIn: Date }>): number {
+    let count = 0;
+    for (const record of clockRecords) {
+      const clockIn = new Date(record.clockIn);
+      // UTC+8 09:00 = UTC 01:00
+      const utcHour = clockIn.getUTCHours();
+      const utcMinute = clockIn.getUTCMinutes();
+      // 09:00 UTC+8 = 01:00 UTC
+      if (utcHour > 1 || (utcHour === 1 && utcMinute > 0)) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  /**
+   * 計算早退天數（clock_out < 18:00 UTC+8）
+   */
+  calculateEarlyLeaveDays(
+    clockRecords: Array<{ clockOut: Date | null }>,
+  ): number {
+    let count = 0;
+    for (const record of clockRecords) {
+      if (!record.clockOut) continue;
+      const clockOut = new Date(record.clockOut);
+      // UTC+8 18:00 = UTC 10:00
+      const utcHour = clockOut.getUTCHours();
+      if (utcHour < 10) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  /**
+   * 計算請假天數
+   * 半天假算 0.5 天
+   */
+  calculateLeaveDays(
+    leaveRequests: Array<{
+      startDate: Date;
+      endDate: Date;
+      startHalf: string;
+      endHalf: string;
+    }>,
+    monthStart: Date,
+    monthEnd: Date,
+  ): number {
+    let totalDays = 0;
+
+    for (const leave of leaveRequests) {
+      const leaveStart = new Date(leave.startDate);
+      leaveStart.setUTCHours(0, 0, 0, 0);
+      const leaveEnd = new Date(leave.endDate);
+      leaveEnd.setUTCHours(0, 0, 0, 0);
+
+      // 限制在月份範圍內
+      const effectiveStart = leaveStart < monthStart ? monthStart : leaveStart;
+      const effectiveEnd = leaveEnd > monthEnd ? monthEnd : leaveEnd;
+
+      const current = new Date(effectiveStart);
+
+      while (current <= effectiveEnd) {
+        const dayOfWeek = current.getUTCDay();
+        // 只計算工作日
+        if (dayOfWeek !== 0 && dayOfWeek !== 6) {
+          if (current.getTime() === leaveStart.getTime() && leave.startHalf !== 'FULL') {
+            totalDays += 0.5;
+          } else if (current.getTime() === leaveEnd.getTime() && leave.endHalf !== 'FULL') {
+            totalDays += 0.5;
+          } else {
+            totalDays += 1;
+          }
+        }
+        current.setUTCDate(current.getUTCDate() + 1);
+      }
+    }
+
+    return totalDays;
+  }
+
+  /**
+   * 建立假別摘要
+   */
+  private buildLeaveSummary(
+    leaveRequests: Array<{
+      leaveType: string;
+      hours: { toNumber?: () => number } | number;
+      startDate: Date;
+      endDate: Date;
+    }>,
+    monthStart: Date,
+    monthEnd: Date,
+  ): Array<{ leave_type: string; hours: number }> {
+    const leaveTypes = [
+      'PERSONAL', 'SICK', 'ANNUAL', 'MARRIAGE',
+      'BEREAVEMENT', 'MATERNITY', 'PATERNITY', 'OFFICIAL',
+    ];
+
+    const summary: Record<string, number> = {};
+    for (const type of leaveTypes) {
+      summary[type] = 0;
+    }
+
+    for (const leave of leaveRequests) {
+      const hours = typeof leave.hours === 'number'
+        ? leave.hours
+        : (leave.hours.toNumber ? leave.hours.toNumber() : Number(leave.hours));
+      summary[leave.leaveType] = (summary[leave.leaveType] || 0) + hours;
+    }
+
+    return leaveTypes.map((type) => ({
+      leave_type: type.toLowerCase(),
+      hours: summary[type],
+    }));
+  }
+
+  /**
+   * 空的個人報表
+   */
+  private buildEmptyPersonalReport(year: number, month: number) {
+    return {
+      user: { id: '', name: '', employee_id: '' },
+      year,
+      month,
+      summary: {
+        workdays: 0,
+        present_days: 0,
+        absent_days: 0,
+        late_days: 0,
+        early_leave_days: 0,
+        leave_days: 0,
+        overtime_hours: 0,
+        attendance_rate: 0,
+      },
+      leave_summary: [],
+    };
+  }
+
+  /**
+   * 產生團隊 CSV
+   */
+  private async generateTeamCsv(
+    user: CurrentUserData,
+    year: number,
+    month: number,
+    departmentId: string,
+  ): Promise<string> {
+    const teamReport = await this.getTeamReport(user, year, month, departmentId);
+    const headers = [
+      '員工編號', '姓名', '出席天數', '缺勤天數', '遲到天數',
+      '早退天數', '請假天數', '加班時數', '出勤率(%)',
+    ];
+
+    const rows = teamReport.members.map((m) => [
+      m.user.employee_id,
+      m.user.name,
+      m.present_days,
+      m.absent_days,
+      m.late_days,
+      m.early_leave_days,
+      m.leave_days,
+      m.overtime_hours,
+      m.attendance_rate,
+    ]);
+
+    return [
+      headers.join(','),
+      ...rows.map((r) => r.join(',')),
+    ].join('\n');
+  }
+
+  /**
+   * 產生全公司 CSV
+   */
+  private async generateCompanyCsv(year: number, month: number): Promise<string> {
+    const companyReport = await this.getCompanyReport(year, month);
+    const headers = [
+      '部門', '人數', '平均出勤率(%)', '遲到總次數', '請假總天數',
+    ];
+
+    const rows = companyReport.departments.map((d) => [
+      d.department.name,
+      d.total_members,
+      d.avg_attendance_rate,
+      d.total_late_count,
+      d.total_leave_days,
+    ]);
+
+    return [
+      headers.join(','),
+      ...rows.map((r) => r.join(',')),
+    ].join('\n');
+  }
+}


### PR DESCRIPTION
## Summary
實作出席報表/統計功能，包含個人月報、團隊報表、全公司報表及 CSV 匯出。

## Changes
- `dev/src/reports/reports.module.ts` - Reports 模組定義
- `dev/src/reports/reports.controller.ts` - 4 個 API endpoint (personal/team/company/export)
- `dev/src/reports/reports.service.ts` - 報表核心邏輯：工作日計算、出勤統計、遲到/早退偵測、請假整合、CSV 產生
- `dev/src/reports/dto/query-report.dto.ts` - 基礎查詢 DTO (year/month)
- `dev/src/reports/dto/query-team-report.dto.ts` - 團隊查詢 DTO (含 department_id)
- `dev/src/reports/dto/export-report.dto.ts` - 匯出查詢 DTO (scope/format)
- `dev/src/app.module.ts` - 註冊 ReportsModule
- `dev/__tests__/reports/reports.service.spec.ts` - 單元測試

## Scenario 覆蓋
- [x] Scenario: 查看個人月報 — 完整出勤統計 + leave_summary
- [x] Scenario: 主管查看團隊報表 — Manager 限自己部門
- [x] Scenario: Admin 查看全公司報表 — 部門匯總
- [x] Scenario: 匯出團隊報表 CSV — Content-Type: text/csv
- [x] Scenario: 員工嘗試看團隊報表 — 403 FORBIDDEN (RolesGuard)
- [x] Scenario: Manager 嘗試看全公司報表 — 403 FORBIDDEN (RolesGuard)
- [x] Scenario: 新進員工月中到職 — workdays 從 hire_date 起算
- [x] Scenario: 查看未來月份 — 所有數值為 0

## Business Rules 實作
- attendance_rate = (present_days / workdays) * 100，四捨五入一位小數
- workdays 排除週六日
- late_days: clock_in > 09:00 UTC+8
- early_leave_days: clock_out < 18:00 UTC+8
- leave_days: approved leave，半天 = 0.5
- overtime_hours: Sprint 3 無加班功能，固定 0
- Manager 只看自己部門；Admin 看全公司

## 測試
- 單元測試涵蓋：workdays 計算、遲到/早退判定、請假天數計算、個人報表、團隊報表、全公司報表、CSV 匯出、權限檢查

Closes #27