### PR TITLE
[Design] Sprint 3 - 可視化 UI

### DIFF
--- a/design/components/attendance-chart.md
+++ b/design/components/attendance-chart.md
@@ -1,0 +1,459 @@
+# AttendanceChart
+
+## 用途
+
+出勤率統計圖表元件，支援圓餅圖（Pie）和長條圖（Bar）兩種呈現方式。基於 shadcn/ui 的 `Chart` 元件（Recharts wrapper）實作。用於個人出勤報表、團隊報表和公司報表頁面。
+
+## Props
+
+| Prop | Type | Default | 說明 |
+|------|------|---------|------|
+| type | `'pie' \| 'bar'` | `'pie'` | 圖表類型 |
+| data | `ChartDataItem[]` | - | 圖表資料 |
+| title | `string` | - | 圖表標題 |
+| description | `string` | - | 圖表說明（選填） |
+| height | `number` | `300` | 圖表高度（px） |
+| showLegend | `boolean` | `true` | 是否顯示圖例 |
+
+## 子型別
+
+```ts
+interface ChartDataItem {
+  name: string;         // 分類名稱
+  value: number;        // 數值
+  color: string;        // CSS 變數名（如 "--chart-present"）
+  percentage?: number;  // 百分比（圓餅圖用）
+}
+```
+
+## Variants
+
+### 圓餅圖（type="pie"）
+
+用於單一指標的組成分析，例如個人出勤天數分布。
+
+```
+┌─────────────────────────────────────────┐
+│  出勤分布                               │
+│  2026 年 4 月                           │
+│                                         │
+│          ┌────────┐                     │
+│         /  正常    \                    │
+│        │  20天 91% │                    │
+│         \  遲到 2  /                    │
+│          └────────┘                     │
+│                                         │
+│  ■ 正常 20天  ■ 遲到 2天  ■ 請假 2天   │
+└─────────────────────────────────────────┘
+```
+
+### 長條圖（type="bar"）
+
+用於多項比較，例如部門間出勤率比較。
+
+```
+┌─────────────────────────────────────────┐
+│  部門出勤率比較                         │
+│  2026 年 4 月                           │
+│                                         │
+│  工程部  ████████████████████  96%      │
+│  業務部  █████████████████    92%       │
+│  人資部  ██████████████████   94%       │
+│  行銷部  ████████████████     90%       │
+│                                         │
+│          0%   25%   50%   75%  100%     │
+└─────────────────────────────────────────┘
+```
+
+## 外觀規格
+
+| 部位 | 樣式 |
+|------|------|
+| 容器 | `rounded-lg border bg-card`，使用 shadcn/ui `Card` |
+| 標題 | `text-lg font-semibold`（CardTitle） |
+| 說明 | `text-sm text-muted-foreground`（CardDescription） |
+| 圖表容器 | `ChartContainer` 搭配 `min-h-[VALUE]` |
+| 圓餅圖 | Recharts `PieChart` + `Pie` + `Cell`，內半徑 60%（Donut） |
+| 長條圖 | Recharts `BarChart` + `Bar`，水平方向 `layout="vertical"` |
+| Tooltip | `ChartTooltip` + `ChartTooltipContent` |
+| 圖例 | `ChartLegend` + `ChartLegendContent`，底部排列 |
+| 色彩 | 使用 `calendar-colors.css` 的 `--chart-*` token |
+| 空狀態 | 中央顯示 "暫無資料"，高度同 height |
+
+## ChartConfig 定義
+
+```ts
+import { type ChartConfig } from "@/components/ui/chart";
+
+// 個人出勤分布圖
+const personalAttendanceConfig: ChartConfig = {
+  present: {
+    label: "正常出勤",
+    color: "hsl(var(--chart-present))",
+  },
+  late: {
+    label: "遲到",
+    color: "hsl(var(--chart-late))",
+  },
+  early_leave: {
+    label: "早退",
+    color: "hsl(var(--chart-early-leave))",
+  },
+  leave: {
+    label: "請假",
+    color: "hsl(var(--chart-leave))",
+  },
+  absent: {
+    label: "缺席",
+    color: "hsl(var(--chart-absent))",
+  },
+  overtime: {
+    label: "加班",
+    color: "hsl(var(--chart-overtime))",
+  },
+};
+
+// 部門出勤率比較（單色漸層或多色）
+const departmentConfig: ChartConfig = {
+  attendance_rate: {
+    label: "出勤率",
+    color: "hsl(var(--primary))",
+  },
+};
+```
+
+## 範例程式碼
+
+### 圓餅圖（Donut）
+
+```tsx
+"use client";
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  ChartConfig,
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+import { PieChart, Pie, Cell, Label } from "recharts";
+
+interface AttendancePieChartProps {
+  title: string;
+  description?: string;
+  data: ChartDataItem[];
+  config: ChartConfig;
+  centerLabel?: string;
+  centerValue?: string | number;
+  height?: number;
+}
+
+export function AttendancePieChart({
+  title,
+  description,
+  data,
+  config,
+  centerLabel,
+  centerValue,
+  height = 300,
+}: AttendancePieChartProps) {
+  const total = data.reduce((sum, d) => sum + d.value, 0);
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-lg">{title}</CardTitle>
+        {description && <CardDescription>{description}</CardDescription>}
+      </CardHeader>
+      <CardContent>
+        {total === 0 ? (
+          <div
+            className="flex items-center justify-center text-sm text-muted-foreground"
+            style={{ height }}
+          >
+            暫無資料
+          </div>
+        ) : (
+          <ChartContainer config={config} className={`min-h-[${height}px]`}>
+            <PieChart>
+              <ChartTooltip content={<ChartTooltipContent />} />
+              <Pie
+                data={data}
+                dataKey="value"
+                nameKey="name"
+                innerRadius="60%"
+                outerRadius="80%"
+                paddingAngle={2}
+                strokeWidth={2}
+                stroke="hsl(var(--background))"
+              >
+                {data.map((entry, i) => (
+                  <Cell
+                    key={entry.name}
+                    fill={`hsl(var(${entry.color}))`}
+                  />
+                ))}
+
+                {/* 中央標籤 */}
+                {centerLabel && (
+                  <Label
+                    content={({ viewBox }) => {
+                      if (viewBox && "cx" in viewBox && "cy" in viewBox) {
+                        return (
+                          <text x={viewBox.cx} y={viewBox.cy} textAnchor="middle">
+                            <tspan
+                              x={viewBox.cx}
+                              y={(viewBox.cy || 0) - 8}
+                              className="fill-foreground text-3xl font-bold"
+                            >
+                              {centerValue}
+                            </tspan>
+                            <tspan
+                              x={viewBox.cx}
+                              y={(viewBox.cy || 0) + 16}
+                              className="fill-muted-foreground text-sm"
+                            >
+                              {centerLabel}
+                            </tspan>
+                          </text>
+                        );
+                      }
+                    }}
+                  />
+                )}
+              </Pie>
+              <ChartLegend content={<ChartLegendContent />} />
+            </PieChart>
+          </ChartContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+```
+
+### 長條圖（水平）
+
+```tsx
+"use client";
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid } from "recharts";
+
+interface AttendanceBarChartProps {
+  title: string;
+  description?: string;
+  data: { name: string; value: number; fill?: string }[];
+  config: ChartConfig;
+  dataKey?: string;
+  height?: number;
+  layout?: "horizontal" | "vertical";
+  unit?: string;
+}
+
+export function AttendanceBarChart({
+  title,
+  description,
+  data,
+  config,
+  dataKey = "value",
+  height = 300,
+  layout = "vertical",
+  unit = "%",
+}: AttendanceBarChartProps) {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-lg">{title}</CardTitle>
+        {description && <CardDescription>{description}</CardDescription>}
+      </CardHeader>
+      <CardContent>
+        {data.length === 0 ? (
+          <div
+            className="flex items-center justify-center text-sm text-muted-foreground"
+            style={{ height }}
+          >
+            暫無資料
+          </div>
+        ) : (
+          <ChartContainer config={config} className={`min-h-[${height}px]`}>
+            <BarChart
+              data={data}
+              layout={layout}
+              margin={{ left: 0, right: 16, top: 8, bottom: 8 }}
+            >
+              <CartesianGrid
+                horizontal={layout === "horizontal"}
+                vertical={layout === "vertical"}
+                strokeDasharray="3 3"
+                className="stroke-border"
+              />
+
+              {layout === "vertical" ? (
+                <>
+                  <YAxis
+                    dataKey="name"
+                    type="category"
+                    width={80}
+                    tickLine={false}
+                    axisLine={false}
+                    className="text-xs"
+                  />
+                  <XAxis
+                    type="number"
+                    domain={[0, 100]}
+                    tickLine={false}
+                    axisLine={false}
+                    className="text-xs"
+                    tickFormatter={(v) => `${v}${unit}`}
+                  />
+                </>
+              ) : (
+                <>
+                  <XAxis
+                    dataKey="name"
+                    tickLine={false}
+                    axisLine={false}
+                    className="text-xs"
+                  />
+                  <YAxis
+                    tickLine={false}
+                    axisLine={false}
+                    className="text-xs"
+                    tickFormatter={(v) => `${v}${unit}`}
+                  />
+                </>
+              )}
+
+              <ChartTooltip
+                content={<ChartTooltipContent />}
+                cursor={{ fill: "hsl(var(--muted))", opacity: 0.5 }}
+              />
+
+              <Bar
+                dataKey={dataKey}
+                radius={[4, 4, 4, 4]}
+                fill="hsl(var(--primary))"
+                maxBarSize={40}
+              />
+            </BarChart>
+          </ChartContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+```
+
+## 使用範例
+
+```tsx
+// 個人出勤分布（圓餅圖）
+<AttendancePieChart
+  title="出勤分布"
+  description="2026 年 4 月"
+  centerLabel="出勤天數"
+  centerValue={20}
+  data={[
+    { name: "present", value: 18, color: "--chart-present" },
+    { name: "late", value: 2, color: "--chart-late" },
+    { name: "leave", value: 2, color: "--chart-leave" },
+  ]}
+  config={personalAttendanceConfig}
+/>
+
+// 請假類型分布（圓餅圖）
+<AttendancePieChart
+  title="請假類型分布"
+  description="2026 年 4 月"
+  centerLabel="請假天數"
+  centerValue={2}
+  data={[
+    { name: "annual", value: 1, color: "--leave-annual" },
+    { name: "sick", value: 0.5, color: "--leave-sick" },
+    { name: "personal", value: 0.5, color: "--leave-personal" },
+  ]}
+  config={{
+    annual: { label: "特休", color: "hsl(var(--leave-annual))" },
+    sick: { label: "病假", color: "hsl(var(--leave-sick))" },
+    personal: { label: "事假", color: "hsl(var(--leave-personal))" },
+  }}
+/>
+
+// 部門出勤率比較（水平長條圖）
+<AttendanceBarChart
+  title="部門出勤率比較"
+  description="2026 年 4 月"
+  data={[
+    { name: "工程部", value: 96 },
+    { name: "業務部", value: 92 },
+    { name: "人資部", value: 94 },
+    { name: "行銷部", value: 90 },
+  ]}
+  config={{ value: { label: "出勤率", color: "hsl(var(--primary))" } }}
+  layout="vertical"
+  unit="%"
+/>
+
+// 月遲到人次（垂直長條圖，可用於趨勢比較）
+<AttendanceBarChart
+  title="遲到人次"
+  description="近 6 個月"
+  data={[
+    { name: "11月", value: 8 },
+    { name: "12月", value: 5 },
+    { name: "1月", value: 12 },
+    { name: "2月", value: 6 },
+    { name: "3月", value: 5 },
+    { name: "4月", value: 3 },
+  ]}
+  config={{ value: { label: "遲到人次", color: "hsl(var(--chart-late))" } }}
+  layout="horizontal"
+  unit="人次"
+/>
+```
+
+## 響應式行為
+
+| 斷點 | 圖表行為 |
+|------|---------|
+| >= 768px (md) | 完整圖表 + 圖例 |
+| < 768px | 圖表高度縮小至 200px，圖例堆疊顯示 |
+
+## Accessibility
+
+- `ChartContainer` 提供 `role="img"` 語意
+- Recharts Tooltip 支援鍵盤操作
+- 色彩搭配文字標籤，不僅依賴色彩傳遞資訊
+- 圖例提供文字標籤 + 色彩方塊
+- 空狀態有文字提示
+- 圓餅圖中央 Label 提供總計數字
+
+## 使用的 shadcn/ui 元件
+
+- `Card`（CardHeader, CardTitle, CardDescription, CardContent）
+- `Chart`（ChartContainer, ChartTooltip, ChartTooltipContent, ChartLegend, ChartLegendContent）
+
+## 依賴
+
+- `recharts`（透過 shadcn/ui Chart 元件整合）

--- a/design/components/calendar-month.md
+++ b/design/components/calendar-month.md
@@ -1,0 +1,404 @@
+# CalendarMonth
+
+## 用途
+
+個人月曆元件，以格子視圖呈現整月的出勤狀態。每個日格以色彩標示當日出勤狀態（正常、遲到、請假、缺席等），點擊日格可展開詳情。搭配 `MonthPicker` 切換月份。
+
+## Props
+
+| Prop | Type | Default | 說明 |
+|------|------|---------|------|
+| year | `number` | - | 年份 |
+| month | `number` | - | 月份（1-12） |
+| days | `CalendarDay[]` | - | 整月日期資料（來自 API） |
+| onDayClick | `(day: CalendarDay) => void` | - | 日格點擊回呼 |
+| isLoading | `boolean` | `false` | 載入中狀態 |
+| selectedDate | `string` | - | 目前選中的日期（YYYY-MM-DD） |
+
+## 子型別
+
+```ts
+interface CalendarDay {
+  date: string; // "2026-04-01"
+  is_workday: boolean;
+  clock: {
+    clock_in: string | null;
+    clock_out: string | null;
+    status: "normal" | "late" | "early_leave" | "absent" | "amended";
+  } | null;
+  leaves: {
+    id: string;
+    leave_type: string;
+    start_half: "full" | "morning" | "afternoon";
+    end_half: "full" | "morning" | "afternoon";
+    status: "approved" | "pending" | "rejected" | "cancelled";
+  }[];
+  overtime: {
+    id: string;
+    hours: number;
+    status: string;
+  } | null;
+}
+
+// 日格衍生狀態（由元件內部計算）
+type DayCellStatus =
+  | "present"    // 正常出勤（綠）
+  | "late"       // 遲到（橙）
+  | "early_leave"// 早退（深橙）
+  | "leave"      // 請假（藍，或依假別色）
+  | "absent"     // 缺席（紅）
+  | "holiday"    // 假日（灰）
+  | "overtime"   // 加班（紫）
+  | "half_leave" // 半天假+半天出勤（左右分色）
+  | "future"     // 未來日期（無色）
+  | null;        // 無資料
+```
+
+## Layout
+
+```
+┌───────────────────────────────────────────────────┐
+│  日    一    二    三    四    五    六             │
+├───────────────────────────────────────────────────┤
+│       [  1] [  2] [  3] [  4] [  5] [  6]         │
+│       正常   特休  正常   正常  遲到  (六)          │
+│                                                   │
+│ [  7] [  8] [  9] [ 10] [ 11] [ 12] [ 13]         │
+│ (日)  正常   正常  半假   缺席  正常  (六)          │
+│                   +出勤                            │
+│ ...                                               │
+└───────────────────────────────────────────────────┘
+
+日格內部（48x48 以上）：
+┌──────────┐
+│  日期數字 │  ← text-sm font-medium
+│  [狀態點] │  ← 小圓點或 mini 文字標籤
+│  [時間]   │  ← text-xs（選填，桌面版才顯示）
+└──────────┘
+```
+
+## 外觀規格
+
+| 部位 | 樣式 |
+|------|------|
+| 容器 | `rounded-lg border bg-card` |
+| 星期 Header | `grid grid-cols-7 border-b`，每格 `p-2 text-center text-xs font-medium text-muted-foreground` |
+| 日格容器 | `grid grid-cols-7`，每格 `min-h-[80px] lg:min-h-[100px] border-b border-r p-1.5` |
+| 日期數字 | `text-sm font-medium`，今天額外 `bg-primary text-primary-foreground rounded-full w-6 h-6 flex items-center justify-center` |
+| 狀態指示 | 小圓點 `w-2 h-2 rounded-full`，使用 `calendar-colors.css` 的 token |
+| 狀態標籤 | `text-[10px] leading-tight`，使用對應狀態文字色 |
+| 假日日格 | `bg-[hsl(var(--cal-holiday-bg))]` |
+| 選中日格 | `ring-2 ring-primary ring-inset` |
+| hover 日格 | `hover:bg-accent/50 cursor-pointer` |
+| 非當月日格 | `opacity-30` |
+| Loading | `Skeleton` 填滿整個格子區域 |
+| 週六 Header | `text-[hsl(var(--cal-holiday-text))]` |
+| 週日 Header | `text-destructive` |
+
+## 日格狀態色彩對應
+
+| DayCellStatus | 背景 Token | 圓點色 Token | 標籤文字 |
+|---------------|-----------|-------------|---------|
+| present | `--cal-present-bg` | `--cal-present` | 正常 |
+| late | `--cal-late-bg` | `--cal-late` | 遲到 |
+| early_leave | `--cal-early-leave-bg` | `--cal-early-leave` | 早退 |
+| leave | `--cal-leave-bg` 或依假別色 | `--cal-leave` | 假別名 |
+| absent | `--cal-absent-bg` | `--cal-absent` | 缺席 |
+| holiday | `--cal-holiday-bg` | - | - |
+| overtime | `--cal-overtime-bg` | `--cal-overtime` | 加班 |
+| half_leave | 左半 leave 色 / 右半 present 色 | 兩色圓點 | 半假 |
+| future | 無特殊背景 | - | - |
+
+## 狀態衍生邏輯
+
+```ts
+function deriveDayCellStatus(day: CalendarDay): DayCellStatus {
+  const today = new Date().toISOString().slice(0, 10);
+
+  // 假日
+  if (!day.is_workday && !day.overtime) return "holiday";
+
+  // 未來日期
+  if (day.date > today) return "future";
+
+  // 加班（假日加班）
+  if (!day.is_workday && day.overtime) return "overtime";
+
+  // 全天請假
+  const approvedLeaves = day.leaves.filter((l) => l.status === "approved");
+  const hasFullDayLeave = approvedLeaves.some((l) => l.start_half === "full");
+  if (hasFullDayLeave) return "leave";
+
+  // 半天假 + 有打卡
+  const hasHalfLeave = approvedLeaves.length > 0;
+  if (hasHalfLeave && day.clock) return "half_leave";
+  if (hasHalfLeave && !day.clock) return "leave";
+
+  // 有打卡紀錄
+  if (day.clock) return day.clock.status as DayCellStatus;
+
+  // 工作日無打卡無請假
+  if (day.is_workday && day.date <= today) return "absent";
+
+  return null;
+}
+```
+
+## 範例程式碼
+
+```tsx
+"use client";
+
+import { useState } from "react";
+import { format, startOfMonth, endOfMonth, getDay, eachDayOfInterval, isSameDay, isToday } from "date-fns";
+import { zhTW } from "date-fns/locale";
+import { cn } from "@/lib/utils";
+import { Skeleton } from "@/components/ui/skeleton";
+
+const WEEKDAYS = ["日", "一", "二", "三", "四", "五", "六"];
+
+const statusStyles: Record<string, { bg: string; dot: string; label: string }> = {
+  present: {
+    bg: "bg-[hsl(var(--cal-present-bg))]",
+    dot: "bg-[hsl(var(--cal-present))]",
+    label: "正常",
+  },
+  late: {
+    bg: "bg-[hsl(var(--cal-late-bg))]",
+    dot: "bg-[hsl(var(--cal-late))]",
+    label: "遲到",
+  },
+  early_leave: {
+    bg: "bg-[hsl(var(--cal-early-leave-bg))]",
+    dot: "bg-[hsl(var(--cal-early-leave))]",
+    label: "早退",
+  },
+  leave: {
+    bg: "bg-[hsl(var(--cal-leave-bg))]",
+    dot: "bg-[hsl(var(--cal-leave))]",
+    label: "請假",
+  },
+  absent: {
+    bg: "bg-[hsl(var(--cal-absent-bg))]",
+    dot: "bg-[hsl(var(--cal-absent))]",
+    label: "缺席",
+  },
+  holiday: {
+    bg: "bg-[hsl(var(--cal-holiday-bg))]",
+    dot: "",
+    label: "",
+  },
+  overtime: {
+    bg: "bg-[hsl(var(--cal-overtime-bg))]",
+    dot: "bg-[hsl(var(--cal-overtime))]",
+    label: "加班",
+  },
+};
+
+interface CalendarMonthProps {
+  year: number;
+  month: number;
+  days: CalendarDay[];
+  onDayClick?: (day: CalendarDay) => void;
+  isLoading?: boolean;
+  selectedDate?: string;
+}
+
+export function CalendarMonth({
+  year,
+  month,
+  days,
+  onDayClick,
+  isLoading = false,
+  selectedDate,
+}: CalendarMonthProps) {
+  // 建立日期 lookup map
+  const dayMap = new Map(days.map((d) => [d.date, d]));
+
+  // 計算月曆格
+  const firstDay = startOfMonth(new Date(year, month - 1));
+  const lastDay = endOfMonth(firstDay);
+  const startOffset = getDay(firstDay); // 0=日, 1=一, ...
+  const allDays = eachDayOfInterval({ start: firstDay, end: lastDay });
+
+  return (
+    <div className="rounded-lg border bg-card">
+      {/* 星期 Header */}
+      <div className="grid grid-cols-7 border-b">
+        {WEEKDAYS.map((day, i) => (
+          <div
+            key={day}
+            className={cn(
+              "p-2 text-center text-xs font-medium text-muted-foreground",
+              i === 0 && "text-destructive",
+              i === 6 && "text-[hsl(var(--cal-holiday-text))]"
+            )}
+          >
+            {day}
+          </div>
+        ))}
+      </div>
+
+      {/* 日格 */}
+      {isLoading ? (
+        <div className="grid grid-cols-7">
+          {Array.from({ length: 35 }).map((_, i) => (
+            <div key={i} className="min-h-[80px] border-b border-r p-1.5 lg:min-h-[100px]">
+              <Skeleton className="h-full w-full rounded" />
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="grid grid-cols-7">
+          {/* 前置空格 */}
+          {Array.from({ length: startOffset }).map((_, i) => (
+            <div key={`empty-${i}`} className="min-h-[80px] border-b border-r lg:min-h-[100px]" />
+          ))}
+
+          {/* 日期格 */}
+          {allDays.map((date) => {
+            const dateStr = format(date, "yyyy-MM-dd");
+            const dayData = dayMap.get(dateStr);
+            const status = dayData ? deriveDayCellStatus(dayData) : null;
+            const style = status ? statusStyles[status] : null;
+            const isSelected = selectedDate === dateStr;
+            const today = isToday(date);
+
+            return (
+              <button
+                key={dateStr}
+                type="button"
+                className={cn(
+                  "min-h-[80px] border-b border-r p-1.5 text-left transition-colors lg:min-h-[100px]",
+                  "hover:bg-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset",
+                  style?.bg,
+                  isSelected && "ring-2 ring-primary ring-inset"
+                )}
+                onClick={() => dayData && onDayClick?.(dayData)}
+                aria-label={`${format(date, "M月d日")}${style?.label ? `，${style.label}` : ""}`}
+                aria-pressed={isSelected}
+              >
+                {/* 日期數字 */}
+                <div className="flex items-start justify-between">
+                  <span
+                    className={cn(
+                      "text-sm font-medium",
+                      today &&
+                        "flex h-6 w-6 items-center justify-center rounded-full bg-primary text-primary-foreground"
+                    )}
+                  >
+                    {date.getDate()}
+                  </span>
+                  {/* 狀態圓點 */}
+                  {style?.dot && (
+                    <span
+                      className={cn("mt-1 h-2 w-2 rounded-full", style.dot)}
+                      aria-hidden="true"
+                    />
+                  )}
+                </div>
+
+                {/* 狀態文字（桌面版） */}
+                {style?.label && (
+                  <span className="mt-1 hidden text-[10px] leading-tight text-muted-foreground lg:block">
+                    {style.label}
+                  </span>
+                )}
+
+                {/* 打卡時間（桌面版） */}
+                {dayData?.clock?.clock_in && (
+                  <span className="mt-0.5 hidden text-[10px] leading-tight text-muted-foreground lg:block">
+                    {format(new Date(dayData.clock.clock_in), "HH:mm")}
+                  </span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      {/* 圖例 */}
+      <div className="flex flex-wrap gap-3 border-t px-3 py-2">
+        {Object.entries(statusStyles)
+          .filter(([, v]) => v.label)
+          .map(([key, style]) => (
+            <div key={key} className="flex items-center gap-1">
+              <span className={cn("h-2 w-2 rounded-full", style.dot)} aria-hidden="true" />
+              <span className="text-xs text-muted-foreground">{style.label}</span>
+            </div>
+          ))}
+      </div>
+    </div>
+  );
+}
+```
+
+## 日格點擊詳情
+
+點擊日格後建議使用 `Sheet`（側邊抽屜）或 `Dialog` 顯示詳情：
+
+```tsx
+// 詳情面板內容
+<div className="space-y-4">
+  <h3 className="font-semibold">{format(selectedDate, "yyyy年M月d日 EEEE", { locale: zhTW })}</h3>
+
+  {/* 打卡紀錄 */}
+  {day.clock && (
+    <div className="space-y-2">
+      <h4 className="text-sm font-medium">打卡紀錄</h4>
+      <div className="flex justify-between text-sm">
+        <span>上班</span>
+        <span>{format(new Date(day.clock.clock_in), "HH:mm:ss")}</span>
+      </div>
+      <div className="flex justify-between text-sm">
+        <span>下班</span>
+        <span>{day.clock.clock_out ? format(new Date(day.clock.clock_out), "HH:mm:ss") : "--:--:--"}</span>
+      </div>
+      <StatusBadge type="attendance" value={day.clock.status} />
+    </div>
+  )}
+
+  {/* 請假紀錄 */}
+  {day.leaves.length > 0 && (
+    <div className="space-y-2">
+      <h4 className="text-sm font-medium">請假紀錄</h4>
+      {day.leaves.map((leave) => (
+        <div key={leave.id} className="flex items-center justify-between text-sm">
+          <LeaveTypeBadge type={leave.leave_type} />
+          <LeaveStatusBadge status={leave.status} />
+        </div>
+      ))}
+    </div>
+  )}
+
+  {/* 加班紀錄 */}
+  {day.overtime && (
+    <div className="space-y-2">
+      <h4 className="text-sm font-medium">加班紀錄</h4>
+      <span className="text-sm">{day.overtime.hours} 小時</span>
+    </div>
+  )}
+</div>
+```
+
+## 響應式行為
+
+| 斷點 | 日格高度 | 日格內容 |
+|------|---------|---------|
+| >= 1024px (lg) | 100px | 日期 + 狀態圓點 + 狀態文字 + 時間 |
+| < 1024px | 80px | 日期 + 狀態圓點 |
+
+## Accessibility
+
+- 每個日格為 `<button>` 元素，支援 keyboard focus
+- 日格有 `aria-label` 含完整日期和狀態描述
+- 選中日格有 `aria-pressed="true"`
+- 狀態圓點有 `aria-hidden="true"`（裝飾性）
+- 圖例區提供視覺以外的色彩含義說明
+- focus 時顯示 `ring` 高亮
+- 色彩對比度符合 WCAG 2.1 AA
+
+## 使用的 shadcn/ui 元件
+
+- `Skeleton`（Loading 狀態）
+- `Sheet` 或 `Dialog`（日格詳情面板）

--- a/design/components/month-picker.md
+++ b/design/components/month-picker.md
@@ -1,0 +1,268 @@
+# MonthPicker
+
+## 用途
+
+月份選擇器，用於行事曆和報表頁面切換年月。支援前後月導航和直接選擇月份。基於 shadcn/ui 的 `Button`、`Popover`、`Select` 元件組合。
+
+## Props
+
+| Prop | Type | Default | 說明 |
+|------|------|---------|------|
+| year | `number` | - | 目前年份 |
+| month | `number` | - | 目前月份（1-12） |
+| onChange | `(year: number, month: number) => void` | - | 年月變更回呼 |
+| minDate | `{ year: number; month: number }` | `{ year: 2020, month: 1 }` | 可選最早年月 |
+| maxDate | `{ year: number; month: number }` | `當月` | 可選最晚年月 |
+| disabled | `boolean` | `false` | 禁用狀態 |
+
+## Layout
+
+```
+┌──────────────────────────────────┐
+│ [<]   2026 年 4 月    [>]        │
+└──────────────────────────────────┘
+
+點擊中間文字展開 Popover：
+┌──────────────────────────────────┐
+│ [<]  2026  [>]                   │
+│                                  │
+│  1月   2月   3月   4月           │
+│  5月   6月   7月   8月           │
+│  9月  10月  11月  12月           │
+└──────────────────────────────────┘
+```
+
+## 外觀規格
+
+| 部位 | 樣式 |
+|------|------|
+| 容器 | `flex items-center gap-2` |
+| 前/後按鈕 | `Button variant="outline" size="icon" className="h-8 w-8"` |
+| 年月顯示按鈕 | `Button variant="ghost" className="min-w-[140px] text-sm font-medium"` |
+| Popover 容器 | `w-[280px] p-4` |
+| 年份切換 | `flex items-center justify-between mb-3`，年份文字 `text-sm font-semibold` |
+| 月份格 | `grid grid-cols-4 gap-2` |
+| 月份按鈕 | `Button variant="ghost" size="sm" className="h-9"`，選中時 `variant="default"` |
+| 禁用月份 | `opacity-50 cursor-not-allowed` |
+
+## States
+
+| State | 外觀變化 |
+|-------|---------|
+| default | 顯示當前年月文字，左右箭頭可用 |
+| hover（箭頭） | 箭頭按鈕 `bg-accent` |
+| disabled（箭頭） | 達到 min/max 時 `opacity-50 cursor-not-allowed` |
+| popover-open | 中間按鈕高亮，顯示月份選擇面板 |
+| selected-month | 當前月份以 `bg-primary text-primary-foreground` 標示 |
+
+## 範例程式碼
+
+```tsx
+"use client";
+
+import { useState } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+
+interface MonthPickerProps {
+  year: number;
+  month: number;
+  onChange: (year: number, month: number) => void;
+  minDate?: { year: number; month: number };
+  maxDate?: { year: number; month: number };
+  disabled?: boolean;
+}
+
+const MONTHS = [
+  "1月", "2月", "3月", "4月",
+  "5月", "6月", "7月", "8月",
+  "9月", "10月", "11月", "12月",
+];
+
+export function MonthPicker({
+  year,
+  month,
+  onChange,
+  minDate = { year: 2020, month: 1 },
+  maxDate,
+  disabled = false,
+}: MonthPickerProps) {
+  const [open, setOpen] = useState(false);
+  const [pickerYear, setPickerYear] = useState(year);
+
+  const now = new Date();
+  const max = maxDate ?? { year: now.getFullYear(), month: now.getMonth() + 1 };
+
+  const canPrev =
+    year > minDate.year || (year === minDate.year && month > minDate.month);
+  const canNext =
+    year < max.year || (year === max.year && month < max.month);
+
+  function goPrev() {
+    if (!canPrev) return;
+    if (month === 1) {
+      onChange(year - 1, 12);
+    } else {
+      onChange(year, month - 1);
+    }
+  }
+
+  function goNext() {
+    if (!canNext) return;
+    if (month === 12) {
+      onChange(year + 1, 1);
+    } else {
+      onChange(year, month + 1);
+    }
+  }
+
+  function isMonthDisabled(m: number): boolean {
+    if (pickerYear < minDate.year) return true;
+    if (pickerYear === minDate.year && m < minDate.month) return true;
+    if (pickerYear > max.year) return true;
+    if (pickerYear === max.year && m > max.month) return true;
+    return false;
+  }
+
+  function selectMonth(m: number) {
+    onChange(pickerYear, m);
+    setOpen(false);
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <Button
+        variant="outline"
+        size="icon"
+        className="h-8 w-8"
+        onClick={goPrev}
+        disabled={disabled || !canPrev}
+        aria-label="上個月"
+      >
+        <ChevronLeft className="h-4 w-4" />
+      </Button>
+
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            variant="ghost"
+            className="min-w-[140px] text-sm font-medium"
+            disabled={disabled}
+            aria-label={`${year} 年 ${month} 月，點擊選擇月份`}
+          >
+            {year} 年 {month} 月
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-[280px] p-4" align="center">
+          {/* 年份切換 */}
+          <div className="mb-3 flex items-center justify-between">
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7"
+              onClick={() => setPickerYear((y) => y - 1)}
+              disabled={pickerYear <= minDate.year}
+              aria-label="上一年"
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </Button>
+            <span className="text-sm font-semibold">{pickerYear}</span>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7"
+              onClick={() => setPickerYear((y) => y + 1)}
+              disabled={pickerYear >= max.year}
+              aria-label="下一年"
+            >
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          </div>
+
+          {/* 月份格 */}
+          <div className="grid grid-cols-4 gap-2">
+            {MONTHS.map((label, i) => {
+              const m = i + 1;
+              const isSelected = pickerYear === year && m === month;
+              const isDisabled = isMonthDisabled(m);
+
+              return (
+                <Button
+                  key={m}
+                  variant={isSelected ? "default" : "ghost"}
+                  size="sm"
+                  className="h-9"
+                  disabled={isDisabled}
+                  onClick={() => selectMonth(m)}
+                  aria-label={`${pickerYear} 年 ${label}`}
+                  aria-pressed={isSelected}
+                >
+                  {label}
+                </Button>
+              );
+            })}
+          </div>
+        </PopoverContent>
+      </Popover>
+
+      <Button
+        variant="outline"
+        size="icon"
+        className="h-8 w-8"
+        onClick={goNext}
+        disabled={disabled || !canNext}
+        aria-label="下個月"
+      >
+        <ChevronRight className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+}
+```
+
+## 使用範例
+
+```tsx
+// 行事曆頁面
+const [year, setYear] = useState(2026);
+const [month, setMonth] = useState(4);
+
+<MonthPicker
+  year={year}
+  month={month}
+  onChange={(y, m) => {
+    setYear(y);
+    setMonth(m);
+  }}
+/>
+
+// 報表頁面（限制只能看到當月以前）
+<MonthPicker
+  year={year}
+  month={month}
+  onChange={(y, m) => {
+    setYear(y);
+    setMonth(m);
+  }}
+  maxDate={{ year: 2026, month: 4 }}
+/>
+```
+
+## Accessibility
+
+- 前/後箭頭按鈕有 `aria-label`（"上個月"、"下個月"）
+- 年月顯示按鈕有 `aria-label` 提示可展開選擇
+- Popover 面板中的年切換按鈕有 `aria-label`
+- 月份按鈕使用 `aria-pressed` 標示選中狀態
+- 禁用月份有 `disabled` 屬性
+- 完整支援 keyboard navigation（Tab、Enter、Escape）
+
+## 使用的 shadcn/ui 元件
+
+- `Button`
+- `Popover`（PopoverTrigger, PopoverContent）

--- a/design/components/report-table.md
+++ b/design/components/report-table.md
@@ -1,0 +1,414 @@
+# ReportTable
+
+## 用途
+
+報表專用表格，擴展自 Sprint 1 的 DataTable，增加匯出功能按鈕列、摘要行（合計/平均）、條件格式化（數值色彩標示）。用於團隊報表和公司報表的成員/部門出勤明細。
+
+## 與 DataTable 的差異
+
+| 項目 | DataTable（Sprint 1） | ReportTable（Sprint 3） |
+|------|---------------------|------------------------|
+| 用途 | 通用列表 | 報表明細 |
+| 匯出 | 無 | 支援 CSV/XLSX |
+| 摘要行 | 無 | Footer 顯示合計/平均 |
+| 條件格式 | 無 | 數值依閾值變色 |
+| 列操作 | 有（DropdownMenu） | 無（唯讀） |
+
+## Props
+
+| Prop | Type | Default | 說明 |
+|------|------|---------|------|
+| columns | `ColumnDef<T>[]` | - | 欄位定義 |
+| data | `T[]` | - | 資料陣列 |
+| title | `string` | - | 表格標題 |
+| description | `string` | - | 表格說明（選填） |
+| searchKey | `string` | - | 搜尋欄位 key |
+| searchPlaceholder | `string` | `"搜尋..."` | 搜尋框 placeholder |
+| pageSize | `number` | `20` | 每頁筆數 |
+| isLoading | `boolean` | `false` | 載入中狀態 |
+| showExport | `boolean` | `true` | 是否顯示匯出按鈕 |
+| onExport | `(format: 'csv' \| 'xlsx') => void` | - | 匯出回呼 |
+| exportLoading | `boolean` | `false` | 匯出中狀態 |
+| summaryRow | `Record<string, string \| number>` | - | 摘要行資料（選填） |
+| emptyMessage | `string` | `"沒有資料"` | 無資料提示 |
+
+## Layout
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ 團隊出勤報表                                            │
+│ 2026 年 4 月 — 工程部                                   │
+│                                                         │
+│ ┌─ Toolbar ───────────────────────────────────────────┐ │
+│ │ [搜尋員工...]                   [匯出 v]           │ │
+│ └─────────────────────────────────────────────────────┘ │
+│                                                         │
+│ ┌─ Table ─────────────────────────────────────────────┐ │
+│ │ 員工編號 ^ │ 姓名   │ 出勤天數 │ 遲到 │ 請假 │ 出勤率│ │
+│ ├────────────┼────────┼─────────┼──────┼──────┼───────│ │
+│ │ EMP001     │ 王小明 │ 20      │  2   │  2   │ 90.9% │ │
+│ │ EMP002     │ 李小華 │ 22      │  0   │  0   │100.0% │ │
+│ │ EMP003     │ 張美玲 │ 18      │  1   │  4   │ 81.8% │ │
+│ ├────────────┼────────┼─────────┼──────┼──────┼───────│ │
+│ │ 合計/平均  │ 3 人   │ avg 20  │  3   │  6   │ 90.9% │ │
+│ └─────────────────────────────────────────────────────┘ │
+│                                                         │
+│ 共 3 筆資料                               第 1 / 1 頁   │
+└─────────────────────────────────────────────────────────┘
+```
+
+## 外觀規格
+
+| 部位 | 樣式 |
+|------|------|
+| 容器 | `rounded-lg border bg-card` |
+| 標題區 | `px-6 pt-6 pb-2`，標題 `text-lg font-semibold`，說明 `text-sm text-muted-foreground` |
+| Toolbar | `flex items-center justify-between gap-4 px-6 py-3 border-b` |
+| 搜尋框 | `max-w-sm`，同 DataTable |
+| 匯出按鈕 | `DropdownMenu`，trigger 為 `Button variant="outline" size="sm"` |
+| 匯出選項 | CSV（FileText icon）、XLSX（FileSpreadsheet icon） |
+| 表格 | 同 DataTable 外觀 |
+| 摘要行（Footer） | `bg-muted/50 font-medium border-t-2` |
+| 條件格式 — success | `text-[hsl(var(--success))] font-medium`（出勤率 >= 95%） |
+| 條件格式 — warning | `text-[hsl(var(--warning))] font-medium`（出勤率 90-95%） |
+| 條件格式 — danger | `text-destructive font-medium`（出勤率 < 90%） |
+| 數值欄位 | `text-right font-mono text-sm` |
+
+## 條件格式化規則
+
+| 指標 | Success | Warning | Danger |
+|------|---------|---------|--------|
+| 出勤率 | >= 95% | 90-95% | < 90% |
+| 遲到天數 | 0 | 1-3 | > 3 |
+| 缺席天數 | 0 | - | > 0 |
+
+## 範例程式碼
+
+### ReportTable 元件
+
+```tsx
+"use client";
+
+import { useState } from "react";
+import {
+  ColumnDef, SortingState, ColumnFiltersState, flexRender,
+  getCoreRowModel, getFilteredRowModel, getPaginationRowModel,
+  getSortedRowModel, useReactTable,
+} from "@tanstack/react-table";
+import {
+  Table, TableBody, TableCell, TableFooter,
+  TableHead, TableHeader, TableRow,
+} from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  DropdownMenu, DropdownMenuContent,
+  DropdownMenuItem, DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Search, Download, FileSpreadsheet, FileText, Loader2,
+  ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight,
+} from "lucide-react";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface ReportTableProps<TData, TValue> {
+  columns: ColumnDef<TData, TValue>[];
+  data: TData[];
+  title?: string;
+  description?: string;
+  searchKey?: string;
+  searchPlaceholder?: string;
+  pageSize?: number;
+  isLoading?: boolean;
+  showExport?: boolean;
+  onExport?: (format: "csv" | "xlsx") => void;
+  exportLoading?: boolean;
+  summaryRow?: Record<string, string | number>;
+  emptyMessage?: string;
+}
+
+export function ReportTable<TData, TValue>({
+  columns, data, title, description,
+  searchKey, searchPlaceholder = "搜尋...",
+  pageSize = 20, isLoading = false,
+  showExport = true, onExport, exportLoading = false,
+  summaryRow, emptyMessage = "沒有資料",
+}: ReportTableProps<TData, TValue>) {
+  const [sorting, setSorting] = useState<SortingState>([]);
+  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+
+  const table = useReactTable({
+    data, columns,
+    getCoreRowModel: getCoreRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    onSortingChange: setSorting,
+    onColumnFiltersChange: setColumnFilters,
+    state: { sorting, columnFilters },
+    initialState: { pagination: { pageSize } },
+  });
+
+  return (
+    <div className="rounded-lg border bg-card">
+      {/* 標題區 */}
+      {(title || description) && (
+        <div className="px-6 pt-6 pb-2">
+          {title && <h3 className="text-lg font-semibold">{title}</h3>}
+          {description && <p className="mt-1 text-sm text-muted-foreground">{description}</p>}
+        </div>
+      )}
+
+      {/* Toolbar */}
+      <div className="flex items-center justify-between gap-4 border-b px-6 py-3">
+        {searchKey ? (
+          <div className="relative max-w-sm">
+            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              placeholder={searchPlaceholder}
+              value={(table.getColumn(searchKey)?.getFilterValue() as string) ?? ""}
+              onChange={(e) => table.getColumn(searchKey)?.setFilterValue(e.target.value)}
+              className="pl-9"
+            />
+          </div>
+        ) : <div />}
+
+        {showExport && onExport && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline" size="sm" disabled={exportLoading}>
+                {exportLoading ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : (
+                  <Download className="mr-2 h-4 w-4" />
+                )}
+                匯出
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem onClick={() => onExport("csv")}>
+                <FileText className="mr-2 h-4 w-4" />
+                匯出 CSV
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => onExport("xlsx")}>
+                <FileSpreadsheet className="mr-2 h-4 w-4" />
+                匯出 XLSX
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+      </div>
+
+      {/* 表格 */}
+      <div className="overflow-x-auto">
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <TableHead key={header.id} className="bg-muted/50">
+                    {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
+                  </TableHead>
+                ))}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {isLoading ? (
+              Array.from({ length: 5 }).map((_, i) => (
+                <TableRow key={i}>
+                  {columns.map((_, j) => (
+                    <TableCell key={j}><Skeleton className="h-5 w-full" /></TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : table.getRowModel().rows?.length ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow key={row.id}>
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id}>
+                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell colSpan={columns.length} className="h-24 text-center text-muted-foreground">
+                  {emptyMessage}
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+          {summaryRow && (
+            <TableFooter>
+              <TableRow className="bg-muted/50 font-medium border-t-2">
+                {table.getAllColumns().map((col) => (
+                  <TableCell key={col.id}>{summaryRow[col.id] ?? ""}</TableCell>
+                ))}
+              </TableRow>
+            </TableFooter>
+          )}
+        </Table>
+      </div>
+
+      {/* 分頁 */}
+      <div className="flex items-center justify-between border-t px-6 py-3">
+        <p className="text-sm text-muted-foreground">
+          共 {table.getFilteredRowModel().rows.length} 筆資料
+        </p>
+        <div className="flex items-center gap-1">
+          <Button variant="outline" size="icon" className="h-8 w-8"
+            onClick={() => table.setPageIndex(0)} disabled={!table.getCanPreviousPage()}>
+            <ChevronsLeft className="h-4 w-4" />
+          </Button>
+          <Button variant="outline" size="icon" className="h-8 w-8"
+            onClick={() => table.previousPage()} disabled={!table.getCanPreviousPage()}>
+            <ChevronLeft className="h-4 w-4" />
+          </Button>
+          <span className="px-2 text-sm text-muted-foreground">
+            第 {table.getState().pagination.pageIndex + 1} / {table.getPageCount()} 頁
+          </span>
+          <Button variant="outline" size="icon" className="h-8 w-8"
+            onClick={() => table.nextPage()} disabled={!table.getCanNextPage()}>
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+          <Button variant="outline" size="icon" className="h-8 w-8"
+            onClick={() => table.setPageIndex(table.getPageCount() - 1)} disabled={!table.getCanNextPage()}>
+            <ChevronsRight className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+### 團隊報表欄位定義範例
+
+```tsx
+import { ColumnDef } from "@tanstack/react-table";
+import { SortableHeader } from "@/components/sortable-header";
+import { cn } from "@/lib/utils";
+
+interface TeamMemberReport {
+  employee_id: string;
+  name: string;
+  present_days: number;
+  absent_days: number;
+  late_days: number;
+  early_leave_days: number;
+  leave_days: number;
+  overtime_hours: number;
+  attendance_rate: number;
+}
+
+export const teamReportColumns: ColumnDef<TeamMemberReport>[] = [
+  {
+    accessorKey: "employee_id",
+    header: "員工編號",
+    cell: ({ row }) => (
+      <span className="font-mono text-sm">{row.getValue("employee_id")}</span>
+    ),
+  },
+  {
+    accessorKey: "name",
+    header: ({ column }) => <SortableHeader column={column} title="姓名" />,
+  },
+  {
+    accessorKey: "present_days",
+    header: ({ column }) => <SortableHeader column={column} title="出勤天數" />,
+    cell: ({ row }) => (
+      <span className="text-right font-mono text-sm">{row.getValue("present_days")}</span>
+    ),
+  },
+  {
+    accessorKey: "late_days",
+    header: ({ column }) => <SortableHeader column={column} title="遲到" />,
+    cell: ({ row }) => {
+      const value = row.getValue("late_days") as number;
+      return (
+        <span className={cn(
+          "text-right font-mono text-sm",
+          value > 3 && "text-destructive font-medium",
+          value > 0 && value <= 3 && "text-[hsl(var(--warning))] font-medium"
+        )}>
+          {value}
+        </span>
+      );
+    },
+  },
+  {
+    accessorKey: "leave_days",
+    header: "請假",
+    cell: ({ row }) => (
+      <span className="text-right font-mono text-sm">{row.getValue("leave_days")}</span>
+    ),
+  },
+  {
+    accessorKey: "overtime_hours",
+    header: "加班(h)",
+    cell: ({ row }) => (
+      <span className="text-right font-mono text-sm">{row.getValue("overtime_hours")}</span>
+    ),
+  },
+  {
+    accessorKey: "attendance_rate",
+    header: ({ column }) => <SortableHeader column={column} title="出勤率" />,
+    cell: ({ row }) => {
+      const rate = row.getValue("attendance_rate") as number;
+      return (
+        <span className={cn(
+          "text-right font-mono text-sm",
+          rate >= 95 && "text-[hsl(var(--success))] font-medium",
+          rate < 90 && "text-destructive font-medium",
+          rate >= 90 && rate < 95 && "text-[hsl(var(--warning))] font-medium"
+        )}>
+          {rate.toFixed(1)}%
+        </span>
+      );
+    },
+  },
+];
+```
+
+## 使用範例
+
+```tsx
+<ReportTable
+  title="團隊出勤明細"
+  description="2026 年 4 月 — 工程部"
+  columns={teamReportColumns}
+  data={teamMembers}
+  searchKey="name"
+  searchPlaceholder="搜尋員工..."
+  onExport={(format) => exportReport({ scope: "team", format, year: 2026, month: 4 })}
+  summaryRow={{
+    employee_id: "合計/平均",
+    name: `${teamMembers.length} 人`,
+    present_days: Math.round(avg("present_days")),
+    late_days: sum("late_days"),
+    leave_days: sum("leave_days"),
+    overtime_hours: sum("overtime_hours"),
+    attendance_rate: `${avg("attendance_rate").toFixed(1)}%`,
+  }}
+/>
+```
+
+## Accessibility
+
+- 同 DataTable 的 Accessibility 規範
+- 匯出按鈕 DropdownMenu 支援 keyboard（Enter 開啟、方向鍵選擇、Escape 關閉）
+- 條件格式化不僅依賴色彩：搭配 font-medium 增加視覺粗細差異
+- 摘要行使用 `<tfoot>` 語意元素
+- 排序按鈕有 `aria-sort` 屬性
+- Loading 狀態使用 `aria-busy="true"`
+- 匯出中顯示 loading spinner，按鈕 disabled
+
+## 使用的 shadcn/ui 元件
+
+- `Table`（含 TableHeader, TableBody, TableFooter, TableRow, TableHead, TableCell）
+- `Button`
+- `Input`
+- `DropdownMenu`
+- `Skeleton`

--- a/design/components/stats-card.md
+++ b/design/components/stats-card.md
@@ -1,0 +1,317 @@
+# StatsCard
+
+## 用途
+
+報表統計卡片，用於出勤報表頁面顯示關鍵指標。相較於 Sprint 1 的 `CardStats`（Dashboard 用），StatsCard 增加了環形進度、大數字強調、及可選的迷你圖表。用於個人/團隊/公司報表頁面的摘要區。
+
+## 與 CardStats 的差異
+
+| 項目 | CardStats（Sprint 1） | StatsCard（Sprint 3） |
+|------|---------------------|---------------------|
+| 用途 | Dashboard 快覽 | 報表頁深度指標 |
+| 主數字 | `text-3xl` | `text-4xl`（Display） |
+| 進度環 | 無 | 可選（用於百分比指標） |
+| 副標題 | 描述文字 | 子指標列表 |
+| 趨勢 | 簡單 +/- 數字 | 與上月比較百分比 |
+
+## Props
+
+| Prop | Type | Default | 說明 |
+|------|------|---------|------|
+| title | `string` | - | 卡片標題 |
+| value | `string \| number` | - | 主要數值 |
+| unit | `string` | - | 數值單位（如 "%"、"天"、"小時"） |
+| icon | `LucideIcon` | - | 圖示 |
+| variant | `'default' \| 'success' \| 'warning' \| 'danger'` | `'default'` | 色彩變體 |
+| progress | `number` | - | 環形進度值 0-100（選填） |
+| comparison | `{ value: number; label: string }` | - | 與上期比較（選填） |
+| subItems | `{ label: string; value: string \| number }[]` | - | 子指標列表（選填） |
+
+## Variants
+
+| Variant | Icon 色 | 進度環色 | 使用場景 |
+|---------|--------|---------|---------|
+| default | `text-primary` | `stroke-primary` | 一般指標 |
+| success | `text-[hsl(var(--success))]` | `stroke-[hsl(var(--success))]` | 出勤率高 |
+| warning | `text-[hsl(var(--warning))]` | `stroke-[hsl(var(--warning))]` | 需注意 |
+| danger | `text-destructive` | `stroke-destructive` | 異常值 |
+
+## Layout
+
+```
+┌─────────────────────────────────────────┐
+│  [Icon]  出勤率                  [環形] │
+│                                  95.5%  │
+│  95.5%                                  │
+│  ~~~~~~~~                               │
+│  +2.3% 較上月                           │
+│  ─────────────────                      │
+│  出勤天數: 20    遲到: 2                │
+│  請假天數: 2     加班: 8h               │
+└─────────────────────────────────────────┘
+```
+
+### 無進度環版本
+
+```
+┌─────────────────────────────────┐
+│  [Icon]  遲到次數               │
+│                                 │
+│  5 次                           │
+│  ~~~~~~~~                       │
+│  -2 較上月                      │
+└─────────────────────────────────┘
+```
+
+## 外觀規格
+
+| 部位 | 樣式 |
+|------|------|
+| 容器 | `rounded-lg border bg-card p-6 shadow-sm` |
+| Header | `flex items-center justify-between mb-4` |
+| Title | `text-sm font-medium text-muted-foreground` |
+| Icon | `h-5 w-5`，顏色依 variant |
+| 主數字 | `text-4xl font-bold tracking-tight` |
+| 單位 | `text-lg font-medium text-muted-foreground ml-1` |
+| 比較 — 正值 | `text-xs font-medium text-[hsl(var(--success))]`，`TrendingUp icon` |
+| 比較 — 負值 | `text-xs font-medium text-destructive`，`TrendingDown icon` |
+| 比較 label | `text-xs text-muted-foreground` |
+| 分隔線 | `border-t mt-3 pt-3` |
+| 子指標 | `grid grid-cols-2 gap-2 text-sm` |
+| 子指標 label | `text-muted-foreground` |
+| 子指標 value | `font-medium text-right` |
+| 進度環 | SVG 圓環 `w-16 h-16`，底色 `stroke-muted`，進度色依 variant |
+
+## 範例程式碼
+
+```tsx
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import { LucideIcon, TrendingUp, TrendingDown } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface StatsCardProps {
+  title: string;
+  value: string | number;
+  unit?: string;
+  icon: LucideIcon;
+  variant?: "default" | "success" | "warning" | "danger";
+  progress?: number;
+  comparison?: { value: number; label: string };
+  subItems?: { label: string; value: string | number }[];
+}
+
+const variantStyles = {
+  default: { icon: "text-primary", ring: "stroke-primary" },
+  success: { icon: "text-[hsl(var(--success))]", ring: "stroke-[hsl(var(--success))]" },
+  warning: { icon: "text-[hsl(var(--warning))]", ring: "stroke-[hsl(var(--warning))]" },
+  danger: { icon: "text-destructive", ring: "stroke-destructive" },
+};
+
+// 環形進度元件
+function ProgressRing({
+  value,
+  size = 64,
+  strokeWidth = 6,
+  className,
+}: {
+  value: number;
+  size?: number;
+  strokeWidth?: number;
+  className?: string;
+}) {
+  const radius = (size - strokeWidth) / 2;
+  const circumference = radius * 2 * Math.PI;
+  const offset = circumference - (value / 100) * circumference;
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      className="rotate-[-90deg]"
+      role="img"
+      aria-label={`${value}%`}
+    >
+      {/* 背景環 */}
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        fill="none"
+        className="stroke-muted"
+        strokeWidth={strokeWidth}
+      />
+      {/* 進度環 */}
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        fill="none"
+        className={cn("transition-all duration-500", className)}
+        strokeWidth={strokeWidth}
+        strokeLinecap="round"
+        strokeDasharray={circumference}
+        strokeDashoffset={offset}
+      />
+    </svg>
+  );
+}
+
+export function StatsCard({
+  title,
+  value,
+  unit,
+  icon: Icon,
+  variant = "default",
+  progress,
+  comparison,
+  subItems,
+}: StatsCardProps) {
+  const styles = variantStyles[variant];
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between pb-2">
+        <div className="flex items-center gap-2">
+          <Icon className={cn("h-5 w-5", styles.icon)} />
+          <CardTitle className="text-sm font-medium text-muted-foreground">
+            {title}
+          </CardTitle>
+        </div>
+        {progress !== undefined && (
+          <div className="relative flex items-center justify-center">
+            <ProgressRing value={progress} className={styles.ring} />
+            <span className="absolute text-xs font-semibold">
+              {Math.round(progress)}%
+            </span>
+          </div>
+        )}
+      </CardHeader>
+      <CardContent>
+        {/* 主數字 */}
+        <div className="flex items-baseline">
+          <span className="text-4xl font-bold tracking-tight">{value}</span>
+          {unit && (
+            <span className="ml-1 text-lg font-medium text-muted-foreground">
+              {unit}
+            </span>
+          )}
+        </div>
+
+        {/* 比較 */}
+        {comparison && (
+          <div className="mt-1 flex items-center gap-1">
+            <span
+              className={cn(
+                "inline-flex items-center gap-0.5 text-xs font-medium",
+                comparison.value >= 0
+                  ? "text-[hsl(var(--success))]"
+                  : "text-destructive"
+              )}
+            >
+              {comparison.value >= 0 ? (
+                <TrendingUp className="h-3 w-3" />
+              ) : (
+                <TrendingDown className="h-3 w-3" />
+              )}
+              {comparison.value >= 0 ? "+" : ""}
+              {comparison.value}%
+            </span>
+            <span className="text-xs text-muted-foreground">
+              {comparison.label}
+            </span>
+          </div>
+        )}
+
+        {/* 子指標 */}
+        {subItems && subItems.length > 0 && (
+          <>
+            <Separator className="my-3" />
+            <div className="grid grid-cols-2 gap-x-4 gap-y-1">
+              {subItems.map((item) => (
+                <div key={item.label} className="flex items-center justify-between text-sm">
+                  <span className="text-muted-foreground">{item.label}</span>
+                  <span className="font-medium">{item.value}</span>
+                </div>
+              ))}
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+```
+
+## 使用範例
+
+```tsx
+import {
+  CalendarCheck,
+  Clock,
+  AlertTriangle,
+  TrendingUp,
+  Timer,
+} from "lucide-react";
+
+// 個人報表 — 出勤率卡片（含進度環）
+<StatsCard
+  title="出勤率"
+  value="95.5"
+  unit="%"
+  icon={CalendarCheck}
+  variant="success"
+  progress={95.5}
+  comparison={{ value: 2.3, label: "較上月" }}
+  subItems={[
+    { label: "出勤天數", value: 20 },
+    { label: "工作日", value: 22 },
+  ]}
+/>
+
+// 個人報表 — 遲到卡片
+<StatsCard
+  title="遲到次數"
+  value={2}
+  unit="次"
+  icon={AlertTriangle}
+  variant="warning"
+  comparison={{ value: -1, label: "較上月" }}
+/>
+
+// 團隊報表 — 平均出勤率
+<StatsCard
+  title="團隊平均出勤率"
+  value="94.2"
+  unit="%"
+  icon={TrendingUp}
+  variant="success"
+  progress={94.2}
+  subItems={[
+    { label: "總人數", value: 10 },
+    { label: "遲到人次", value: 5 },
+    { label: "請假天數", value: 12 },
+    { label: "加班時數", value: "24h" },
+  ]}
+/>
+
+// 報表摘要區 Layout
+<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+  <StatsCard ... />
+  <StatsCard ... />
+  <StatsCard ... />
+  <StatsCard ... />
+</div>
+```
+
+## Accessibility
+
+- 進度環使用 `role="img"` + `aria-label` 提供百分比文字
+- 趨勢 icon 為裝飾性（lucide-react 預設 `aria-hidden="true"`）
+- 文字色彩對比度符合 WCAG 2.1 AA
+- Card 語意結構清晰（CardHeader + CardContent）
+
+## 使用的 shadcn/ui 元件
+
+- `Card`（CardHeader, CardTitle, CardContent）
+- `Separator`

--- a/design/components/team-calendar-grid.md
+++ b/design/components/team-calendar-grid.md
@@ -1,0 +1,341 @@
+# TeamCalendarGrid
+
+## 用途
+
+團隊行事曆元件，以「成員 x 日期」表格呈現整個團隊的月出勤狀況。行為成員名稱，列為每日狀態，使用色彩方塊標示。適用於主管和 Admin 查看團隊出勤總覽。
+
+## Props
+
+| Prop | Type | Default | 說明 |
+|------|------|---------|------|
+| year | `number` | - | 年份 |
+| month | `number` | - | 月份（1-12） |
+| department | `{ id: string; name: string }` | - | 部門資訊 |
+| members | `TeamMember[]` | - | 團隊成員出勤資料（來自 API） |
+| onMemberClick | `(member: TeamMember) => void` | - | 成員名點擊回呼 |
+| onCellClick | `(member: TeamMember, date: string) => void` | - | 日格點擊回呼 |
+| isLoading | `boolean` | `false` | 載入中狀態 |
+
+## 子型別
+
+```ts
+interface TeamMember {
+  user: {
+    id: string;
+    name: string;
+    employee_id: string;
+  };
+  days: TeamDay[];
+}
+
+interface TeamDay {
+  date: string;        // "2026-04-01"
+  status: TeamDayStatus;
+  leave_type: string | null; // 請假時的假別
+}
+
+type TeamDayStatus =
+  | "present"      // 正常出勤
+  | "late"         // 遲到
+  | "early_leave"  // 早退
+  | "leave"        // 請假
+  | "absent"       // 缺席
+  | "holiday"      // 假日
+  | "overtime";    // 加班
+```
+
+## Layout
+
+```
+┌───────────┬────┬────┬────┬────┬────┬────┬────┬─ ...
+│ 成員      │  1 │  2 │  3 │  4 │  5 │  6 │  7 │
+│           │ 三 │ 四 │ 五 │ 六 │ 日 │ 一 │ 二 │
+├───────────┼────┼────┼────┼────┼────┼────┼────┤
+│ EMP001    │ ■  │ ■  │ ■  │ -- │ -- │ ■  │ ■  │
+│ 王小明    │ 綠 │ 綠 │ 橙 │ 灰 │ 灰 │ 藍 │ 綠 │
+├───────────┼────┼────┼────┼────┼────┼────┼────┤
+│ EMP002    │ ■  │ ■  │ ■  │ -- │ -- │ ■  │ ■  │
+│ 李小華    │ 綠 │ 紅 │ 綠 │ 灰 │ 灰 │ 綠 │ 綠 │
+└───────────┴────┴────┴────┴────┴────┴────┴────┘
+                                         ← 橫向可捲動 →
+```
+
+## 外觀規格
+
+| 部位 | 樣式 |
+|------|------|
+| 外層容器 | `rounded-lg border bg-card overflow-hidden` |
+| 捲動容器 | `overflow-x-auto`（日期欄可橫向捲動） |
+| 表格 | `min-w-full` |
+| 成員欄（sticky） | `sticky left-0 z-10 bg-card min-w-[140px] px-3 py-2 border-r` |
+| 成員名 | `text-sm font-medium truncate` |
+| 員工編號 | `text-xs text-muted-foreground font-mono` |
+| 日期 Header | `text-center min-w-[40px] px-1 py-2 text-xs` |
+| 日期數字 | `font-medium` |
+| 星期文字 | `text-muted-foreground` |
+| 假日欄 Header | `bg-[hsl(var(--cal-holiday-bg))]` |
+| 狀態方塊 | `w-6 h-6 rounded mx-auto`，使用 `calendar-colors.css` token |
+| 表格行 | `border-b hover:bg-muted/30` |
+| 今日欄 | `border-x-2 border-[hsl(var(--cal-today-ring))]` |
+
+## 狀態方塊色彩對應
+
+| Status | 方塊背景色 | Tooltip |
+|--------|----------|---------|
+| present | `bg-[hsl(var(--cal-present))]` | 正常出勤 |
+| late | `bg-[hsl(var(--cal-late))]` | 遲到 |
+| early_leave | `bg-[hsl(var(--cal-early-leave))]` | 早退 |
+| leave | `bg-[hsl(var(--cal-leave))]` 或依假別色 | 請假（假別名） |
+| absent | `bg-[hsl(var(--cal-absent))]` | 缺席 |
+| holiday | 無方塊，顯示 `--` | 假日 |
+| overtime | `bg-[hsl(var(--cal-overtime))]` | 加班 |
+
+## 範例程式碼
+
+```tsx
+"use client";
+
+import { format, eachDayOfInterval, startOfMonth, endOfMonth, getDay, isToday } from "date-fns";
+import { zhTW } from "date-fns/locale";
+import { cn } from "@/lib/utils";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Skeleton } from "@/components/ui/skeleton";
+
+const statusColorMap: Record<TeamDayStatus, { bg: string; label: string }> = {
+  present: { bg: "bg-[hsl(var(--cal-present))]", label: "正常出勤" },
+  late: { bg: "bg-[hsl(var(--cal-late))]", label: "遲到" },
+  early_leave: { bg: "bg-[hsl(var(--cal-early-leave))]", label: "早退" },
+  leave: { bg: "bg-[hsl(var(--cal-leave))]", label: "請假" },
+  absent: { bg: "bg-[hsl(var(--cal-absent))]", label: "缺席" },
+  holiday: { bg: "", label: "假日" },
+  overtime: { bg: "bg-[hsl(var(--cal-overtime))]", label: "加班" },
+};
+
+// 假別色彩對應（使用 leave-colors.css）
+const leaveTypeColorMap: Record<string, string> = {
+  annual: "bg-[hsl(var(--leave-annual))]",
+  personal: "bg-[hsl(var(--leave-personal))]",
+  sick: "bg-[hsl(var(--leave-sick))]",
+  marriage: "bg-[hsl(var(--leave-marriage))]",
+  bereavement: "bg-[hsl(var(--leave-bereavement))]",
+  maternity: "bg-[hsl(var(--leave-maternity))]",
+  paternity: "bg-[hsl(var(--leave-paternity))]",
+  official: "bg-[hsl(var(--leave-official))]",
+};
+
+const leaveTypeLabels: Record<string, string> = {
+  annual: "特休",
+  personal: "事假",
+  sick: "病假",
+  marriage: "婚假",
+  bereavement: "喪假",
+  maternity: "產假",
+  paternity: "陪產假",
+  official: "公假",
+};
+
+interface TeamCalendarGridProps {
+  year: number;
+  month: number;
+  department: { id: string; name: string };
+  members: TeamMember[];
+  onMemberClick?: (member: TeamMember) => void;
+  onCellClick?: (member: TeamMember, date: string) => void;
+  isLoading?: boolean;
+}
+
+export function TeamCalendarGrid({
+  year,
+  month,
+  department,
+  members,
+  onMemberClick,
+  onCellClick,
+  isLoading = false,
+}: TeamCalendarGridProps) {
+  const firstDay = startOfMonth(new Date(year, month - 1));
+  const lastDay = endOfMonth(firstDay);
+  const allDays = eachDayOfInterval({ start: firstDay, end: lastDay });
+
+  if (isLoading) {
+    return (
+      <div className="rounded-lg border bg-card p-4">
+        <Skeleton className="mb-4 h-6 w-48" />
+        <div className="space-y-2">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <Skeleton key={i} className="h-10 w-full" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <TooltipProvider delayDuration={200}>
+      <div className="rounded-lg border bg-card overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="min-w-full border-collapse">
+            <thead>
+              <tr className="border-b">
+                {/* 成員欄 Header */}
+                <th className="sticky left-0 z-10 min-w-[140px] border-r bg-card px-3 py-2 text-left text-xs font-medium text-muted-foreground">
+                  成員 ({members.length})
+                </th>
+
+                {/* 日期欄 Header */}
+                {allDays.map((date) => {
+                  const dow = getDay(date);
+                  const isHoliday = dow === 0 || dow === 6;
+                  const today = isToday(date);
+                  return (
+                    <th
+                      key={date.toISOString()}
+                      className={cn(
+                        "min-w-[40px] px-1 py-2 text-center text-xs",
+                        isHoliday && "bg-[hsl(var(--cal-holiday-bg))]",
+                        today && "border-x-2 border-[hsl(var(--cal-today-ring))]"
+                      )}
+                    >
+                      <div className="font-medium">{date.getDate()}</div>
+                      <div className={cn(
+                        "text-muted-foreground",
+                        dow === 0 && "text-destructive",
+                        dow === 6 && "text-[hsl(var(--cal-holiday-text))]"
+                      )}>
+                        {format(date, "EEEEE", { locale: zhTW })}
+                      </div>
+                    </th>
+                  );
+                })}
+              </tr>
+            </thead>
+            <tbody>
+              {members.map((member) => {
+                const dayMap = new Map(member.days.map((d) => [d.date, d]));
+
+                return (
+                  <tr key={member.user.id} className="border-b hover:bg-muted/30">
+                    {/* 成員名 */}
+                    <td className="sticky left-0 z-10 min-w-[140px] border-r bg-card px-3 py-2">
+                      <button
+                        type="button"
+                        className="text-left hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
+                        onClick={() => onMemberClick?.(member)}
+                      >
+                        <div className="text-sm font-medium truncate">{member.user.name}</div>
+                        <div className="text-xs text-muted-foreground font-mono">
+                          {member.user.employee_id}
+                        </div>
+                      </button>
+                    </td>
+
+                    {/* 日期狀態格 */}
+                    {allDays.map((date) => {
+                      const dateStr = format(date, "yyyy-MM-dd");
+                      const dayData = dayMap.get(dateStr);
+                      const today = isToday(date);
+
+                      if (!dayData) {
+                        return (
+                          <td key={dateStr} className={cn(
+                            "px-1 py-2 text-center",
+                            today && "border-x-2 border-[hsl(var(--cal-today-ring))]"
+                          )}>
+                            <span className="text-xs text-muted-foreground">-</span>
+                          </td>
+                        );
+                      }
+
+                      const statusConfig = statusColorMap[dayData.status];
+                      const isLeave = dayData.status === "leave" && dayData.leave_type;
+                      const cellBg = isLeave
+                        ? leaveTypeColorMap[dayData.leave_type!] ?? statusConfig.bg
+                        : statusConfig.bg;
+                      const tooltipLabel = isLeave
+                        ? `${leaveTypeLabels[dayData.leave_type!] ?? dayData.leave_type}`
+                        : statusConfig.label;
+
+                      return (
+                        <td
+                          key={dateStr}
+                          className={cn(
+                            "px-1 py-2 text-center",
+                            today && "border-x-2 border-[hsl(var(--cal-today-ring))]"
+                          )}
+                        >
+                          {dayData.status === "holiday" ? (
+                            <span className="text-xs text-muted-foreground" aria-label="假日">--</span>
+                          ) : (
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <button
+                                  type="button"
+                                  className={cn(
+                                    "mx-auto h-6 w-6 rounded transition-transform hover:scale-110",
+                                    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                                    cellBg
+                                  )}
+                                  onClick={() => onCellClick?.(member, dateStr)}
+                                  aria-label={`${member.user.name} ${format(date, "M月d日")} ${tooltipLabel}`}
+                                />
+                              </TooltipTrigger>
+                              <TooltipContent>
+                                <p>{member.user.name} - {format(date, "M/d")}</p>
+                                <p className="font-medium">{tooltipLabel}</p>
+                              </TooltipContent>
+                            </Tooltip>
+                          )}
+                        </td>
+                      );
+                    })}
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+
+        {/* 圖例 */}
+        <div className="flex flex-wrap gap-3 border-t px-3 py-2">
+          {Object.entries(statusColorMap)
+            .filter(([key]) => key !== "holiday")
+            .map(([key, config]) => (
+              <div key={key} className="flex items-center gap-1.5">
+                <span className={cn("h-3 w-3 rounded", config.bg)} aria-hidden="true" />
+                <span className="text-xs text-muted-foreground">{config.label}</span>
+              </div>
+            ))}
+        </div>
+      </div>
+    </TooltipProvider>
+  );
+}
+```
+
+## 響應式行為
+
+| 斷點 | 行為 |
+|------|------|
+| >= 1280px (xl) | 完整表格，所有日期可見 |
+| 768-1279px | 成員欄 sticky，日期欄橫向捲動 |
+| < 768px | 同上，建議提示「橫向滑動查看更多」 |
+
+## Accessibility
+
+- 使用語意化 `<table>` 元素（`<thead>`, `<tbody>`, `<tr>`, `<th>`, `<td>`）
+- 成員欄 Header 和日期 Header 為 `<th>` 元素
+- 狀態方塊為 `<button>` 元素，有完整 `aria-label`（含成員名、日期、狀態）
+- Tooltip 提供色彩以外的狀態文字說明
+- 假日欄位使用 `aria-label="假日"`
+- 成員名可點擊，有 `focus-visible` ring
+- 圖例區提供色彩含義的文字對照
+
+## 使用的 shadcn/ui 元件
+
+- `Tooltip`（TooltipProvider, TooltipTrigger, TooltipContent）
+- `Skeleton`（Loading 狀態）

--- a/design/pages/company-report.md
+++ b/design/pages/company-report.md
@@ -1,0 +1,301 @@
+# 全公司報表（Admin）
+
+## 對應 Feature
+
+#22 F-005: 出席報表/統計
+
+## Layout
+
+```
+┌──────────────────────────────────────────────────┐
+│ Header: [=] 報表 > 全公司報表        [Avatar v]   │
+├────────────┬─────────────────────────────────────┤
+│ Sidebar    │ Main Content                        │
+│            │                                     │
+│ Dashboard  │ ┌── PageHeader ──────────────────┐  │
+│ 打卡       │ │ 全公司出勤報表                 │  │
+│ 打卡紀錄   │ │ 全公司月出勤統計及部門比較     │  │
+│ ─────      │ └────────────────────────────────┘  │
+│ 行事曆     │                                     │
+│ ─────      │ ┌── MonthPicker ─────────────────┐  │
+│ 報表       │ │ [<]  2026 年 4 月  [>]         │  │
+│   個人     │ └────────────────────────────────┘  │
+│   團隊     │                                     │
+│ > 全公司   │ ┌── StatsCards (grid-cols-5) ─────┐ │
+│            │ │[總員工][出勤率][遲到][請假][加班]│ │
+│            │ │ 100   94.2%  35次  80天  120h   │ │
+│            │ └────────────────────────────────┘  │
+│            │                                     │
+│            │ ┌── Charts (grid-cols-2) ─────────┐ │
+│            │ │ [部門出勤率]    [出勤分布]       │ │
+│            │ │  水平長條圖      圓餅圖          │ │
+│            │ └────────────────────────────────┘  │
+│            │                                     │
+│            │ ┌── ReportTable ──────────────────┐ │
+│            │ │ 部門出勤明細       [匯出 ▼]     │ │
+│            │ │────────────────────────────────  │ │
+│            │ │ 部門 │ 人數 │ 出勤率│ 遲到│ 請假│ │
+│            │ │ ...  │ ...  │  ... │ ... │ ... │ │
+│            │ │────────────────────────────────  │ │
+│            │ │ 全公司合計 ...                   │ │
+│            │ └────────────────────────────────┘  │
+└────────────┴─────────────────────────────────────┘
+```
+
+## 頁面規格
+
+| 項目 | 說明 |
+|------|------|
+| 路由 | `/reports/company` |
+| 認證 | 需要（admin 限定） |
+| 權限 | 非 admin 導向 403 |
+| Layout | `AppLayout` |
+| Breadcrumb | `[報表, 全公司報表]` |
+
+## API 呼叫
+
+| API | 時機 | 說明 |
+|-----|------|------|
+| `GET /api/v1/reports/company?year={y}&month={m}` | 頁面載入、月份切換 | 取得全公司報表 |
+| `GET /api/v1/reports/export?year={y}&month={m}&scope=company&format={f}` | 點擊匯出 | 下載報表檔案 |
+
+## 使用的元件
+
+| 元件 | 來源 | 用途 |
+|------|------|------|
+| AppLayout | `components/layout` | 頁面框架 |
+| PageHeader | `components/layout` | 頁面標題 |
+| MonthPicker | `components/month-picker` | 月份切換 |
+| StatsCard | `components/stats-card` | 全公司摘要統計卡片 |
+| AttendanceBarChart | `components/attendance-chart` | 部門出勤率長條圖 |
+| AttendancePieChart | `components/attendance-chart` | 全公司出勤分布圓餅圖 |
+| ReportTable | `components/report-table` | 部門出勤明細表 |
+
+## 內容區塊
+
+### 1. 統計卡片區（grid-cols-5 / 響應式 2+3）
+
+| 卡片 | Icon | 主值 | 單位 | 進度環 |
+|------|------|------|------|--------|
+| 總員工數 | `Users` | total_employees | 人 | 無 |
+| 平均出勤率 | `CalendarCheck` | avg_attendance_rate | % | 有 |
+| 遲到人次 | `AlertTriangle` | total_late_count | 次 | 無 |
+| 請假天數 | `CalendarX` | total_leave_days | 天 | 無 |
+| 加班時數 | `Timer` | total_overtime_hours | h | 無 |
+
+### 2. 圖表區（grid-cols-2）
+
+| 圖表 | 類型 | 資料 | 說明 |
+|------|------|------|------|
+| 部門出勤率比較 | 水平長條圖 | departments[].avg_attendance_rate | 各部門出勤率橫向比較 |
+| 全公司出勤分布 | Donut 圓餅圖 | 加總所有部門的各類天數 | 概覽正常/遲到/請假/缺席比例 |
+
+### 3. 部門明細表
+
+使用 `ReportTable`，欄位：
+
+| 欄位 | 來源 | 格式 |
+|------|------|------|
+| 部門名稱 | department.name | 文字 |
+| 人數 | total_members | 數字 |
+| 平均出勤率 | avg_attendance_rate | 百分比，條件格式 |
+| 遲到人次 | total_late_count | 數字，條件格式 |
+| 請假天數 | total_leave_days | 數字 |
+
+摘要行：全公司合計/平均
+
+## 範例程式碼
+
+```tsx
+"use client";
+
+import { useState } from "react";
+import { useQuery, useMutation } from "@tanstack/react-query";
+import { AppLayout } from "@/components/layout";
+import { PageHeader } from "@/components/page-header";
+import { MonthPicker } from "@/components/month-picker";
+import { StatsCard } from "@/components/stats-card";
+import { AttendancePieChart, AttendanceBarChart } from "@/components/attendance-chart";
+import { ReportTable } from "@/components/report-table";
+import { ColumnDef } from "@tanstack/react-table";
+import { SortableHeader } from "@/components/sortable-header";
+import {
+  Users, CalendarCheck, AlertTriangle, CalendarX, Timer,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { fetchCompanyReport, exportReport } from "@/lib/api/reports";
+
+interface DepartmentReport {
+  department: { id: string; name: string };
+  total_members: number;
+  avg_attendance_rate: number;
+  total_late_count: number;
+  total_leave_days: number;
+}
+
+const deptColumns: ColumnDef<DepartmentReport>[] = [
+  {
+    accessorKey: "department.name",
+    header: ({ column }) => <SortableHeader column={column} title="部門" />,
+    cell: ({ row }) => (
+      <span className="font-medium">{row.original.department.name}</span>
+    ),
+  },
+  {
+    accessorKey: "total_members",
+    header: "人數",
+    cell: ({ row }) => (
+      <span className="text-right font-mono text-sm">{row.original.total_members}</span>
+    ),
+  },
+  {
+    accessorKey: "avg_attendance_rate",
+    header: ({ column }) => <SortableHeader column={column} title="出勤率" />,
+    cell: ({ row }) => {
+      const rate = row.original.avg_attendance_rate;
+      return (
+        <span className={cn(
+          "text-right font-mono text-sm",
+          rate >= 95 && "text-[hsl(var(--success))] font-medium",
+          rate < 90 && "text-destructive font-medium",
+          rate >= 90 && rate < 95 && "text-[hsl(var(--warning))] font-medium"
+        )}>
+          {rate.toFixed(1)}%
+        </span>
+      );
+    },
+  },
+  {
+    accessorKey: "total_late_count",
+    header: ({ column }) => <SortableHeader column={column} title="遲到人次" />,
+    cell: ({ row }) => {
+      const v = row.original.total_late_count;
+      return (
+        <span className={cn(
+          "text-right font-mono text-sm",
+          v > 10 && "text-destructive font-medium",
+          v > 0 && v <= 10 && "text-[hsl(var(--warning))] font-medium"
+        )}>
+          {v}
+        </span>
+      );
+    },
+  },
+  {
+    accessorKey: "total_leave_days",
+    header: "請假天數",
+    cell: ({ row }) => (
+      <span className="text-right font-mono text-sm">{row.original.total_leave_days}</span>
+    ),
+  },
+];
+
+export default function CompanyReportPage() {
+  const now = new Date();
+  const [year, setYear] = useState(now.getFullYear());
+  const [month, setMonth] = useState(now.getMonth() + 1);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["reports", "company", year, month],
+    queryFn: () => fetchCompanyReport(year, month),
+  });
+
+  const exportMutation = useMutation({
+    mutationFn: (format: "csv" | "xlsx") =>
+      exportReport({ year, month, scope: "company", format }),
+  });
+
+  const summary = data?.company_summary;
+  const departments = data?.departments ?? [];
+
+  return (
+    <AppLayout breadcrumbs={[{ label: "報表", href: "/reports" }, { label: "全公司報表" }]}>
+      <PageHeader title="全公司出勤報表" description="全公司月出勤統計及部門比較" />
+
+      <div className="mb-6">
+        <MonthPicker year={year} month={month} onChange={(y, m) => { setYear(y); setMonth(m); }} />
+      </div>
+
+      {/* 統計卡片 */}
+      <div className="mb-6 grid gap-4 grid-cols-2 lg:grid-cols-5">
+        <StatsCard title="總員工數" value={summary?.total_employees ?? 0} unit="人" icon={Users} />
+        <StatsCard
+          title="平均出勤率"
+          value={summary?.avg_attendance_rate ?? 0}
+          unit="%"
+          icon={CalendarCheck}
+          variant={!summary ? "default" : summary.avg_attendance_rate >= 95 ? "success" : summary.avg_attendance_rate >= 90 ? "warning" : "danger"}
+          progress={summary?.avg_attendance_rate}
+        />
+        <StatsCard
+          title="遲到人次"
+          value={summary?.total_late_count ?? 0}
+          unit="次"
+          icon={AlertTriangle}
+          variant={summary?.total_late_count ? "warning" : "default"}
+        />
+        <StatsCard title="請假天數" value={summary?.total_leave_days ?? 0} unit="天" icon={CalendarX} />
+        <StatsCard title="加班時數" value={summary?.total_overtime_hours ?? 0} unit="h" icon={Timer} />
+      </div>
+
+      {/* 圖表 */}
+      <div className="mb-6 grid gap-6 lg:grid-cols-2">
+        <AttendanceBarChart
+          title="部門出勤率比較"
+          description={`${year} 年 ${month} 月`}
+          data={departments.map((d) => ({
+            name: d.department.name,
+            value: d.avg_attendance_rate,
+          }))}
+          config={{ value: { label: "出勤率", color: "hsl(var(--primary))" } }}
+          layout="vertical"
+          unit="%"
+        />
+
+        <AttendancePieChart
+          title="全公司出勤分布"
+          description={`${year} 年 ${month} 月`}
+          centerLabel="總員工"
+          centerValue={summary?.total_employees ?? 0}
+          data={[
+            { name: "late", value: summary?.total_late_count ?? 0, color: "--chart-late" },
+            { name: "leave", value: summary?.total_leave_days ?? 0, color: "--chart-leave" },
+          ].filter((d) => d.value > 0)}
+          config={{
+            late: { label: "遲到人次", color: "hsl(var(--chart-late))" },
+            leave: { label: "請假天數", color: "hsl(var(--chart-leave))" },
+          }}
+        />
+      </div>
+
+      {/* 部門明細 */}
+      <ReportTable
+        title="部門出勤明細"
+        description={`${year} 年 ${month} 月`}
+        columns={deptColumns}
+        data={departments}
+        isLoading={isLoading}
+        searchKey="department.name"
+        searchPlaceholder="搜尋部門..."
+        onExport={(format) => exportMutation.mutate(format)}
+        exportLoading={exportMutation.isPending}
+        summaryRow={summary ? {
+          "department.name": "全公司",
+          total_members: summary.total_employees,
+          avg_attendance_rate: `${summary.avg_attendance_rate}%`,
+          total_late_count: summary.total_late_count,
+          total_leave_days: summary.total_leave_days,
+        } : undefined}
+      />
+    </AppLayout>
+  );
+}
+```
+
+## 響應式行為
+
+| 斷點 | Stats Grid | Charts Grid | ReportTable |
+|------|-----------|------------|------------|
+| >= 1024px (lg) | 5 欄 | 2 欄 | 完整 |
+| 640-1023px (sm-lg) | 2 欄 | 1 欄 | 橫向可捲 |
+| < 640px | 1 欄 | 1 欄 | 橫向可捲 |

--- a/design/pages/personal-calendar.md
+++ b/design/pages/personal-calendar.md
@@ -1,0 +1,228 @@
+# 個人行事曆頁
+
+## 對應 Feature
+
+#21 F-004: 行事曆檢視
+
+## Layout
+
+```
+┌──────────────────────────────────────────────────┐
+│ Header: [=] 行事曆 > 個人行事曆     [Avatar v]   │
+├────────────┬─────────────────────────────────────┤
+│ Sidebar    │ Main Content                        │
+│            │                                     │
+│ Dashboard  │ ┌── PageHeader ──────────────────┐  │
+│ 打卡       │ │ 個人行事曆                     │  │
+│ 打卡紀錄   │ │ 查看您的月出勤、請假、加班紀錄 │  │
+│ ─────      │ └────────────────────────────────┘  │
+│ > 行事曆   │                                     │
+│   個人     │ ┌── MonthPicker ─────────────────┐  │
+│   團隊     │ │ [<]  2026 年 4 月  [>]         │  │
+│ ─────      │ └────────────────────────────────┘  │
+│ 報表       │                                     │
+│   個人     │ ┌── CalendarMonth ───────────────┐  │
+│   團隊     │ │ 日  一  二  三  四  五  六      │  │
+│   全公司   │ │ ...（整月格子視圖）...          │  │
+│            │ │                                 │  │
+│            │ │ ■正常 ■遲到 ■請假 ■缺席 ■加班  │  │
+│            │ └────────────────────────────────┘  │
+│            │                                     │
+│            │ ┌── 日期詳情 Sheet ──────────────┐  │
+│            │ │ （點擊日格後從右側滑入）        │  │
+│            │ │ 2026年4月10日 星期五            │  │
+│            │ │ 打卡: 09:05 - 18:30            │  │
+│            │ │ 狀態: [遲到]                    │  │
+│            │ │ 請假: 無                        │  │
+│            │ └────────────────────────────────┘  │
+└────────────┴─────────────────────────────────────┘
+```
+
+## 頁面規格
+
+| 項目 | 說明 |
+|------|------|
+| 路由 | `/calendar/personal` |
+| 認證 | 需要（所有角色） |
+| Layout | `AppLayout` |
+| Breadcrumb | `[行事曆, 個人行事曆]` |
+
+## API 呼叫
+
+| API | 時機 | 說明 |
+|-----|------|------|
+| `GET /api/v1/calendar/personal?year={y}&month={m}` | 頁面載入、月份切換 | 取得整月出勤資料 |
+
+## 使用的元件
+
+| 元件 | 來源 | 用途 |
+|------|------|------|
+| AppLayout | `components/layout` | 頁面框架 |
+| PageHeader | `components/layout` | 頁面標題 |
+| MonthPicker | `components/month-picker` | 月份切換 |
+| CalendarMonth | `components/calendar-month` | 月曆格子視圖 |
+| Sheet | shadcn/ui | 日格詳情抽屜 |
+| StatusBadge | `components/status-badge` | 打卡狀態標籤 |
+| LeaveTypeBadge | `components/leave-type-badge` | 假別標籤 |
+
+## 互動行為
+
+1. 頁面載入時以當前年月呼叫 API
+2. 使用 MonthPicker 切換月份，觸發重新載入
+3. 點擊日格開啟右側 Sheet 顯示詳情（打卡時間、請假紀錄、加班紀錄）
+4. Sheet 關閉時清除選中狀態
+5. 使用 `@tanstack/react-query` 快取資料，切回已瀏覽的月份不重複請求
+6. Loading 狀態：CalendarMonth 顯示 Skeleton grid
+
+## 範例程式碼
+
+```tsx
+"use client";
+
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { AppLayout } from "@/components/layout";
+import { PageHeader } from "@/components/page-header";
+import { MonthPicker } from "@/components/month-picker";
+import { CalendarMonth, CalendarDay } from "@/components/calendar-month";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { StatusBadge } from "@/components/status-badge";
+import { format } from "date-fns";
+import { zhTW } from "date-fns/locale";
+import { fetchPersonalCalendar } from "@/lib/api/calendar";
+
+export default function PersonalCalendarPage() {
+  const now = new Date();
+  const [year, setYear] = useState(now.getFullYear());
+  const [month, setMonth] = useState(now.getMonth() + 1);
+  const [selectedDay, setSelectedDay] = useState<CalendarDay | null>(null);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["calendar", "personal", year, month],
+    queryFn: () => fetchPersonalCalendar(year, month),
+  });
+
+  return (
+    <AppLayout breadcrumbs={[{ label: "行事曆", href: "/calendar" }, { label: "個人行事曆" }]}>
+      <PageHeader
+        title="個人行事曆"
+        description="查看您的月出勤、請假、加班紀錄"
+      />
+
+      {/* 月份選擇 */}
+      <div className="mb-4">
+        <MonthPicker
+          year={year}
+          month={month}
+          onChange={(y, m) => {
+            setYear(y);
+            setMonth(m);
+            setSelectedDay(null);
+          }}
+        />
+      </div>
+
+      {/* 月曆 */}
+      <CalendarMonth
+        year={year}
+        month={month}
+        days={data?.days ?? []}
+        isLoading={isLoading}
+        selectedDate={selectedDay?.date}
+        onDayClick={(day) => setSelectedDay(day)}
+      />
+
+      {/* 日格詳情 Sheet */}
+      <Sheet open={!!selectedDay} onOpenChange={(open) => !open && setSelectedDay(null)}>
+        <SheetContent>
+          {selectedDay && (
+            <>
+              <SheetHeader>
+                <SheetTitle>
+                  {format(new Date(selectedDay.date), "yyyy年M月d日 EEEE", { locale: zhTW })}
+                </SheetTitle>
+              </SheetHeader>
+
+              <div className="mt-6 space-y-6">
+                {/* 打卡紀錄 */}
+                {selectedDay.clock && (
+                  <div className="space-y-2">
+                    <h4 className="text-sm font-semibold">打卡紀錄</h4>
+                    <div className="rounded-lg border p-3 space-y-2">
+                      <div className="flex justify-between text-sm">
+                        <span className="text-muted-foreground">上班</span>
+                        <span className="font-mono">
+                          {selectedDay.clock.clock_in
+                            ? format(new Date(selectedDay.clock.clock_in), "HH:mm:ss")
+                            : "--:--:--"}
+                        </span>
+                      </div>
+                      <div className="flex justify-between text-sm">
+                        <span className="text-muted-foreground">下班</span>
+                        <span className="font-mono">
+                          {selectedDay.clock.clock_out
+                            ? format(new Date(selectedDay.clock.clock_out), "HH:mm:ss")
+                            : "--:--:--"}
+                        </span>
+                      </div>
+                      <div className="flex justify-between items-center">
+                        <span className="text-sm text-muted-foreground">狀態</span>
+                        <StatusBadge type="attendance" value={selectedDay.clock.status} />
+                      </div>
+                    </div>
+                  </div>
+                )}
+
+                {/* 請假紀錄 */}
+                {selectedDay.leaves.length > 0 && (
+                  <div className="space-y-2">
+                    <h4 className="text-sm font-semibold">請假紀錄</h4>
+                    {selectedDay.leaves.map((leave) => (
+                      <div key={leave.id} className="rounded-lg border p-3 space-y-1">
+                        <div className="flex items-center justify-between text-sm">
+                          <span>{leave.leave_type}</span>
+                          <StatusBadge type="leave" value={leave.status} />
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+
+                {/* 加班紀錄 */}
+                {selectedDay.overtime && (
+                  <div className="space-y-2">
+                    <h4 className="text-sm font-semibold">加班紀錄</h4>
+                    <div className="rounded-lg border p-3">
+                      <span className="text-sm">{selectedDay.overtime.hours} 小時</span>
+                    </div>
+                  </div>
+                )}
+
+                {/* 無資料 */}
+                {!selectedDay.clock && selectedDay.leaves.length === 0 && !selectedDay.overtime && (
+                  <p className="text-sm text-muted-foreground text-center py-8">
+                    {selectedDay.is_workday ? "當日無出勤紀錄" : "非工作日"}
+                  </p>
+                )}
+              </div>
+            </>
+          )}
+        </SheetContent>
+      </Sheet>
+    </AppLayout>
+  );
+}
+```
+
+## 響應式行為
+
+| 斷點 | CalendarMonth | Sheet |
+|------|-------------|-------|
+| >= 1024px (lg) | 日格 100px，顯示狀態文字+時間 | 右側 400px |
+| 768-1023px (md) | 日格 80px，僅顯示圓點 | 右側 320px |
+| < 768px | 日格 80px，僅顯示圓點 | 底部全寬 Sheet |

--- a/design/pages/personal-report.md
+++ b/design/pages/personal-report.md
@@ -1,0 +1,257 @@
+# 個人出勤報表
+
+## 對應 Feature
+
+#22 F-005: 出席報表/統計
+
+## Layout
+
+```
+┌──────────────────────────────────────────────────┐
+│ Header: [=] 報表 > 個人報表          [Avatar v]   │
+├────────────┬─────────────────────────────────────┤
+│ Sidebar    │ Main Content                        │
+│            │                                     │
+│ Dashboard  │ ┌── PageHeader ──────────────────┐  │
+│ 打卡       │ │ 個人出勤報表                   │  │
+│ 打卡紀錄   │ │ 查看您的月出勤統計             │  │
+│ ─────      │ └────────────────────────────────┘  │
+│ 行事曆     │                                     │
+│ ─────      │ ┌── MonthPicker ─────────────────┐  │
+│ > 報表     │ │ [<]  2026 年 4 月  [>]         │  │
+│   個人     │ └────────────────────────────────┘  │
+│   團隊     │                                     │
+│   全公司   │ ┌── StatsCards (grid-cols-4) ─────┐ │
+│            │ │ [出勤率]  [遲到]  [請假]  [加班] │ │
+│            │ │  95.5%    2次     2天     8h     │ │
+│            │ │  (環形)                          │ │
+│            │ └────────────────────────────────┘  │
+│            │                                     │
+│            │ ┌── Charts (grid-cols-2) ─────────┐ │
+│            │ │ [出勤分布]    [請假類型分布]     │ │
+│            │ │  圓餅圖        圓餅圖            │ │
+│            │ └────────────────────────────────┘  │
+│            │                                     │
+│            │ ┌── 請假明細 ────────────────────┐  │
+│            │ │ leave_type │ hours │ 說明       │  │
+│            │ │ 特休       │ 16h   │            │  │
+│            │ │ 病假       │  0h   │            │  │
+│            │ └────────────────────────────────┘  │
+└────────────┴─────────────────────────────────────┘
+```
+
+## 頁面規格
+
+| 項目 | 說明 |
+|------|------|
+| 路由 | `/reports/personal` |
+| 認證 | 需要（所有角色） |
+| Layout | `AppLayout` |
+| Breadcrumb | `[報表, 個人報表]` |
+
+## API 呼叫
+
+| API | 時機 | 說明 |
+|-----|------|------|
+| `GET /api/v1/reports/personal?year={y}&month={m}` | 頁面載入、月份切換 | 取得個人出勤統計 |
+
+## 使用的元件
+
+| 元件 | 來源 | 用途 |
+|------|------|------|
+| AppLayout | `components/layout` | 頁面框架 |
+| PageHeader | `components/layout` | 頁面標題 |
+| MonthPicker | `components/month-picker` | 月份切換 |
+| StatsCard | `components/stats-card` | 統計指標卡片 |
+| AttendancePieChart | `components/attendance-chart` | 出勤分布圓餅圖 |
+| Table | shadcn/ui | 請假明細表格 |
+
+## 內容區塊
+
+### 1. 統計卡片區（grid-cols-4）
+
+| 卡片 | Icon | 主值 | 單位 | 進度環 | variant | 子指標 |
+|------|------|------|------|--------|---------|--------|
+| 出勤率 | `CalendarCheck` | attendance_rate | % | 有 | success/warning/danger | 出勤天數, 工作日 |
+| 遲到 | `AlertTriangle` | late_days | 次 | 無 | warning（>0時） | - |
+| 請假 | `CalendarX` | leave_days | 天 | 無 | default | - |
+| 加班 | `Timer` | overtime_hours | h | 無 | default | - |
+
+### 2. 圖表區（grid-cols-2）
+
+| 圖表 | 類型 | 資料來源 | 中央標籤 |
+|------|------|---------|---------|
+| 出勤分布 | Donut Pie | summary 中的各天數 | 出勤天數/工作日 |
+| 請假類型分布 | Donut Pie | leave_summary | 總請假天數 |
+
+### 3. 請假明細表
+
+簡單表格顯示各假別使用時數，來自 `leave_summary`。
+
+## 範例程式碼
+
+```tsx
+"use client";
+
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { AppLayout } from "@/components/layout";
+import { PageHeader } from "@/components/page-header";
+import { MonthPicker } from "@/components/month-picker";
+import { StatsCard } from "@/components/stats-card";
+import { AttendancePieChart } from "@/components/attendance-chart";
+import {
+  Table, TableBody, TableCell,
+  TableHead, TableHeader, TableRow,
+} from "@/components/ui/table";
+import {
+  CalendarCheck, AlertTriangle, CalendarX, Timer,
+} from "lucide-react";
+import { fetchPersonalReport } from "@/lib/api/reports";
+
+const leaveTypeLabels: Record<string, string> = {
+  annual: "特休", personal: "事假", sick: "病假",
+  marriage: "婚假", bereavement: "喪假", maternity: "產假",
+  paternity: "陪產假", official: "公假",
+};
+
+export default function PersonalReportPage() {
+  const now = new Date();
+  const [year, setYear] = useState(now.getFullYear());
+  const [month, setMonth] = useState(now.getMonth() + 1);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["reports", "personal", year, month],
+    queryFn: () => fetchPersonalReport(year, month),
+  });
+
+  const summary = data?.summary;
+
+  // 出勤率 variant
+  const rateVariant = !summary ? "default"
+    : summary.attendance_rate >= 95 ? "success"
+    : summary.attendance_rate >= 90 ? "warning"
+    : "danger";
+
+  return (
+    <AppLayout breadcrumbs={[{ label: "報表", href: "/reports" }, { label: "個人報表" }]}>
+      <PageHeader title="個人出勤報表" description="查看您的月出勤統計" />
+
+      {/* 月份選擇 */}
+      <div className="mb-6">
+        <MonthPicker year={year} month={month} onChange={(y, m) => { setYear(y); setMonth(m); }} />
+      </div>
+
+      {/* 統計卡片 */}
+      <div className="mb-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <StatsCard
+          title="出勤率"
+          value={summary?.attendance_rate ?? 0}
+          unit="%"
+          icon={CalendarCheck}
+          variant={rateVariant}
+          progress={summary?.attendance_rate}
+          subItems={[
+            { label: "出勤天數", value: summary?.present_days ?? 0 },
+            { label: "工作日", value: summary?.workdays ?? 0 },
+          ]}
+        />
+        <StatsCard
+          title="遲到"
+          value={summary?.late_days ?? 0}
+          unit="次"
+          icon={AlertTriangle}
+          variant={summary?.late_days ? "warning" : "default"}
+        />
+        <StatsCard
+          title="請假"
+          value={summary?.leave_days ?? 0}
+          unit="天"
+          icon={CalendarX}
+        />
+        <StatsCard
+          title="加班"
+          value={summary?.overtime_hours ?? 0}
+          unit="h"
+          icon={Timer}
+        />
+      </div>
+
+      {/* 圖表 */}
+      <div className="mb-6 grid gap-6 lg:grid-cols-2">
+        <AttendancePieChart
+          title="出勤分布"
+          description={`${year} 年 ${month} 月`}
+          centerLabel="出勤天數"
+          centerValue={summary?.present_days ?? 0}
+          data={[
+            { name: "present", value: summary?.present_days ?? 0, color: "--chart-present" },
+            { name: "late", value: summary?.late_days ?? 0, color: "--chart-late" },
+            { name: "leave", value: summary?.leave_days ?? 0, color: "--chart-leave" },
+            { name: "absent", value: summary?.absent_days ?? 0, color: "--chart-absent" },
+          ].filter((d) => d.value > 0)}
+          config={{
+            present: { label: "正常出勤", color: "hsl(var(--chart-present))" },
+            late: { label: "遲到", color: "hsl(var(--chart-late))" },
+            leave: { label: "請假", color: "hsl(var(--chart-leave))" },
+            absent: { label: "缺席", color: "hsl(var(--chart-absent))" },
+          }}
+        />
+
+        <AttendancePieChart
+          title="請假類型分布"
+          description={`${year} 年 ${month} 月`}
+          centerLabel="總請假"
+          centerValue={`${summary?.leave_days ?? 0}天`}
+          data={(data?.leave_summary ?? [])
+            .filter((l) => l.hours > 0)
+            .map((l) => ({
+              name: l.leave_type,
+              value: l.hours / 8,
+              color: `--leave-${l.leave_type}`,
+            }))}
+          config={Object.fromEntries(
+            (data?.leave_summary ?? []).map((l) => [
+              l.leave_type,
+              { label: leaveTypeLabels[l.leave_type] ?? l.leave_type, color: `hsl(var(--leave-${l.leave_type}))` },
+            ])
+          )}
+        />
+      </div>
+
+      {/* 請假明細 */}
+      <div className="rounded-lg border bg-card">
+        <div className="px-6 pt-6 pb-2">
+          <h3 className="text-lg font-semibold">請假明細</h3>
+        </div>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="bg-muted/50">假別</TableHead>
+              <TableHead className="bg-muted/50 text-right">使用時數</TableHead>
+              <TableHead className="bg-muted/50 text-right">使用天數</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {(data?.leave_summary ?? []).map((item) => (
+              <TableRow key={item.leave_type}>
+                <TableCell>{leaveTypeLabels[item.leave_type] ?? item.leave_type}</TableCell>
+                <TableCell className="text-right font-mono">{item.hours}h</TableCell>
+                <TableCell className="text-right font-mono">{item.hours / 8}天</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </AppLayout>
+  );
+}
+```
+
+## 響應式行為
+
+| 斷點 | Stats Grid | Charts Grid |
+|------|-----------|------------|
+| >= 1024px (lg) | 4 欄 | 2 欄 |
+| 640-1023px (sm-lg) | 2 欄 | 1 欄 |
+| < 640px | 1 欄 | 1 欄 |

--- a/design/pages/team-calendar.md
+++ b/design/pages/team-calendar.md
@@ -1,0 +1,184 @@
+# 團隊行事曆頁
+
+## 對應 Feature
+
+#21 F-004: 行事曆檢視
+
+## Layout
+
+```
+┌──────────────────────────────────────────────────┐
+│ Header: [=] 行事曆 > 團隊行事曆     [Avatar v]   │
+├────────────┬─────────────────────────────────────┤
+│ Sidebar    │ Main Content                        │
+│            │                                     │
+│ Dashboard  │ ┌── PageHeader ──────────────────┐  │
+│ 打卡       │ │ 團隊行事曆         [部門選擇 v]│  │
+│ 打卡紀錄   │ │ 查看團隊成員的月出勤狀況       │  │
+│ ─────      │ └────────────────────────────────┘  │
+│ 行事曆     │                                     │
+│   個人     │ ┌── MonthPicker ─────────────────┐  │
+│ > 團隊     │ │ [<]  2026 年 4 月  [>]         │  │
+│ ─────      │ └────────────────────────────────┘  │
+│ 報表       │                                     │
+│            │ ┌── TeamCalendarGrid ─────────────┐ │
+│            │ │ 成員     │ 1 │ 2 │ 3 │...│30│31│ │
+│            │ │          │ 三│ 四│ 五│   │  │  │ │
+│            │ │──────────┼───┼───┼───┼   ┼──┼──│ │
+│            │ │ EMP001   │ ■ │ ■ │ ■ │...│  │  │ │
+│            │ │ 王小明   │   │   │   │   │  │  │ │
+│            │ │ EMP002   │ ■ │ ■ │ ■ │...│  │  │ │
+│            │ │ 李小華   │   │   │   │   │  │  │ │
+│            │ │──────────────────────────────── │ │
+│            │ │ ■正常 ■遲到 ■請假 ■缺席 ■加班  │ │
+│            │ └────────────────────────────────┘  │
+└────────────┴─────────────────────────────────────┘
+```
+
+## 頁面規格
+
+| 項目 | 說明 |
+|------|------|
+| 路由 | `/calendar/team` |
+| 認證 | 需要（manager, admin） |
+| 權限 | employee 會導向 403 |
+| Layout | `AppLayout` |
+| Breadcrumb | `[行事曆, 團隊行事曆]` |
+
+## API 呼叫
+
+| API | 時機 | 說明 |
+|-----|------|------|
+| `GET /api/v1/calendar/team?year={y}&month={m}&department_id={id}` | 頁面載入、月份/部門切換 | 取得團隊出勤資料 |
+| `GET /api/v1/departments` | 頁面載入（Admin 用） | 取得部門列表（部門選擇器） |
+
+## 使用的元件
+
+| 元件 | 來源 | 用途 |
+|------|------|------|
+| AppLayout | `components/layout` | 頁面框架 |
+| PageHeader | `components/layout` | 頁面標題 + 部門選擇 |
+| MonthPicker | `components/month-picker` | 月份切換 |
+| TeamCalendarGrid | `components/team-calendar-grid` | 團隊出勤表格 |
+| Select | shadcn/ui | 部門切換（Admin 限定） |
+
+## 互動行為
+
+1. 頁面載入時以當前年月呼叫 API
+2. Manager：自動帶入自己部門，無部門切換
+3. Admin：顯示部門選擇 Select，可切換查看不同部門
+4. 使用 MonthPicker 切換月份
+5. 點擊成員名稱可導向該成員的個人報表（Admin 功能）
+6. 點擊狀態方塊顯示 Tooltip 詳情
+7. 表格日期欄可橫向捲動，成員欄 sticky
+8. Loading 狀態：TeamCalendarGrid 顯示 Skeleton
+
+## 範例程式碼
+
+```tsx
+"use client";
+
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { AppLayout } from "@/components/layout";
+import { PageHeader } from "@/components/page-header";
+import { MonthPicker } from "@/components/month-picker";
+import { TeamCalendarGrid } from "@/components/team-calendar-grid";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useAuth } from "@/hooks/use-auth";
+import { fetchTeamCalendar } from "@/lib/api/calendar";
+import { fetchDepartments } from "@/lib/api/departments";
+
+export default function TeamCalendarPage() {
+  const { user } = useAuth();
+  const now = new Date();
+  const [year, setYear] = useState(now.getFullYear());
+  const [month, setMonth] = useState(now.getMonth() + 1);
+  const [departmentId, setDepartmentId] = useState<string | undefined>(
+    user.role === "admin" ? undefined : user.department_id
+  );
+
+  // Admin: 取得部門列表
+  const { data: departments } = useQuery({
+    queryKey: ["departments"],
+    queryFn: fetchDepartments,
+    enabled: user.role === "admin",
+  });
+
+  // 取得團隊行事曆
+  const { data, isLoading } = useQuery({
+    queryKey: ["calendar", "team", year, month, departmentId],
+    queryFn: () => fetchTeamCalendar(year, month, departmentId),
+    enabled: !!departmentId || user.role === "manager",
+  });
+
+  return (
+    <AppLayout breadcrumbs={[{ label: "行事曆", href: "/calendar" }, { label: "團隊行事曆" }]}>
+      <PageHeader
+        title="團隊行事曆"
+        description="查看團隊成員的月出勤狀況"
+        actions={
+          user.role === "admin" && departments ? (
+            <Select
+              value={departmentId}
+              onValueChange={setDepartmentId}
+            >
+              <SelectTrigger className="w-[200px]">
+                <SelectValue placeholder="選擇部門" />
+              </SelectTrigger>
+              <SelectContent>
+                {departments.map((dept) => (
+                  <SelectItem key={dept.id} value={dept.id}>
+                    {dept.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          ) : undefined
+        }
+      />
+
+      {/* 月份選擇 */}
+      <div className="mb-4">
+        <MonthPicker
+          year={year}
+          month={month}
+          onChange={(y, m) => {
+            setYear(y);
+            setMonth(m);
+          }}
+        />
+      </div>
+
+      {/* 團隊行事曆 */}
+      <TeamCalendarGrid
+        year={year}
+        month={month}
+        department={data?.department ?? { id: "", name: "" }}
+        members={data?.members ?? []}
+        isLoading={isLoading}
+        onMemberClick={(member) => {
+          // Admin 可查看成員個人報表
+          if (user.role === "admin") {
+            window.location.href = `/reports/personal?user_id=${member.user.id}&year=${year}&month=${month}`;
+          }
+        }}
+      />
+    </AppLayout>
+  );
+}
+```
+
+## 響應式行為
+
+| 斷點 | 行為 |
+|------|------|
+| >= 1280px (xl) | 完整表格可見 |
+| 768-1279px | 成員欄 sticky，日期欄橫向捲動 |
+| < 768px | 同上，頁面底部提示「橫向滑動查看更多日期」 |

--- a/design/pages/team-report.md
+++ b/design/pages/team-report.md
@@ -1,0 +1,224 @@
+# 團隊報表
+
+## 對應 Feature
+
+#22 F-005: 出席報表/統計
+
+## Layout
+
+```
+┌──────────────────────────────────────────────────┐
+│ Header: [=] 報表 > 團隊報表          [Avatar v]   │
+├────────────┬─────────────────────────────────────┤
+│ Sidebar    │ Main Content                        │
+│            │                                     │
+│ Dashboard  │ ┌── PageHeader ──────────────────┐  │
+│ 打卡       │ │ 團隊報表           [部門選擇 v]│  │
+│ 打卡紀錄   │ │ 查看團隊的月出勤統計           │  │
+│ ─────      │ └────────────────────────────────┘  │
+│ 行事曆     │                                     │
+│ ─────      │ ┌── MonthPicker ─────────────────┐  │
+│ 報表       │ │ [<]  2026 年 4 月  [>]         │  │
+│   個人     │ └────────────────────────────────┘  │
+│ > 團隊     │                                     │
+│   全公司   │ ┌── StatsCards (grid-cols-4) ─────┐ │
+│            │ │ [平均出勤率] [總人數] [遲到] [請假]│ │
+│            │ │   95.5%       10     5次   12天  │ │
+│            │ └────────────────────────────────┘  │
+│            │                                     │
+│            │ ┌── ReportTable ──────────────────┐ │
+│            │ │ 團隊出勤明細       [匯出 ▼]     │ │
+│            │ │ [搜尋員工...]                    │ │
+│            │ │────────────────────────────────  │ │
+│            │ │ 編號 │ 姓名 │ 出勤 │ 遲到│ 出勤率│ │
+│            │ │ ...  │ ...  │ ... │ ... │ ...  │ │
+│            │ │────────────────────────────────  │ │
+│            │ │ 合計/平均 ...                    │ │
+│            │ └────────────────────────────────┘  │
+└────────────┴─────────────────────────────────────┘
+```
+
+## 頁面規格
+
+| 項目 | 說明 |
+|------|------|
+| 路由 | `/reports/team` |
+| 認證 | 需要（manager, admin） |
+| 權限 | employee 導向 403 |
+| Layout | `AppLayout` |
+| Breadcrumb | `[報表, 團隊報表]` |
+
+## API 呼叫
+
+| API | 時機 | 說明 |
+|-----|------|------|
+| `GET /api/v1/reports/team?year={y}&month={m}&department_id={id}` | 頁面載入、月份/部門切換 | 取得團隊報表 |
+| `GET /api/v1/reports/export?year={y}&month={m}&scope=team&format={f}` | 點擊匯出 | 下載報表檔案 |
+| `GET /api/v1/departments` | 頁面載入（Admin） | 部門列表 |
+
+## 使用的元件
+
+| 元件 | 來源 | 用途 |
+|------|------|------|
+| AppLayout | `components/layout` | 頁面框架 |
+| PageHeader | `components/layout` | 頁面標題 + 部門選擇 |
+| MonthPicker | `components/month-picker` | 月份切換 |
+| StatsCard | `components/stats-card` | 團隊摘要統計卡片 |
+| ReportTable | `components/report-table` | 成員出勤明細表 |
+| Select | shadcn/ui | 部門切換（Admin） |
+
+## 內容區塊
+
+### 1. 統計卡片區
+
+| 卡片 | 主值 | 來源 | 進度環 |
+|------|------|------|--------|
+| 平均出勤率 | avg_attendance_rate | team_summary | 有 |
+| 總人數 | total_members | team_summary | 無 |
+| 遲到人次 | total_late_count | team_summary | 無 |
+| 請假天數 | total_leave_days | team_summary | 無 |
+
+### 2. 報表表格
+
+使用 `ReportTable` 搭配 `teamReportColumns` 欄位定義。
+
+欄位：員工編號、姓名、出勤天數、缺席、遲到、早退、請假、加班(h)、出勤率
+
+功能：
+- 可依姓名搜尋
+- 可依出勤率、遲到等欄位排序
+- 摘要行顯示合計/平均
+- 匯出 CSV / XLSX
+
+## 範例程式碼
+
+```tsx
+"use client";
+
+import { useState } from "react";
+import { useQuery, useMutation } from "@tanstack/react-query";
+import { AppLayout } from "@/components/layout";
+import { PageHeader } from "@/components/page-header";
+import { MonthPicker } from "@/components/month-picker";
+import { StatsCard } from "@/components/stats-card";
+import { ReportTable } from "@/components/report-table";
+import { teamReportColumns } from "@/components/columns/team-report-columns";
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from "@/components/ui/select";
+import {
+  CalendarCheck, Users, AlertTriangle, CalendarX,
+} from "lucide-react";
+import { useAuth } from "@/hooks/use-auth";
+import { fetchTeamReport, exportReport } from "@/lib/api/reports";
+import { fetchDepartments } from "@/lib/api/departments";
+
+export default function TeamReportPage() {
+  const { user } = useAuth();
+  const now = new Date();
+  const [year, setYear] = useState(now.getFullYear());
+  const [month, setMonth] = useState(now.getMonth() + 1);
+  const [departmentId, setDepartmentId] = useState<string | undefined>(
+    user.role === "admin" ? undefined : user.department_id
+  );
+
+  const { data: departments } = useQuery({
+    queryKey: ["departments"],
+    queryFn: fetchDepartments,
+    enabled: user.role === "admin",
+  });
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["reports", "team", year, month, departmentId],
+    queryFn: () => fetchTeamReport(year, month, departmentId),
+    enabled: !!departmentId || user.role === "manager",
+  });
+
+  const exportMutation = useMutation({
+    mutationFn: (format: "csv" | "xlsx") =>
+      exportReport({ year, month, scope: "team", department_id: departmentId, format }),
+  });
+
+  const summary = data?.team_summary;
+
+  return (
+    <AppLayout breadcrumbs={[{ label: "報表", href: "/reports" }, { label: "團隊報表" }]}>
+      <PageHeader
+        title="團隊報表"
+        description="查看團隊的月出勤統計"
+        actions={
+          user.role === "admin" && departments ? (
+            <Select value={departmentId} onValueChange={setDepartmentId}>
+              <SelectTrigger className="w-[200px]">
+                <SelectValue placeholder="選擇部門" />
+              </SelectTrigger>
+              <SelectContent>
+                {departments.map((dept) => (
+                  <SelectItem key={dept.id} value={dept.id}>{dept.name}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          ) : undefined
+        }
+      />
+
+      <div className="mb-6">
+        <MonthPicker year={year} month={month} onChange={(y, m) => { setYear(y); setMonth(m); }} />
+      </div>
+
+      {/* 統計卡片 */}
+      <div className="mb-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <StatsCard
+          title="平均出勤率"
+          value={summary?.avg_attendance_rate ?? 0}
+          unit="%"
+          icon={CalendarCheck}
+          variant={!summary ? "default" : summary.avg_attendance_rate >= 95 ? "success" : summary.avg_attendance_rate >= 90 ? "warning" : "danger"}
+          progress={summary?.avg_attendance_rate}
+        />
+        <StatsCard title="總人數" value={summary?.total_members ?? 0} unit="人" icon={Users} />
+        <StatsCard
+          title="遲到人次"
+          value={summary?.total_late_count ?? 0}
+          unit="次"
+          icon={AlertTriangle}
+          variant={summary?.total_late_count ? "warning" : "default"}
+        />
+        <StatsCard title="請假天數" value={summary?.total_leave_days ?? 0} unit="天" icon={CalendarX} />
+      </div>
+
+      {/* 報表表格 */}
+      <ReportTable
+        title="團隊出勤明細"
+        description={`${year} 年 ${month} 月 — ${data?.department?.name ?? ""}`}
+        columns={teamReportColumns}
+        data={data?.members ?? []}
+        isLoading={isLoading}
+        searchKey="name"
+        searchPlaceholder="搜尋員工..."
+        onExport={(format) => exportMutation.mutate(format)}
+        exportLoading={exportMutation.isPending}
+        summaryRow={summary ? {
+          employee_id: "合計/平均",
+          name: `${summary.total_members} 人`,
+          present_days: "-",
+          absent_days: "-",
+          late_days: summary.total_late_count,
+          early_leave_days: "-",
+          leave_days: summary.total_leave_days,
+          overtime_hours: "-",
+          attendance_rate: `${summary.avg_attendance_rate}%`,
+        } : undefined}
+      />
+    </AppLayout>
+  );
+}
+```
+
+## 響應式行為
+
+| 斷點 | Stats Grid | ReportTable |
+|------|-----------|------------|
+| >= 1024px (lg) | 4 欄 | 完整欄位 |
+| 640-1023px (sm-lg) | 2 欄 | 橫向可捲 |
+| < 640px | 1 欄 | 橫向可捲 |

--- a/design/tokens/calendar-colors.css
+++ b/design/tokens/calendar-colors.css
@@ -1,0 +1,114 @@
+/*
+ * Design Tokens - Calendar & Report Colors
+ * Sprint 3: 行事曆 + 報表可視化專用色彩
+ *
+ * 行事曆日格狀態色 + 圖表色階
+ * 與 colors.css / leave-colors.css 搭配使用。
+ */
+
+:root {
+  /* ========================================
+   * 行事曆日格狀態色（Calendar Day Cell Colors）
+   * 用於個人月曆和團隊行事曆的日格背景/文字。
+   * 每個狀態有 3 個 token：背景色、文字色、邊框色。
+   * ======================================== */
+
+  /* 正常出勤 — Green */
+  --cal-present: 142 71% 45%;
+  --cal-present-bg: 138 76% 97%;
+  --cal-present-text: 142 72% 29%;
+  --cal-present-border: 142 71% 85%;
+
+  /* 遲到 — Amber */
+  --cal-late: 38 92% 50%;
+  --cal-late-bg: 48 100% 96%;
+  --cal-late-text: 26 90% 37%;
+  --cal-late-border: 38 92% 82%;
+
+  /* 早退 — Deep Amber / Orange */
+  --cal-early-leave: 25 95% 53%;
+  --cal-early-leave-bg: 33 100% 96%;
+  --cal-early-leave-text: 21 90% 38%;
+  --cal-early-leave-border: 25 95% 82%;
+
+  /* 請假 — Blue（預設；依假別可用 leave-colors.css 覆蓋） */
+  --cal-leave: 217 91% 60%;
+  --cal-leave-bg: 214 100% 97%;
+  --cal-leave-text: 224 76% 48%;
+  --cal-leave-border: 217 91% 85%;
+
+  /* 缺席 — Red */
+  --cal-absent: 0 84% 60%;
+  --cal-absent-bg: 0 86% 97%;
+  --cal-absent-text: 0 74% 42%;
+  --cal-absent-border: 0 84% 85%;
+
+  /* 假日 — Neutral (Gray) */
+  --cal-holiday: 0 0% 64%;
+  --cal-holiday-bg: 0 0% 96%;
+  --cal-holiday-text: 0 0% 45%;
+  --cal-holiday-border: 0 0% 90%;
+
+  /* 加班 — Purple */
+  --cal-overtime: 262 83% 58%;
+  --cal-overtime-bg: 270 100% 98%;
+  --cal-overtime-text: 262 72% 44%;
+  --cal-overtime-border: 262 83% 85%;
+
+  /* 今天高亮 */
+  --cal-today-ring: 221 83% 53%;
+
+  /* ========================================
+   * 圖表色階（Chart Palette）
+   * 用於圓餅圖、長條圖等統計圖表。
+   * 基於 colors.css 的 --chart-* 擴展。
+   * ======================================== */
+
+  --chart-present: 142 71% 45%;
+  --chart-late: 38 92% 50%;
+  --chart-early-leave: 25 95% 53%;
+  --chart-leave: 217 91% 60%;
+  --chart-absent: 0 84% 60%;
+  --chart-overtime: 262 83% 58%;
+}
+
+.dark {
+  /* 行事曆日格 Dark Mode */
+  --cal-present-bg: 142 55% 12%;
+  --cal-present-text: 141 84% 70%;
+  --cal-present-border: 142 55% 25%;
+
+  --cal-late-bg: 32 80% 15%;
+  --cal-late-text: 48 96% 72%;
+  --cal-late-border: 38 80% 28%;
+
+  --cal-early-leave-bg: 21 80% 15%;
+  --cal-early-leave-text: 27 96% 61%;
+  --cal-early-leave-border: 25 80% 28%;
+
+  --cal-leave-bg: 224 71% 15%;
+  --cal-leave-text: 213 94% 68%;
+  --cal-leave-border: 217 71% 28%;
+
+  --cal-absent-bg: 0 63% 15%;
+  --cal-absent-text: 0 93% 75%;
+  --cal-absent-border: 0 63% 28%;
+
+  --cal-holiday-bg: 0 0% 12%;
+  --cal-holiday-text: 0 0% 55%;
+  --cal-holiday-border: 0 0% 22%;
+
+  --cal-overtime-bg: 262 60% 15%;
+  --cal-overtime-text: 262 83% 75%;
+  --cal-overtime-border: 262 60% 28%;
+
+  --cal-today-ring: 217 91% 60%;
+
+  /* 圖表色 Dark Mode */
+  --chart-present: 141 84% 70%;
+  --chart-late: 48 96% 72%;
+  --chart-early-leave: 27 96% 61%;
+  --chart-leave: 213 94% 68%;
+  --chart-absent: 0 93% 75%;
+  --chart-overtime: 262 83% 75%;
+}

--- a/design/tokens/tokens.md
+++ b/design/tokens/tokens.md
@@ -15,6 +15,7 @@
 |------|------|
 | `colors.css` | 原始色票 + 語意色票 + 狀態色票 |
 | `leave-colors.css` | 假別色彩 + 請假狀態色彩（Sprint 2） |
+| `calendar-colors.css` | 行事曆日格狀態色 + 圖表色階（Sprint 3） |
 | `typography.css` | 字型、字級、字重、行高 |
 | `spacing.css` | 間距、Layout 尺寸、圓角、陰影、z-index、動畫 |
 
@@ -83,6 +84,34 @@
 | 已核准 | `--leave-status-approved` | Green |
 | 已駁回 | `--leave-status-rejected` | Red |
 | 已取消 | `--leave-status-cancelled` | Gray |
+
+### 行事曆日格狀態色（Sprint 3）
+
+定義於 `calendar-colors.css`。每個狀態有背景色、文字色、邊框色三個 token。
+
+| 狀態 | Token 前綴 | 顏色 | 說明 |
+|------|-----------|------|------|
+| 正常出勤 | `--cal-present` | Green | 準時上下班 |
+| 遲到 | `--cal-late` | Amber | clock_in > 09:00 |
+| 早退 | `--cal-early-leave` | Orange | clock_out < 18:00 |
+| 請假 | `--cal-leave` | Blue | 預設；可依假別覆蓋 |
+| 缺席 | `--cal-absent` | Red | 無打卡且無請假 |
+| 假日 | `--cal-holiday` | Gray | 週末/國定假日 |
+| 加班 | `--cal-overtime` | Purple | 假日加班 |
+| 今天 | `--cal-today-ring` | Primary Blue | 今日高亮環 |
+
+### 圖表色階（Sprint 3）
+
+定義於 `calendar-colors.css`。用於 Recharts 圖表。
+
+| Token | 顏色 | 用途 |
+|-------|------|------|
+| `--chart-present` | Green | 正常出勤 |
+| `--chart-late` | Amber | 遲到 |
+| `--chart-early-leave` | Orange | 早退 |
+| `--chart-leave` | Blue | 請假 |
+| `--chart-absent` | Red | 缺席 |
+| `--chart-overtime` | Purple | 加班 |
 
 ## 字型系統
 


### PR DESCRIPTION
## Summary
Sprint 3 可視化功能的 UI component dataset，供前端 engineer 開發使用。

## Design Tokens
- `design/tokens/calendar-colors.css` — 行事曆日格狀態色 + 圖表色階（Light/Dark）

## Components（6 個）
| 元件 | Spec | 說明 |
|------|------|------|
| MonthPicker | `design/components/month-picker.md` | 月份選擇器（前後導航 + Popover 月份格） |
| CalendarMonth | `design/components/calendar-month.md` | 個人月曆（格子視圖，色彩標示出勤狀態） |
| TeamCalendarGrid | `design/components/team-calendar-grid.md` | 團隊行事曆（成員 x 日期表格，Tooltip） |
| StatsCard | `design/components/stats-card.md` | 統計卡片（數字+趨勢+環形進度+子指標） |
| AttendanceChart | `design/components/attendance-chart.md` | 出勤率圓餅圖/長條圖（Recharts + shadcn Chart） |
| ReportTable | `design/components/report-table.md` | 報表表格（可排序+摘要行+匯出 CSV/XLSX） |

## Pages（5 個）
| 頁面 | Layout | 對應 Feature |
|------|--------|-------------|
| 個人行事曆 | `design/pages/personal-calendar.md` | F-004 |
| 團隊行事曆 | `design/pages/team-calendar.md` | F-004 |
| 個人出勤報表 | `design/pages/personal-report.md` | F-005 |
| 團隊報表 | `design/pages/team-report.md` | F-005 |
| 全公司報表 | `design/pages/company-report.md` | F-005 |

Closes #29