### PR TITLE
feat: 行事曆 + 報表頁面 (FE-005)

### DIFF
--- a/dev/frontend/app/(authenticated)/calendar/page.tsx
+++ b/dev/frontend/app/(authenticated)/calendar/page.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { AppLayout } from "@/components/layout";
+import { PageHeader } from "@/components/layout";
+import { MonthPicker } from "@/components/month-picker";
+import { CalendarMonth, type CalendarDay } from "@/components/calendar-month";
+import { StatusBadge } from "@/components/status-badge";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { format } from "date-fns";
+import { zhTW } from "date-fns/locale";
+import api from "@/lib/api";
+
+const leaveTypeLabels: Record<string, string> = {
+  annual: "特休",
+  personal: "事假",
+  sick: "病假",
+  marriage: "婚假",
+  bereavement: "喪假",
+  maternity: "產假",
+  paternity: "陪產假",
+  official: "公假",
+};
+
+const leaveStatusLabels: Record<string, string> = {
+  approved: "已核准",
+  pending: "待審核",
+  rejected: "已駁回",
+  cancelled: "已取消",
+};
+
+export default function PersonalCalendarPage() {
+  const now = new Date();
+  const [year, setYear] = useState(now.getFullYear());
+  const [month, setMonth] = useState(now.getMonth() + 1);
+  const [selectedDay, setSelectedDay] = useState<CalendarDay | null>(null);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["calendar", "personal", year, month],
+    queryFn: async () => {
+      const res = await api.get("/calendar/personal", {
+        params: { year, month },
+      });
+      return res.data as { days: CalendarDay[] };
+    },
+  });
+
+  const handleMonthChange = (y: number, m: number) => {
+    setYear(y);
+    setMonth(m);
+    setSelectedDay(null);
+  };
+
+  return (
+    <AppLayout
+      breadcrumbs={[
+        { label: "行事曆", href: "/calendar" },
+        { label: "個人行事曆" },
+      ]}
+    >
+      <PageHeader
+        title="個人行事曆"
+        description="查看您的月出勤、請假、加班紀錄"
+      />
+
+      <div className="mb-4">
+        <MonthPicker year={year} month={month} onChange={handleMonthChange} />
+      </div>
+
+      <CalendarMonth
+        year={year}
+        month={month}
+        days={data?.days ?? []}
+        isLoading={isLoading}
+        selectedDate={selectedDay?.date}
+        onDayClick={(day) => setSelectedDay(day)}
+      />
+
+      {/* Day detail sheet */}
+      <Sheet
+        open={!!selectedDay}
+        onOpenChange={(open) => !open && setSelectedDay(null)}
+      >
+        <SheetContent>
+          <SheetHeader>
+            <SheetTitle>
+              {selectedDay &&
+                format(new Date(selectedDay.date), "yyyy年M月d日 EEEE", {
+                  locale: zhTW,
+                })}
+            </SheetTitle>
+          </SheetHeader>
+
+          {selectedDay && (
+            <div className="mt-6 space-y-6">
+              {/* Clock record */}
+              {selectedDay.clock && (
+                <div className="space-y-2">
+                  <h4 className="text-sm font-medium">打卡紀錄</h4>
+                  <div className="rounded-lg border p-3 space-y-2">
+                    <div className="flex justify-between text-sm">
+                      <span className="text-muted-foreground">上班</span>
+                      <span>
+                        {selectedDay.clock.clock_in
+                          ? selectedDay.clock.clock_in.slice(11, 19)
+                          : "--:--:--"}
+                      </span>
+                    </div>
+                    <div className="flex justify-between text-sm">
+                      <span className="text-muted-foreground">下班</span>
+                      <span>
+                        {selectedDay.clock.clock_out
+                          ? selectedDay.clock.clock_out.slice(11, 19)
+                          : "--:--:--"}
+                      </span>
+                    </div>
+                    <div className="pt-1">
+                      <StatusBadge
+                        type="attendance"
+                        value={selectedDay.clock.status}
+                      />
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {/* Leave records */}
+              {selectedDay.leaves.length > 0 && (
+                <div className="space-y-2">
+                  <h4 className="text-sm font-medium">請假紀錄</h4>
+                  {selectedDay.leaves.map((leave) => (
+                    <div
+                      key={leave.id}
+                      className="flex items-center justify-between rounded-lg border p-3 text-sm"
+                    >
+                      <span>
+                        {leaveTypeLabels[leave.leave_type] || leave.leave_type}
+                      </span>
+                      <span
+                        className={
+                          leave.status === "approved"
+                            ? "text-green-600"
+                            : leave.status === "rejected"
+                              ? "text-red-600"
+                              : "text-muted-foreground"
+                        }
+                      >
+                        {leaveStatusLabels[leave.status] || leave.status}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {/* Overtime */}
+              {selectedDay.overtime && (
+                <div className="space-y-2">
+                  <h4 className="text-sm font-medium">加班紀錄</h4>
+                  <div className="rounded-lg border p-3 text-sm">
+                    <span>{selectedDay.overtime.hours} 小時</span>
+                  </div>
+                </div>
+              )}
+
+              {/* No records */}
+              {!selectedDay.clock &&
+                selectedDay.leaves.length === 0 &&
+                !selectedDay.overtime && (
+                  <p className="text-sm text-muted-foreground">
+                    {selectedDay.is_workday ? "無出勤紀錄" : "非工作日"}
+                  </p>
+                )}
+            </div>
+          )}
+        </SheetContent>
+      </Sheet>
+    </AppLayout>
+  );
+}

--- a/dev/frontend/app/(authenticated)/calendar/team/page.tsx
+++ b/dev/frontend/app/(authenticated)/calendar/team/page.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { AppLayout } from "@/components/layout";
+import { PageHeader } from "@/components/layout";
+import { MonthPicker } from "@/components/month-picker";
+import { TeamCalendarGrid, type TeamMember } from "@/components/team-calendar-grid";
+import { RoleGuard } from "@/components/role-guard";
+import { useAuthStore } from "@/lib/auth-store";
+import api from "@/lib/api";
+
+interface Department {
+  id: string;
+  name: string;
+  code: string;
+}
+
+export default function TeamCalendarPage() {
+  const { user } = useAuthStore();
+  const now = new Date();
+  const [year, setYear] = useState(now.getFullYear());
+  const [month, setMonth] = useState(now.getMonth() + 1);
+  const [departmentId, setDepartmentId] = useState<string>(
+    user?.department?.id ?? ""
+  );
+
+  // Fetch departments for admin
+  const { data: departments } = useQuery({
+    queryKey: ["departments"],
+    queryFn: async () => {
+      const res = await api.get("/departments");
+      return res.data as Department[];
+    },
+    enabled: user?.role === "admin",
+  });
+
+  // Fetch team calendar
+  const { data, isLoading } = useQuery({
+    queryKey: ["calendar", "team", year, month, departmentId],
+    queryFn: async () => {
+      const params: Record<string, string | number> = { year, month };
+      if (departmentId) params.department_id = departmentId;
+      const res = await api.get("/calendar/team", { params });
+      return res.data as { members: TeamMember[] };
+    },
+    enabled: !!departmentId || user?.role === "admin",
+  });
+
+  const handleMonthChange = (y: number, m: number) => {
+    setYear(y);
+    setMonth(m);
+  };
+
+  return (
+    <RoleGuard allowedRoles={["manager", "admin"]}>
+      <AppLayout
+        breadcrumbs={[
+          { label: "行事曆", href: "/calendar" },
+          { label: "團隊行事曆" },
+        ]}
+      >
+        <PageHeader
+          title="團隊行事曆"
+          description="查看團隊成員的月出勤狀況"
+          actions={
+            user?.role === "admin" && departments ? (
+              <select
+                value={departmentId}
+                onChange={(e) => setDepartmentId(e.target.value)}
+                className="rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+              >
+                <option value="">全部部門</option>
+                {departments.map((dept) => (
+                  <option key={dept.id} value={dept.id}>
+                    {dept.name}
+                  </option>
+                ))}
+              </select>
+            ) : undefined
+          }
+        />
+
+        <div className="mb-4">
+          <MonthPicker year={year} month={month} onChange={handleMonthChange} />
+        </div>
+
+        <TeamCalendarGrid
+          year={year}
+          month={month}
+          members={data?.members ?? []}
+          isLoading={isLoading}
+        />
+      </AppLayout>
+    </RoleGuard>
+  );
+}

--- a/dev/frontend/app/(authenticated)/reports/company/page.tsx
+++ b/dev/frontend/app/(authenticated)/reports/company/page.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { AppLayout } from "@/components/layout";
+import { PageHeader } from "@/components/layout";
+import { MonthPicker } from "@/components/month-picker";
+import { CardStats } from "@/components/card-stats";
+import { DonutChart, type DonutSegment } from "@/components/donut-chart";
+import { HorizontalBarChart, type BarItem } from "@/components/bar-chart";
+import { RoleGuard } from "@/components/role-guard";
+import {
+  Users,
+  CalendarCheck,
+  AlertTriangle,
+  CalendarX,
+  Timer,
+} from "lucide-react";
+import { Skeleton } from "@/components/ui/skeleton";
+import api from "@/lib/api";
+
+interface DepartmentReport {
+  department_id: string;
+  department_name: string;
+  total_members: number;
+  avg_attendance_rate: number;
+  total_late_count: number;
+  total_leave_days: number;
+  total_overtime_hours: number;
+  total_attendance_days: number;
+  total_absent_days: number;
+}
+
+interface CompanyReport {
+  company_summary: {
+    total_employees: number;
+    avg_attendance_rate: number;
+    total_late_count: number;
+    total_leave_days: number;
+    total_overtime_hours: number;
+    total_attendance_days: number;
+    total_absent_days: number;
+    working_days: number;
+  };
+  departments: DepartmentReport[];
+}
+
+const attendanceColors: Record<string, string> = {
+  present: "#22c55e",
+  late: "#f59e0b",
+  leave: "#3b82f6",
+  absent: "#ef4444",
+};
+
+export default function CompanyReportPage() {
+  const now = new Date();
+  const [year, setYear] = useState(now.getFullYear());
+  const [month, setMonth] = useState(now.getMonth() + 1);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["reports", "company", year, month],
+    queryFn: async () => {
+      const res = await api.get("/reports/company", {
+        params: { year, month },
+      });
+      return res.data as CompanyReport;
+    },
+  });
+
+  const handleMonthChange = (y: number, m: number) => {
+    setYear(y);
+    setMonth(m);
+  };
+
+  const summary = data?.company_summary;
+  const departments = data?.departments ?? [];
+
+  // Bar chart data for department attendance rates
+  const barItems: BarItem[] = departments.map((d) => ({
+    label: d.department_name,
+    value: Number(d.avg_attendance_rate.toFixed(1)),
+    color: "bg-primary",
+  }));
+
+  // Donut chart for company-wide attendance distribution
+  const donutSegments: DonutSegment[] = summary
+    ? [
+        {
+          label: "正常出勤",
+          value: summary.total_attendance_days - summary.total_late_count,
+          color: attendanceColors.present,
+        },
+        { label: "遲到", value: summary.total_late_count, color: attendanceColors.late },
+        { label: "請假", value: summary.total_leave_days, color: attendanceColors.leave },
+        { label: "缺席", value: summary.total_absent_days, color: attendanceColors.absent },
+      ]
+    : [];
+
+  return (
+    <RoleGuard allowedRoles={["admin"]}>
+      <AppLayout
+        breadcrumbs={[
+          { label: "報表", href: "/reports/personal" },
+          { label: "全公司報表" },
+        ]}
+      >
+        <PageHeader
+          title="全公司出勤報表"
+          description="全公司月出勤統計及部門比較"
+        />
+
+        <div className="mb-4">
+          <MonthPicker year={year} month={month} onChange={handleMonthChange} />
+        </div>
+
+        {isLoading ? (
+          <div className="grid grid-cols-2 gap-4 md:grid-cols-5">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <Skeleton key={i} className="h-[120px] rounded-lg" />
+            ))}
+          </div>
+        ) : summary ? (
+          <>
+            {/* Stats cards */}
+            <div className="mb-6 grid grid-cols-2 gap-4 md:grid-cols-5">
+              <CardStats
+                title="總員工數"
+                value={summary.total_employees}
+                icon={Users}
+              />
+              <CardStats
+                title="平均出勤率"
+                value={`${summary.avg_attendance_rate.toFixed(1)}%`}
+                icon={CalendarCheck}
+              />
+              <CardStats
+                title="遲到人次"
+                value={`${summary.total_late_count} 次`}
+                icon={AlertTriangle}
+              />
+              <CardStats
+                title="請假天數"
+                value={`${summary.total_leave_days} 天`}
+                icon={CalendarX}
+              />
+              <CardStats
+                title="加班時數"
+                value={`${summary.total_overtime_hours}h`}
+                icon={Timer}
+              />
+            </div>
+
+            {/* Charts */}
+            <div className="mb-6 grid gap-4 md:grid-cols-2">
+              <HorizontalBarChart
+                title="部門出勤率比較"
+                description={`${year} 年 ${month} 月`}
+                items={barItems}
+                maxValue={100}
+                unit="%"
+              />
+              <DonutChart
+                title="全公司出勤分布"
+                description={`${year} 年 ${month} 月`}
+                segments={donutSegments}
+                centerLabel="出勤率"
+                centerValue={`${summary.avg_attendance_rate.toFixed(1)}%`}
+              />
+            </div>
+
+            {/* Department detail table */}
+            <div className="rounded-lg border bg-card">
+              <div className="border-b px-4 py-3">
+                <h3 className="font-semibold">部門出勤明細</h3>
+              </div>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b bg-muted/50">
+                      <th className="px-4 py-2 text-left font-medium text-muted-foreground">部門</th>
+                      <th className="px-4 py-2 text-right font-medium text-muted-foreground">人數</th>
+                      <th className="px-4 py-2 text-right font-medium text-muted-foreground">出勤率</th>
+                      <th className="px-4 py-2 text-right font-medium text-muted-foreground">遲到</th>
+                      <th className="px-4 py-2 text-right font-medium text-muted-foreground">請假</th>
+                      <th className="px-4 py-2 text-right font-medium text-muted-foreground">加班(h)</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {departments.length === 0 ? (
+                      <tr>
+                        <td colSpan={6} className="px-4 py-8 text-center text-muted-foreground">
+                          暫無資料
+                        </td>
+                      </tr>
+                    ) : (
+                      <>
+                        {departments.map((dept) => (
+                          <tr key={dept.department_id} className="border-b hover:bg-muted/50">
+                            <td className="px-4 py-2 font-medium">{dept.department_name}</td>
+                            <td className="px-4 py-2 text-right">{dept.total_members}</td>
+                            <td className="px-4 py-2 text-right">
+                              <span
+                                className={
+                                  dept.avg_attendance_rate >= 95
+                                    ? "text-green-600"
+                                    : dept.avg_attendance_rate >= 85
+                                      ? "text-amber-600"
+                                      : "text-red-600"
+                                }
+                              >
+                                {dept.avg_attendance_rate.toFixed(1)}%
+                              </span>
+                            </td>
+                            <td className="px-4 py-2 text-right">{dept.total_late_count}</td>
+                            <td className="px-4 py-2 text-right">{dept.total_leave_days}</td>
+                            <td className="px-4 py-2 text-right">{dept.total_overtime_hours}</td>
+                          </tr>
+                        ))}
+                        {/* Summary row */}
+                        <tr className="border-t-2 bg-muted/30 font-medium">
+                          <td className="px-4 py-2">全公司合計</td>
+                          <td className="px-4 py-2 text-right">{summary.total_employees}</td>
+                          <td className="px-4 py-2 text-right">
+                            {summary.avg_attendance_rate.toFixed(1)}%
+                          </td>
+                          <td className="px-4 py-2 text-right">{summary.total_late_count}</td>
+                          <td className="px-4 py-2 text-right">{summary.total_leave_days}</td>
+                          <td className="px-4 py-2 text-right">{summary.total_overtime_hours}</td>
+                        </tr>
+                      </>
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </>
+        ) : (
+          <div className="rounded-lg border bg-card p-8 text-center text-sm text-muted-foreground">
+            暫無資料
+          </div>
+        )}
+      </AppLayout>
+    </RoleGuard>
+  );
+}

--- a/dev/frontend/app/(authenticated)/reports/personal/page.tsx
+++ b/dev/frontend/app/(authenticated)/reports/personal/page.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { AppLayout } from "@/components/layout";
+import { PageHeader } from "@/components/layout";
+import { MonthPicker } from "@/components/month-picker";
+import { CardStats } from "@/components/card-stats";
+import { DonutChart, type DonutSegment } from "@/components/donut-chart";
+import {
+  CalendarCheck,
+  AlertTriangle,
+  CalendarX,
+  Timer,
+} from "lucide-react";
+import { Skeleton } from "@/components/ui/skeleton";
+import api from "@/lib/api";
+
+interface PersonalReport {
+  summary: {
+    working_days: number;
+    attendance_days: number;
+    attendance_rate: number;
+    late_days: number;
+    early_leave_days: number;
+    absent_days: number;
+    leave_days: number;
+    overtime_hours: number;
+  };
+  leave_summary: {
+    leave_type: string;
+    days: number;
+    hours: number;
+  }[];
+}
+
+const leaveTypeLabels: Record<string, string> = {
+  annual: "特休",
+  personal: "事假",
+  sick: "病假",
+  marriage: "婚假",
+  bereavement: "喪假",
+  maternity: "產假",
+  paternity: "陪產假",
+  official: "公假",
+};
+
+const attendanceColors: Record<string, string> = {
+  present: "#22c55e",
+  late: "#f59e0b",
+  leave: "#3b82f6",
+  absent: "#ef4444",
+};
+
+const leaveColors = [
+  "#3b82f6", "#8b5cf6", "#06b6d4", "#f59e0b",
+  "#ef4444", "#10b981", "#ec4899", "#6366f1",
+];
+
+export default function PersonalReportPage() {
+  const now = new Date();
+  const [year, setYear] = useState(now.getFullYear());
+  const [month, setMonth] = useState(now.getMonth() + 1);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["reports", "personal", year, month],
+    queryFn: async () => {
+      const res = await api.get("/reports/personal", {
+        params: { year, month },
+      });
+      return res.data as PersonalReport;
+    },
+  });
+
+  const handleMonthChange = (y: number, m: number) => {
+    setYear(y);
+    setMonth(m);
+  };
+
+  const summary = data?.summary;
+
+  // Build donut segments for attendance distribution
+  const attendanceSegments: DonutSegment[] = summary
+    ? [
+        { label: "正常出勤", value: summary.attendance_days - summary.late_days - summary.early_leave_days, color: attendanceColors.present },
+        { label: "遲到", value: summary.late_days, color: attendanceColors.late },
+        { label: "請假", value: summary.leave_days, color: attendanceColors.leave },
+        { label: "缺席", value: summary.absent_days, color: attendanceColors.absent },
+      ]
+    : [];
+
+  // Build donut segments for leave type distribution
+  const leaveSegments: DonutSegment[] =
+    data?.leave_summary?.map((ls, i) => ({
+      label: leaveTypeLabels[ls.leave_type] || ls.leave_type,
+      value: ls.days,
+      color: leaveColors[i % leaveColors.length],
+    })) ?? [];
+
+  return (
+    <AppLayout
+      breadcrumbs={[
+        { label: "報表", href: "/reports/personal" },
+        { label: "個人報表" },
+      ]}
+    >
+      <PageHeader
+        title="個人出勤報表"
+        description="查看您的月出勤統計"
+      />
+
+      <div className="mb-4">
+        <MonthPicker year={year} month={month} onChange={handleMonthChange} />
+      </div>
+
+      {isLoading ? (
+        <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} className="h-[120px] rounded-lg" />
+          ))}
+        </div>
+      ) : summary ? (
+        <>
+          {/* Stats cards */}
+          <div className="mb-6 grid grid-cols-2 gap-4 md:grid-cols-4">
+            <CardStats
+              title="出勤率"
+              value={`${summary.attendance_rate.toFixed(1)}%`}
+              description={`${summary.attendance_days}/${summary.working_days} 工作日`}
+              icon={CalendarCheck}
+            />
+            <CardStats
+              title="遲到"
+              value={`${summary.late_days} 次`}
+              icon={AlertTriangle}
+            />
+            <CardStats
+              title="請假"
+              value={`${summary.leave_days} 天`}
+              icon={CalendarX}
+            />
+            <CardStats
+              title="加班"
+              value={`${summary.overtime_hours}h`}
+              icon={Timer}
+            />
+          </div>
+
+          {/* Charts */}
+          <div className="mb-6 grid gap-4 md:grid-cols-2">
+            <DonutChart
+              title="出勤分布"
+              description={`${year} 年 ${month} 月`}
+              segments={attendanceSegments}
+              centerLabel="出勤天數"
+              centerValue={summary.attendance_days}
+            />
+            <DonutChart
+              title="請假類型分布"
+              description={`${year} 年 ${month} 月`}
+              segments={leaveSegments}
+              centerLabel="請假天數"
+              centerValue={summary.leave_days}
+            />
+          </div>
+
+          {/* Leave detail table */}
+          {data.leave_summary && data.leave_summary.length > 0 && (
+            <div className="rounded-lg border bg-card">
+              <div className="border-b px-4 py-3">
+                <h3 className="font-semibold">請假明細</h3>
+              </div>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b bg-muted/50">
+                      <th className="px-4 py-2 text-left font-medium text-muted-foreground">假別</th>
+                      <th className="px-4 py-2 text-right font-medium text-muted-foreground">天數</th>
+                      <th className="px-4 py-2 text-right font-medium text-muted-foreground">時數</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {data.leave_summary.map((ls) => (
+                      <tr key={ls.leave_type} className="border-b last:border-b-0">
+                        <td className="px-4 py-2">
+                          {leaveTypeLabels[ls.leave_type] || ls.leave_type}
+                        </td>
+                        <td className="px-4 py-2 text-right">{ls.days}</td>
+                        <td className="px-4 py-2 text-right">{ls.hours}h</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+        </>
+      ) : (
+        <div className="rounded-lg border bg-card p-8 text-center text-sm text-muted-foreground">
+          暫無資料
+        </div>
+      )}
+    </AppLayout>
+  );
+}

--- a/dev/frontend/app/(authenticated)/reports/team/page.tsx
+++ b/dev/frontend/app/(authenticated)/reports/team/page.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { AppLayout } from "@/components/layout";
+import { PageHeader } from "@/components/layout";
+import { MonthPicker } from "@/components/month-picker";
+import { CardStats } from "@/components/card-stats";
+import { RoleGuard } from "@/components/role-guard";
+import { useAuthStore } from "@/lib/auth-store";
+import {
+  CalendarCheck,
+  Users,
+  AlertTriangle,
+  CalendarX,
+} from "lucide-react";
+import { Skeleton } from "@/components/ui/skeleton";
+import api from "@/lib/api";
+
+interface Department {
+  id: string;
+  name: string;
+  code: string;
+}
+
+interface TeamMemberReport {
+  user_id: string;
+  employee_id: string;
+  name: string;
+  attendance_days: number;
+  absent_days: number;
+  late_days: number;
+  early_leave_days: number;
+  leave_days: number;
+  overtime_hours: number;
+  attendance_rate: number;
+}
+
+interface TeamReport {
+  team_summary: {
+    total_members: number;
+    avg_attendance_rate: number;
+    total_late_count: number;
+    total_leave_days: number;
+  };
+  members: TeamMemberReport[];
+}
+
+export default function TeamReportPage() {
+  const { user } = useAuthStore();
+  const now = new Date();
+  const [year, setYear] = useState(now.getFullYear());
+  const [month, setMonth] = useState(now.getMonth() + 1);
+  const [departmentId, setDepartmentId] = useState<string>(
+    user?.department?.id ?? ""
+  );
+  const [searchTerm, setSearchTerm] = useState("");
+
+  // Fetch departments for admin
+  const { data: departments } = useQuery({
+    queryKey: ["departments"],
+    queryFn: async () => {
+      const res = await api.get("/departments");
+      return res.data as Department[];
+    },
+    enabled: user?.role === "admin",
+  });
+
+  // Fetch team report
+  const { data, isLoading } = useQuery({
+    queryKey: ["reports", "team", year, month, departmentId],
+    queryFn: async () => {
+      const params: Record<string, string | number> = { year, month };
+      if (departmentId) params.department_id = departmentId;
+      const res = await api.get("/reports/team", { params });
+      return res.data as TeamReport;
+    },
+    enabled: !!departmentId || user?.role === "admin",
+  });
+
+  const handleMonthChange = (y: number, m: number) => {
+    setYear(y);
+    setMonth(m);
+  };
+
+  const filteredMembers =
+    data?.members?.filter((m) =>
+      searchTerm
+        ? m.name.includes(searchTerm) || m.employee_id.includes(searchTerm)
+        : true
+    ) ?? [];
+
+  const summary = data?.team_summary;
+
+  return (
+    <RoleGuard allowedRoles={["manager", "admin"]}>
+      <AppLayout
+        breadcrumbs={[
+          { label: "報表", href: "/reports/personal" },
+          { label: "團隊報表" },
+        ]}
+      >
+        <PageHeader
+          title="團隊報表"
+          description="查看團隊的月出勤統計"
+          actions={
+            user?.role === "admin" && departments ? (
+              <select
+                value={departmentId}
+                onChange={(e) => setDepartmentId(e.target.value)}
+                className="rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+              >
+                <option value="">全部部門</option>
+                {departments.map((dept) => (
+                  <option key={dept.id} value={dept.id}>
+                    {dept.name}
+                  </option>
+                ))}
+              </select>
+            ) : undefined
+          }
+        />
+
+        <div className="mb-4">
+          <MonthPicker year={year} month={month} onChange={handleMonthChange} />
+        </div>
+
+        {isLoading ? (
+          <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <Skeleton key={i} className="h-[120px] rounded-lg" />
+            ))}
+          </div>
+        ) : summary ? (
+          <>
+            {/* Stats cards */}
+            <div className="mb-6 grid grid-cols-2 gap-4 md:grid-cols-4">
+              <CardStats
+                title="平均出勤率"
+                value={`${summary.avg_attendance_rate.toFixed(1)}%`}
+                icon={CalendarCheck}
+              />
+              <CardStats
+                title="總人數"
+                value={summary.total_members}
+                icon={Users}
+              />
+              <CardStats
+                title="遲到人次"
+                value={`${summary.total_late_count} 次`}
+                icon={AlertTriangle}
+              />
+              <CardStats
+                title="請假天數"
+                value={`${summary.total_leave_days} 天`}
+                icon={CalendarX}
+              />
+            </div>
+
+            {/* Member table */}
+            <div className="rounded-lg border bg-card">
+              <div className="flex items-center justify-between border-b px-4 py-3">
+                <h3 className="font-semibold">團隊出勤明細</h3>
+                <input
+                  type="text"
+                  placeholder="搜尋員工..."
+                  value={searchTerm}
+                  onChange={(e) => setSearchTerm(e.target.value)}
+                  className="rounded-md border border-input bg-background px-3 py-1.5 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                />
+              </div>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b bg-muted/50">
+                      <th className="px-4 py-2 text-left font-medium text-muted-foreground">編號</th>
+                      <th className="px-4 py-2 text-left font-medium text-muted-foreground">姓名</th>
+                      <th className="px-4 py-2 text-right font-medium text-muted-foreground">出勤</th>
+                      <th className="px-4 py-2 text-right font-medium text-muted-foreground">缺席</th>
+                      <th className="px-4 py-2 text-right font-medium text-muted-foreground">遲到</th>
+                      <th className="px-4 py-2 text-right font-medium text-muted-foreground">早退</th>
+                      <th className="px-4 py-2 text-right font-medium text-muted-foreground">請假</th>
+                      <th className="px-4 py-2 text-right font-medium text-muted-foreground">加班(h)</th>
+                      <th className="px-4 py-2 text-right font-medium text-muted-foreground">出勤率</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {filteredMembers.length === 0 ? (
+                      <tr>
+                        <td colSpan={9} className="px-4 py-8 text-center text-muted-foreground">
+                          暫無資料
+                        </td>
+                      </tr>
+                    ) : (
+                      filteredMembers.map((m) => (
+                        <tr key={m.user_id} className="border-b last:border-b-0 hover:bg-muted/50">
+                          <td className="px-4 py-2 text-muted-foreground">{m.employee_id}</td>
+                          <td className="px-4 py-2 font-medium">{m.name}</td>
+                          <td className="px-4 py-2 text-right">{m.attendance_days}</td>
+                          <td className="px-4 py-2 text-right">{m.absent_days}</td>
+                          <td className="px-4 py-2 text-right">{m.late_days}</td>
+                          <td className="px-4 py-2 text-right">{m.early_leave_days}</td>
+                          <td className="px-4 py-2 text-right">{m.leave_days}</td>
+                          <td className="px-4 py-2 text-right">{m.overtime_hours}</td>
+                          <td className="px-4 py-2 text-right">
+                            <span
+                              className={
+                                m.attendance_rate >= 95
+                                  ? "text-green-600"
+                                  : m.attendance_rate >= 85
+                                    ? "text-amber-600"
+                                    : "text-red-600"
+                              }
+                            >
+                              {m.attendance_rate.toFixed(1)}%
+                            </span>
+                          </td>
+                        </tr>
+                      ))
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </>
+        ) : (
+          <div className="rounded-lg border bg-card p-8 text-center text-sm text-muted-foreground">
+            暫無資料
+          </div>
+        )}
+      </AppLayout>
+    </RoleGuard>
+  );
+}

--- a/dev/frontend/app/globals.css
+++ b/dev/frontend/app/globals.css
@@ -42,6 +42,30 @@
     --sidebar-ring: 221 83% 53%;
     --radius: 0.5rem;
 
+    /* Calendar colors */
+    --cal-present: 142 71% 45%;
+    --cal-present-bg: 142 71% 95%;
+    --cal-late: 38 92% 50%;
+    --cal-late-bg: 38 92% 95%;
+    --cal-early-leave: 32 95% 44%;
+    --cal-early-leave-bg: 32 95% 95%;
+    --cal-leave: 217 91% 60%;
+    --cal-leave-bg: 217 91% 95%;
+    --cal-absent: 0 84% 60%;
+    --cal-absent-bg: 0 84% 95%;
+    --cal-holiday-bg: 0 0% 97%;
+    --cal-holiday-text: 0 84% 60%;
+    --cal-overtime: 262 83% 58%;
+    --cal-overtime-bg: 262 83% 95%;
+
+    /* Chart colors */
+    --chart-present: 142 71% 45%;
+    --chart-late: 38 92% 50%;
+    --chart-early-leave: 32 95% 44%;
+    --chart-leave: 217 91% 60%;
+    --chart-absent: 0 84% 60%;
+    --chart-overtime: 262 83% 58%;
+
     /* Status colors */
     --status-normal: 142 71% 45%;
     --status-late: 38 92% 50%;
@@ -85,6 +109,29 @@
     --chart-3: 48 96% 89%;
     --chart-4: 0 93% 94%;
     --chart-5: 262 83% 58%;
+    /* Calendar colors (dark) */
+    --cal-present: 142 76% 36%;
+    --cal-present-bg: 142 76% 10%;
+    --cal-late: 32 95% 44%;
+    --cal-late-bg: 32 95% 10%;
+    --cal-early-leave: 32 95% 38%;
+    --cal-early-leave-bg: 32 95% 10%;
+    --cal-leave: 213 94% 68%;
+    --cal-leave-bg: 213 94% 10%;
+    --cal-absent: 0 63% 31%;
+    --cal-absent-bg: 0 63% 10%;
+    --cal-holiday-bg: 0 0% 8%;
+    --cal-holiday-text: 0 93% 94%;
+    --cal-overtime: 262 83% 58%;
+    --cal-overtime-bg: 262 83% 10%;
+
+    --chart-present: 142 76% 36%;
+    --chart-late: 32 95% 44%;
+    --chart-early-leave: 32 95% 38%;
+    --chart-leave: 213 94% 68%;
+    --chart-absent: 0 63% 31%;
+    --chart-overtime: 262 83% 58%;
+
     --sidebar-background: 0 0% 7%;
     --sidebar-foreground: 0 0% 83%;
     --sidebar-primary: 217 91% 60%;

--- a/dev/frontend/components/bar-chart.tsx
+++ b/dev/frontend/components/bar-chart.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+export interface BarItem {
+  label: string;
+  value: number;
+  color?: string;
+}
+
+interface HorizontalBarChartProps {
+  title: string;
+  description?: string;
+  items: BarItem[];
+  maxValue?: number;
+  unit?: string;
+}
+
+export function HorizontalBarChart({
+  title,
+  description,
+  items,
+  maxValue,
+  unit = "%",
+}: HorizontalBarChartProps) {
+  const max = maxValue ?? Math.max(...items.map((i) => i.value), 1);
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-lg">{title}</CardTitle>
+        {description && <CardDescription>{description}</CardDescription>}
+      </CardHeader>
+      <CardContent>
+        {items.length === 0 ? (
+          <div className="flex h-[200px] items-center justify-center text-sm text-muted-foreground">
+            暫無資料
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {items.map((item) => {
+              const pct = max > 0 ? (item.value / max) * 100 : 0;
+              return (
+                <div key={item.label} className="space-y-1">
+                  <div className="flex items-center justify-between text-sm">
+                    <span className="font-medium">{item.label}</span>
+                    <span className="text-muted-foreground">
+                      {item.value}
+                      {unit}
+                    </span>
+                  </div>
+                  <div className="h-3 w-full rounded-full bg-muted">
+                    <div
+                      className={cn(
+                        "h-3 rounded-full transition-all duration-500",
+                        item.color || "bg-primary"
+                      )}
+                      style={{
+                        width: `${Math.min(pct, 100)}%`,
+                        ...(item.color?.startsWith("#") || item.color?.startsWith("hsl")
+                          ? { backgroundColor: item.color }
+                          : {}),
+                      }}
+                    />
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/dev/frontend/components/calendar-month.tsx
+++ b/dev/frontend/components/calendar-month.tsx
@@ -1,0 +1,251 @@
+"use client";
+
+import {
+  startOfMonth,
+  endOfMonth,
+  getDay,
+  eachDayOfInterval,
+  isToday,
+  format,
+} from "date-fns";
+import { cn } from "@/lib/utils";
+import { Skeleton } from "@/components/ui/skeleton";
+
+// --- Types ---
+
+export interface CalendarDay {
+  date: string; // "2026-04-01"
+  is_workday: boolean;
+  clock: {
+    clock_in: string | null;
+    clock_out: string | null;
+    status: "normal" | "late" | "early_leave" | "absent" | "amended";
+  } | null;
+  leaves: {
+    id: string;
+    leave_type: string;
+    start_half: "full" | "morning" | "afternoon";
+    end_half: "full" | "morning" | "afternoon";
+    status: "approved" | "pending" | "rejected" | "cancelled";
+  }[];
+  overtime: {
+    id: string;
+    hours: number;
+    status: string;
+  } | null;
+}
+
+export type DayCellStatus =
+  | "present"
+  | "late"
+  | "early_leave"
+  | "leave"
+  | "absent"
+  | "holiday"
+  | "overtime"
+  | "half_leave"
+  | "future"
+  | null;
+
+// --- Helpers ---
+
+export function deriveDayCellStatus(day: CalendarDay): DayCellStatus {
+  const today = new Date().toISOString().slice(0, 10);
+
+  if (!day.is_workday && !day.overtime) return "holiday";
+  if (day.date > today) return "future";
+  if (!day.is_workday && day.overtime) return "overtime";
+
+  const approvedLeaves = day.leaves.filter((l) => l.status === "approved");
+  const hasFullDayLeave = approvedLeaves.some((l) => l.start_half === "full");
+  if (hasFullDayLeave) return "leave";
+
+  const hasHalfLeave = approvedLeaves.length > 0;
+  if (hasHalfLeave && day.clock) return "half_leave";
+  if (hasHalfLeave && !day.clock) return "leave";
+
+  if (day.clock) {
+    const s = day.clock.status;
+    if (s === "normal" || s === "amended") return "present";
+    if (s === "late") return "late";
+    if (s === "early_leave") return "early_leave";
+    if (s === "absent") return "absent";
+    return "present";
+  }
+
+  if (day.is_workday && day.date <= today) return "absent";
+
+  return null;
+}
+
+const WEEKDAYS = ["日", "一", "二", "三", "四", "五", "六"];
+
+const statusStyles: Record<string, { bg: string; dot: string; label: string }> = {
+  present: {
+    bg: "bg-green-50 dark:bg-green-950/30",
+    dot: "bg-green-500 dark:bg-green-400",
+    label: "正常",
+  },
+  late: {
+    bg: "bg-amber-50 dark:bg-amber-950/30",
+    dot: "bg-amber-500 dark:bg-amber-400",
+    label: "遲到",
+  },
+  early_leave: {
+    bg: "bg-orange-50 dark:bg-orange-950/30",
+    dot: "bg-orange-500 dark:bg-orange-400",
+    label: "早退",
+  },
+  leave: {
+    bg: "bg-blue-50 dark:bg-blue-950/30",
+    dot: "bg-blue-500 dark:bg-blue-400",
+    label: "請假",
+  },
+  absent: {
+    bg: "bg-red-50 dark:bg-red-950/30",
+    dot: "bg-red-500 dark:bg-red-400",
+    label: "缺席",
+  },
+  holiday: {
+    bg: "bg-gray-50 dark:bg-gray-900/30",
+    dot: "",
+    label: "",
+  },
+  overtime: {
+    bg: "bg-purple-50 dark:bg-purple-950/30",
+    dot: "bg-purple-500 dark:bg-purple-400",
+    label: "加班",
+  },
+  half_leave: {
+    bg: "bg-blue-50 dark:bg-blue-950/20",
+    dot: "bg-blue-400",
+    label: "半假",
+  },
+};
+
+// --- Component ---
+
+interface CalendarMonthProps {
+  year: number;
+  month: number;
+  days: CalendarDay[];
+  onDayClick?: (day: CalendarDay) => void;
+  isLoading?: boolean;
+  selectedDate?: string;
+}
+
+export function CalendarMonth({
+  year,
+  month,
+  days,
+  onDayClick,
+  isLoading = false,
+  selectedDate,
+}: CalendarMonthProps) {
+  const dayMap = new Map(days.map((d) => [d.date, d]));
+  const firstDay = startOfMonth(new Date(year, month - 1));
+  const lastDay = endOfMonth(firstDay);
+  const startOffset = getDay(firstDay);
+  const allDays = eachDayOfInterval({ start: firstDay, end: lastDay });
+
+  return (
+    <div className="rounded-lg border bg-card">
+      {/* Weekday header */}
+      <div className="grid grid-cols-7 border-b">
+        {WEEKDAYS.map((day, i) => (
+          <div
+            key={day}
+            className={cn(
+              "p-2 text-center text-xs font-medium text-muted-foreground",
+              i === 0 && "text-destructive",
+              i === 6 && "text-blue-500"
+            )}
+          >
+            {day}
+          </div>
+        ))}
+      </div>
+
+      {/* Day grid */}
+      {isLoading ? (
+        <div className="grid grid-cols-7">
+          {Array.from({ length: 35 }).map((_, i) => (
+            <div key={i} className="min-h-[80px] border-b border-r p-1.5 lg:min-h-[100px]">
+              <Skeleton className="h-full w-full rounded" />
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="grid grid-cols-7">
+          {Array.from({ length: startOffset }).map((_, i) => (
+            <div key={`empty-${i}`} className="min-h-[80px] border-b border-r lg:min-h-[100px]" />
+          ))}
+          {allDays.map((date) => {
+            const dateStr = format(date, "yyyy-MM-dd");
+            const dayData = dayMap.get(dateStr);
+            const status = dayData ? deriveDayCellStatus(dayData) : null;
+            const style = status ? statusStyles[status] : null;
+            const isSelected = selectedDate === dateStr;
+            const today = isToday(date);
+
+            return (
+              <button
+                key={dateStr}
+                type="button"
+                className={cn(
+                  "min-h-[80px] border-b border-r p-1.5 text-left transition-colors lg:min-h-[100px]",
+                  "hover:bg-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset",
+                  style?.bg,
+                  isSelected && "ring-2 ring-primary ring-inset"
+                )}
+                onClick={() => dayData && onDayClick?.(dayData)}
+                aria-label={`${format(date, "M月d日")}${style?.label ? ` ${style.label}` : ""}`}
+                aria-pressed={isSelected}
+              >
+                <div className="flex items-start justify-between">
+                  <span
+                    className={cn(
+                      "text-sm font-medium",
+                      today &&
+                        "flex h-6 w-6 items-center justify-center rounded-full bg-primary text-primary-foreground"
+                    )}
+                  >
+                    {date.getDate()}
+                  </span>
+                  {style?.dot && (
+                    <span
+                      className={cn("mt-1 h-2 w-2 rounded-full", style.dot)}
+                      aria-hidden="true"
+                    />
+                  )}
+                </div>
+                {style?.label && (
+                  <span className="mt-1 hidden text-[10px] leading-tight text-muted-foreground lg:block">
+                    {style.label}
+                  </span>
+                )}
+                {dayData?.clock?.clock_in && (
+                  <span className="mt-0.5 hidden text-[10px] leading-tight text-muted-foreground lg:block">
+                    {dayData.clock.clock_in.slice(11, 16)}
+                  </span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Legend */}
+      <div className="flex flex-wrap gap-3 border-t px-3 py-2">
+        {Object.entries(statusStyles)
+          .filter(([, v]) => v.label)
+          .map(([key, style]) => (
+            <div key={key} className="flex items-center gap-1">
+              <span className={cn("h-2 w-2 rounded-full", style.dot)} aria-hidden="true" />
+              <span className="text-xs text-muted-foreground">{style.label}</span>
+            </div>
+          ))}
+      </div>
+    </div>
+  );
+}

--- a/dev/frontend/components/donut-chart.tsx
+++ b/dev/frontend/components/donut-chart.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+export interface DonutSegment {
+  label: string;
+  value: number;
+  color: string; // Tailwind color class or hex
+}
+
+interface DonutChartProps {
+  title: string;
+  description?: string;
+  segments: DonutSegment[];
+  centerLabel?: string;
+  centerValue?: string | number;
+  size?: number;
+}
+
+export function DonutChart({
+  title,
+  description,
+  segments,
+  centerLabel,
+  centerValue,
+  size = 200,
+}: DonutChartProps) {
+  const total = segments.reduce((sum, s) => sum + s.value, 0);
+  const radius = size / 2;
+  const strokeWidth = size * 0.15;
+  const innerRadius = radius - strokeWidth;
+  const circumference = 2 * Math.PI * innerRadius;
+
+  let cumulativeOffset = 0;
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-lg">{title}</CardTitle>
+        {description && <CardDescription>{description}</CardDescription>}
+      </CardHeader>
+      <CardContent>
+        {total === 0 ? (
+          <div className="flex h-[200px] items-center justify-center text-sm text-muted-foreground">
+            暫無資料
+          </div>
+        ) : (
+          <div className="flex flex-col items-center gap-4">
+            <div className="relative" style={{ width: size, height: size }}>
+              <svg
+                width={size}
+                height={size}
+                viewBox={`0 0 ${size} ${size}`}
+                className="-rotate-90"
+              >
+                {/* Background circle */}
+                <circle
+                  cx={radius}
+                  cy={radius}
+                  r={innerRadius}
+                  fill="none"
+                  stroke="hsl(var(--muted))"
+                  strokeWidth={strokeWidth}
+                />
+                {/* Segments */}
+                {segments
+                  .filter((s) => s.value > 0)
+                  .map((segment) => {
+                    const segmentLength = (segment.value / total) * circumference;
+                    const offset = cumulativeOffset;
+                    cumulativeOffset += segmentLength;
+                    return (
+                      <circle
+                        key={segment.label}
+                        cx={radius}
+                        cy={radius}
+                        r={innerRadius}
+                        fill="none"
+                        stroke={segment.color}
+                        strokeWidth={strokeWidth}
+                        strokeDasharray={`${segmentLength} ${circumference - segmentLength}`}
+                        strokeDashoffset={-offset}
+                        strokeLinecap="butt"
+                        className="transition-all duration-500"
+                      />
+                    );
+                  })}
+              </svg>
+              {/* Center text */}
+              {(centerLabel || centerValue !== undefined) && (
+                <div className="absolute inset-0 flex flex-col items-center justify-center">
+                  {centerValue !== undefined && (
+                    <span className="text-2xl font-bold">{centerValue}</span>
+                  )}
+                  {centerLabel && (
+                    <span className="text-xs text-muted-foreground">{centerLabel}</span>
+                  )}
+                </div>
+              )}
+            </div>
+
+            {/* Legend */}
+            <div className="flex flex-wrap justify-center gap-x-4 gap-y-1">
+              {segments
+                .filter((s) => s.value > 0)
+                .map((segment) => (
+                  <div key={segment.label} className="flex items-center gap-1.5">
+                    <span
+                      className="inline-block h-2.5 w-2.5 rounded-full"
+                      style={{ backgroundColor: segment.color }}
+                      aria-hidden="true"
+                    />
+                    <span className="text-xs text-muted-foreground">
+                      {segment.label} {segment.value}
+                    </span>
+                  </div>
+                ))}
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/dev/frontend/components/month-picker.tsx
+++ b/dev/frontend/components/month-picker.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface MonthPickerProps {
+  year: number;
+  month: number;
+  onChange: (year: number, month: number) => void;
+}
+
+export function MonthPicker({ year, month, onChange }: MonthPickerProps) {
+  const handlePrev = () => {
+    if (month === 1) {
+      onChange(year - 1, 12);
+    } else {
+      onChange(year, month - 1);
+    }
+  };
+
+  const handleNext = () => {
+    if (month === 12) {
+      onChange(year + 1, 1);
+    } else {
+      onChange(year, month + 1);
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <Button variant="outline" size="icon" onClick={handlePrev} aria-label="上個月">
+        <ChevronLeft className="h-4 w-4" />
+      </Button>
+      <span className="min-w-[120px] text-center text-sm font-medium">
+        {year} 年 {month} 月
+      </span>
+      <Button variant="outline" size="icon" onClick={handleNext} aria-label="下個月">
+        <ChevronRight className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+}

--- a/dev/frontend/components/role-guard.tsx
+++ b/dev/frontend/components/role-guard.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useAuthStore } from "@/lib/auth-store";
+import { ShieldAlert } from "lucide-react";
+import { type ReactNode } from "react";
+
+interface RoleGuardProps {
+  allowedRoles: string[];
+  children: ReactNode;
+}
+
+export function RoleGuard({ allowedRoles, children }: RoleGuardProps) {
+  const { user } = useAuthStore();
+
+  if (!user || !allowedRoles.includes(user.role)) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-4 py-20">
+        <ShieldAlert className="h-16 w-16 text-muted-foreground" />
+        <h2 className="text-xl font-semibold">403 - 權限不足</h2>
+        <p className="text-sm text-muted-foreground">
+          您沒有權限存取此頁面
+        </p>
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/dev/frontend/components/team-calendar-grid.tsx
+++ b/dev/frontend/components/team-calendar-grid.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import {
+  eachDayOfInterval,
+  startOfMonth,
+  endOfMonth,
+  getDay,
+  format,
+  isToday,
+} from "date-fns";
+import { cn } from "@/lib/utils";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+// --- Types ---
+
+export interface TeamMemberDay {
+  date: string;
+  status: "normal" | "late" | "early_leave" | "absent" | "leave" | "holiday" | "overtime" | null;
+  clock_in?: string | null;
+  clock_out?: string | null;
+  leave_type?: string | null;
+}
+
+export interface TeamMember {
+  user_id: string;
+  employee_id: string;
+  name: string;
+  days: TeamMemberDay[];
+}
+
+// --- Helpers ---
+
+const statusColors: Record<string, { bg: string; label: string }> = {
+  normal: { bg: "bg-green-500", label: "正常" },
+  late: { bg: "bg-amber-500", label: "遲到" },
+  early_leave: { bg: "bg-orange-500", label: "早退" },
+  absent: { bg: "bg-red-500", label: "缺席" },
+  leave: { bg: "bg-blue-500", label: "請假" },
+  holiday: { bg: "bg-gray-300 dark:bg-gray-600", label: "假日" },
+  overtime: { bg: "bg-purple-500", label: "加班" },
+};
+
+const WEEKDAY_LABELS = ["日", "一", "二", "三", "四", "五", "六"];
+
+// --- Component ---
+
+interface TeamCalendarGridProps {
+  year: number;
+  month: number;
+  members: TeamMember[];
+  isLoading?: boolean;
+}
+
+export function TeamCalendarGrid({
+  year,
+  month,
+  members,
+  isLoading = false,
+}: TeamCalendarGridProps) {
+  const firstDay = startOfMonth(new Date(year, month - 1));
+  const lastDay = endOfMonth(firstDay);
+  const allDays = eachDayOfInterval({ start: firstDay, end: lastDay });
+
+  if (isLoading) {
+    return (
+      <div className="rounded-lg border bg-card p-4">
+        <div className="space-y-3">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <Skeleton key={i} className="h-10 w-full" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (members.length === 0) {
+    return (
+      <div className="rounded-lg border bg-card p-8 text-center text-sm text-muted-foreground">
+        暫無團隊成員資料
+      </div>
+    );
+  }
+
+  return (
+    <TooltipProvider delayDuration={200}>
+      <div className="rounded-lg border bg-card">
+        <div className="overflow-x-auto">
+          <table className="w-full border-collapse text-sm">
+            <thead>
+              <tr className="border-b">
+                <th className="sticky left-0 z-10 min-w-[120px] bg-card px-3 py-2 text-left font-medium text-muted-foreground">
+                  成員
+                </th>
+                {allDays.map((date) => {
+                  const dayOfWeek = getDay(date);
+                  const isWeekend = dayOfWeek === 0 || dayOfWeek === 6;
+                  const today = isToday(date);
+                  return (
+                    <th
+                      key={date.toISOString()}
+                      className={cn(
+                        "min-w-[32px] px-0.5 py-2 text-center font-medium",
+                        isWeekend
+                          ? "text-muted-foreground/60"
+                          : "text-muted-foreground",
+                        today && "bg-primary/5"
+                      )}
+                    >
+                      <div className="text-xs">{date.getDate()}</div>
+                      <div className="text-[10px]">{WEEKDAY_LABELS[dayOfWeek]}</div>
+                    </th>
+                  );
+                })}
+              </tr>
+            </thead>
+            <tbody>
+              {members.map((member) => {
+                const dayMap = new Map(member.days.map((d) => [d.date, d]));
+                return (
+                  <tr key={member.user_id} className="border-b last:border-b-0">
+                    <td className="sticky left-0 z-10 bg-card px-3 py-2">
+                      <div className="text-xs text-muted-foreground">{member.employee_id}</div>
+                      <div className="font-medium">{member.name}</div>
+                    </td>
+                    {allDays.map((date) => {
+                      const dateStr = format(date, "yyyy-MM-dd");
+                      const dayData = dayMap.get(dateStr);
+                      const status = dayData?.status;
+                      const style = status ? statusColors[status] : null;
+                      const today = isToday(date);
+
+                      return (
+                        <td
+                          key={dateStr}
+                          className={cn(
+                            "px-0.5 py-2 text-center",
+                            today && "bg-primary/5"
+                          )}
+                        >
+                          {style ? (
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <div
+                                  className={cn(
+                                    "mx-auto h-5 w-5 rounded-sm",
+                                    style.bg
+                                  )}
+                                  aria-label={`${member.name} ${format(date, "M/d")} ${style.label}`}
+                                />
+                              </TooltipTrigger>
+                              <TooltipContent>
+                                <div className="text-xs">
+                                  <p className="font-medium">{member.name} - {format(date, "M/d")}</p>
+                                  <p>{style.label}</p>
+                                  {dayData?.clock_in && (
+                                    <p>上班: {dayData.clock_in.slice(11, 16)}</p>
+                                  )}
+                                  {dayData?.clock_out && (
+                                    <p>下班: {dayData.clock_out.slice(11, 16)}</p>
+                                  )}
+                                  {dayData?.leave_type && (
+                                    <p>假別: {dayData.leave_type}</p>
+                                  )}
+                                </div>
+                              </TooltipContent>
+                            </Tooltip>
+                          ) : (
+                            <div className="mx-auto h-5 w-5" />
+                          )}
+                        </td>
+                      );
+                    })}
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Legend */}
+        <div className="flex flex-wrap gap-3 border-t px-3 py-2">
+          {Object.entries(statusColors).map(([key, style]) => (
+            <div key={key} className="flex items-center gap-1">
+              <span className={cn("h-3 w-3 rounded-sm", style.bg)} aria-hidden="true" />
+              <span className="text-xs text-muted-foreground">{style.label}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </TooltipProvider>
+  );
+}


### PR DESCRIPTION
## Summary
- 新增個人行事曆 (`/calendar`)、團隊行事曆 (`/calendar/team`)、個人報表 (`/reports/personal`)、團隊報表 (`/reports/team`)、全公司報表 (`/reports/company`) 五個頁面
- 自訂月曆 grid 元件，不依賴外部日曆庫
- SVG Donut Chart 與 CSS 長條圖，不依賴外部圖表庫
- Manager/Admin 頁面包含 RoleGuard 角色檢查

## Changes
- `dev/frontend/app/globals.css` - 新增行事曆狀態色彩 CSS 變數（含 dark mode）
- `dev/frontend/components/month-picker.tsx` - 月份切換元件
- `dev/frontend/components/calendar-month.tsx` - 個人月曆 grid 元件（含狀態衍生邏輯、圖例）
- `dev/frontend/components/team-calendar-grid.tsx` - 團隊行事曆 grid（行=成員，列=日期，含 tooltip）
- `dev/frontend/components/donut-chart.tsx` - SVG Donut 圓餅圖元件
- `dev/frontend/components/bar-chart.tsx` - CSS 水平長條圖元件
- `dev/frontend/components/role-guard.tsx` - 角色守衛元件（403 頁面）
- `dev/frontend/app/(authenticated)/calendar/page.tsx` - 個人行事曆頁面
- `dev/frontend/app/(authenticated)/calendar/team/page.tsx` - 團隊行事曆頁面
- `dev/frontend/app/(authenticated)/reports/personal/page.tsx` - 個人出勤報表
- `dev/frontend/app/(authenticated)/reports/team/page.tsx` - 團隊出勤報表
- `dev/frontend/app/(authenticated)/reports/company/page.tsx` - 全公司報表

## Scenario 覆蓋
- [x] 個人行事曆：月曆檢視、月份切換、日期點擊詳情（Sheet）、出勤狀態色塊
- [x] 團隊行事曆：Grid 成員 x 日期、部門篩選（Admin）、Tooltip 詳情
- [x] 個人報表：統計卡片、出勤分布圓餅圖、請假類型分布、請假明細表
- [x] 團隊報表：團隊摘要、成員出勤明細表、搜尋篩選
- [x] 全公司報表：部門出勤率長條圖、全公司圓餅圖、部門明細表

## 測試
- `next build` 通過，所有頁面成功編譯
- TypeScript 型別檢查通過

## Related Issues
Closes #49